### PR TITLE
feat: add Ireland report JSON

### DIFF
--- a/ireland_report.json
+++ b/ireland_report.json
@@ -1,0 +1,454 @@
+{
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Generally high environmental quality outside dense urban cores; extensive protected landscapes and coastline.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Rising precipitation and storm intensity; coastal flooding risk; less extreme heat than continental Europe.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Oceanic—cool summers, mild winters, frequent rain/overcast; long summer daylight, short winter days.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Scenic but cool-water beaches; swimmable mostly for cold‑tolerant; great walks year‑round.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Roughly warmest Jul–Sep; otherwise chilly; wetsuits common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Cliffs, peninsulas, lakelands, low mountains; many day/weekend trips.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Generally good; occasional winter particulate spikes (solid‑fuel heating) in some areas.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Low seismic risk; Atlantic storms possible; robust building standards.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work‑Life Balance",
+      "alignmentText": "EU norms for leave and hours; team culture varies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Legal max 48; typical around 39–40 in many sectors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "At least 4 weeks annually (plus public holidays).",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech often 23–25+ days, varies by employer.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Verify current national rate and any 2025 updates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": ".NET / Ruby / Game dev ranges; senior vs. mid; Dublin highest.",
+      "alignmentValue": 8
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Good in finance/consulting/enterprise (Dublin hub).",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Smaller market; present in startups/SMEs; confirm demand.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Small ecosystem; mix of indie, middleware, services.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "[Keywords Studios](https://www.keywordsstudios.com) (HQ Dublin), [Vela Games](https://velagames.com) (Dublin), [WarDucks](https://warducks.com) (AR/VR); plus indies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "[Imirt — Irish Game Makers](https://www.imirt.ie) (national association/network).",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Dublin fast and pricey; Cork/Galway slower with trade‑offs on roles.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote‑Friendly Culture",
+      "alignmentText": "Hybrid common post‑pandemic; co‑working widely available.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Common for ICT roles via Critical Skills; reliable processes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Low unemployment; GDP volatile due to multinationals; high cost of living.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Friendly, community‑oriented culture; vibrant music and pub life; strong literary/history scene.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominant; Irish is co‑official; high English proficiency.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Significant liberal shifts (e.g., marriage equality, reproductive rights) alongside some conservative currents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Niche in discourse; mainstream politics centrist/center‑left/right mix.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secularization advanced; Church influence diminished but present in schools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Generally moderate‑liberal; sex‑ed improving; verify local norms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Broad legal protections; social acceptance high in cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Welcoming to newcomers; strong clubs/associations; expat communities in cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Safe cities; parks/playgrounds common; weather limits outdoor time some days.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Not legally recognized; social acceptance niche and discreet; assess city subcultures.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Balanced; extracurriculars common; independence encouraged; verify school‑home load.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child‑Friendliness of Cities",
+      "alignmentText": "Good playgrounds, libraries, family‑friendly cafes; breastfeeding generally accepted.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "English‑medium public schools; many with Catholic patronage; limited international schools; Irish taught.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Increasingly egalitarian; traditional norms persist in pockets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Visible in urban areas; acceptance growing.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Strong legal protections; parental leave improving; confirm details.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Broadly flexible; safety relatively high.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Evolving; caregiving more normalized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Hiking, GAA sports, soccer, cycling, music, sea‑swimming.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Active scenes in cities; FLGS and clubs; cons like [Gaelcon](https://gaelcon.com) / [Warpcon](https://warpcon.ie).",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Strong live music/pub culture; festivals year‑round.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Active tech/game dev, parenting, LGBTQ+ groups; poly communities exist but low‑profile.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Abundant day trips by rail/bus/car from major cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Parliamentary republic; PR‑STV voting; multiparty coalition governance common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Generally secular governance; residual church influence in education/health.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers’ Rights",
+      "alignmentText": "EU standards; unions present; termination processes regulated; non‑competes limited/enforceability varies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Market‑friendly with social supports; strong MNC presence.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Public system with long queues for some services; many carry private insurance.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Private insurance often required; access to public services depends on residency status—verify specifics.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidies expanding (National Childcare Scheme); availability varies by city.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Supports for families; verify benefits by status and income.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Low; independent media/judiciary; EU member checks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Open economy; corporate tax reforms ongoing per OECD.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Strong outcomes; English instruction; higher‑ed quality; fees vary for non‑EU.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "High political and economic stability; protest risk low‑moderate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Low systemic propaganda; normal political messaging.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Focus on economy, services, housing; standard partisan frames.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Robust anti‑discrimination; LGBTQ+ legal recognition; reproductive rights.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Moderate; varies with housing/health outcomes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Low by EU standards; transparency relatively strong.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "More administrative/planning than overt; enforcement present.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Tight in Dublin; new supply improving; tenant protections exist; high rents.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Good in Dublin (bus, Luas, DART); limited intercity/regional frequencies; cars common outside cities.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fast broadband in cities; widespread contactless; decent e‑gov; reliable grid.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Generally safe; petty crime in city cores; rare unrest episodes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Open market economy with EU social protections.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "State pension based on PRSI contributions over years; consider private pensions; US‑Ireland totalization agreement may help—verify.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "PAYE with USC and PRSI; yearly self‑assessment if needed; credits for couples.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Progressive bands; mid‑to‑high effective rates when including USC/PRSI—model scenarios.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "PPSN typically needed to open accounts; major banks plus fintechs; contactless ubiquitous.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Housing/childcare expensive in Dublin; groceries/utilities moderate EU‑level—verify local indices.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Critical Skills Employment Permit (CSEP), General Employment Permit (GEP), intra‑company transfer, student, family routes; Startup programmes via Enterprise Ireland.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Generally positive; high presence of US companies; straightforward processes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Enterprise Ireland/LEO supports, New Frontiers, Imirt network; publishers/services in Dublin.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Stamps (1/1G/4 etc.); CSEP can lead to Stamp 4 after a period; GEP longer path.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalisation typically after ~5 years of reckonable residence (with continuity requirements); dual citizenship allowed.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Partner work authorization often available (e.g., Stamp 1G with CSEP spouse); confirm current policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing times vary by route; expect weeks to months; fees apply.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Track tax residency days; keep GNIB/IRP renewals current; maintain health insurance as required.",
+      "alignmentValue": 8
+    }
+  ],
+  "cityShortlist": [
+    {
+      "city": "Dublin",
+      "reason": "Deepest tech/game ecosystem; Azure presence; best transit; highest costs."
+    },
+    {
+      "city": "Cork",
+      "reason": "Slower pace, good amenities and schools; growing tech; better affordability than Dublin."
+    },
+    {
+      "city": "Galway",
+      "reason": "Creative vibe, family-friendly, access to nature; smaller job market; consider remote/hybrid."
+    }
+  ],
+  "risksAndMitigations": [
+    {
+      "risk": "Housing scarcity in Dublin",
+      "mitigation": "Expand search radius; consider Cork/Galway; engage relocation agents; time move with lease cycle."
+    },
+    {
+      "risk": "Healthcare wait times",
+      "mitigation": "Maintain private insurance; choose area with GP availability; plan for private clinics."
+    },
+    {
+      "risk": "Childcare cost/availability",
+      "mitigation": "Apply early; target neighborhoods with multiple providers; leverage subsidies."
+    }
+  ],
+  "openQuestions": [
+    "What are the current (2025) minimum wage and tax band thresholds?",
+    "Which neighborhoods balance walkability, school ethos (ET/non-denominational), and rent in each target city?",
+    "Which grants/incubators are most suitable for an indie game studio this year (EI/LEO/New Frontiers timing)?",
+    "What are current processing times and spouse work authorization details for CSEP/GEP?"
+  ],
+  "executiveSummary": {
+    "topPositives": "English-first, stable EU democracy, mild climate, friendly culture, strong tech presence (Dublin), Azure region locally, good nature access.",
+    "keyConcerns": "High housing and childcare costs (esp. Dublin), healthcare wait times, rainy/overcast weather, smaller Ruby and game-dev job markets.",
+    "unknownsToResearch": "Current minimum wage and tax brackets, childcare subsidies in target cities, game-dev grants timeline and eligibility, permit processing times.",
+    "bottomLine": "Good cultural/political fit and language; quality-of-life balanced by cost and healthcare access. Worth a scouting trip focused on Dublin/Cork/Galway."
+  }
+}


### PR DESCRIPTION
## Summary
- base Ireland report alignment scores on bullet-level notes instead of summary categories
- retain city shortlist, risk mitigations, open questions, and executive summary for data view usage

## Testing
- `jq . ireland_report.json`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c361618efc83218ba5c7700348e27d