### PR TITLE
Add scorecard layout JSON and flatten Ireland report values

### DIFF
--- a/ireland_report.json
+++ b/ireland_report.json
@@ -3,452 +3,427 @@
     {
       "key": "Environment",
       "alignmentText": "Generally high environmental quality outside dense urban cores; extensive protected landscapes and coastline.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Global Warming Risk",
       "alignmentText": "Rising precipitation and storm intensity; coastal flooding risk; less extreme heat than continental Europe.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Seasonal Weather",
       "alignmentText": "Oceanic—cool summers, mild winters, frequent rain/overcast; long summer daylight, short winter days.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Beach Life",
-      "alignmentText": "Scenic but cool-water beaches; swimmable mostly for cold‑tolerant; great walks year‑round.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Seasonal Beach Water Temp",
-      "alignmentText": "Roughly warmest Jul–Sep; otherwise chilly; wetsuits common.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Natural Beauty",
-      "alignmentText": "Cliffs, peninsulas, lakelands, low mountains; many day/weekend trips.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Air Quality",
       "alignmentText": "Generally good; occasional winter particulate spikes (solid‑fuel heating) in some areas.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Natural Disasters",
       "alignmentText": "Low seismic risk; Atlantic storms possible; robust building standards.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
-      "key": "Work‑Life Balance",
-      "alignmentText": "EU norms for leave and hours; team culture varies.",
-      "alignmentValue": 8
+      "key": "Beach Life",
+      "alignmentText": "Scenic but cool-water beaches; swimmable mostly for cold‑tolerant; great walks year‑round.",
+      "alignmentValue": 8.0
     },
     {
-      "key": "Work Week Hours",
-      "alignmentText": "Legal max 48; typical around 39–40 in many sectors.",
-      "alignmentValue": 8
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Roughly warmest Jul–Sep; otherwise chilly; wetsuits common.",
+      "alignmentValue": 8.0
     },
     {
-      "key": "Vacation Days (Minimum)",
-      "alignmentText": "At least 4 weeks annually (plus public holidays).",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Vacation Days (Typical)",
-      "alignmentText": "Tech often 23–25+ days, varies by employer.",
-      "alignmentValue": 8
+      "key": "Natural Beauty",
+      "alignmentText": "Cliffs, peninsulas, lakelands, low mountains; many day/weekend trips.",
+      "alignmentValue": 8.0
     },
     {
       "key": "Minimum Wage",
       "alignmentText": "Verify current national rate and any 2025 updates.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Typical Software Salaries",
       "alignmentText": ".NET / Ruby / Game dev ranges; senior vs. mid; Dublin highest.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": ".NET Work Prospects",
       "alignmentText": "Good in finance/consulting/enterprise (Dublin hub).",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Ruby Work Prospects",
       "alignmentText": "Smaller market; present in startups/SMEs; confirm demand.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Game Dev Work Prospects",
-      "alignmentText": "Small ecosystem; mix of indie, middleware, services.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Notable Game Studios",
-      "alignmentText": "[Keywords Studios](https://www.keywordsstudios.com) (HQ Dublin), [Vela Games](https://velagames.com) (Dublin), [WarDucks](https://warducks.com) (AR/VR); plus indies.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Notable Game Development Communities",
-      "alignmentText": "[Imirt — Irish Game Makers](https://www.imirt.ie) (national association/network).",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Pace of Life",
-      "alignmentText": "Dublin fast and pricey; Cork/Galway slower with trade‑offs on roles.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Remote‑Friendly Culture",
-      "alignmentText": "Hybrid common post‑pandemic; co‑working widely available.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Employer Visa Sponsorship",
       "alignmentText": "Common for ICT roles via Critical Skills; reliable processes.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Economic Health",
       "alignmentText": "Low unemployment; GDP volatile due to multinationals; high cost of living.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
-      "key": "What Is Intriguing",
-      "alignmentText": "Friendly, community‑oriented culture; vibrant music and pub life; strong literary/history scene.",
-      "alignmentValue": 8
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid common post‑pandemic; co‑working widely available.",
+      "alignmentValue": 8.0
     },
     {
-      "key": "Language & English Ubiquity",
-      "alignmentText": "English dominant; Irish is co‑official; high English proficiency.",
-      "alignmentValue": 8
+      "key": "Work-Life Balance",
+      "alignmentText": "EU norms for leave and hours; team culture varies.",
+      "alignmentValue": 8.0
     },
     {
-      "key": "Progressivism",
-      "alignmentText": "Significant liberal shifts (e.g., marriage equality, reproductive rights) alongside some conservative currents.",
-      "alignmentValue": 8
+      "key": "Work Week Hours",
+      "alignmentText": "Legal max 48; typical around 39–40 in many sectors.",
+      "alignmentValue": 8.0
     },
     {
-      "key": "Marxism (Societal Attitudes)",
-      "alignmentText": "Niche in discourse; mainstream politics centrist/center‑left/right mix.",
-      "alignmentValue": 8
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "At least 4 weeks annually (plus public holidays).",
+      "alignmentValue": 8.0
     },
     {
-      "key": "Atheism",
-      "alignmentText": "Secularization advanced; Church influence diminished but present in schools.",
-      "alignmentValue": 8
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech often 23–25+ days, varies by employer.",
+      "alignmentValue": 8.0
     },
     {
-      "key": "Sex (Attitudes)",
-      "alignmentText": "Generally moderate‑liberal; sex‑ed improving; verify local norms.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Broad legal protections; social acceptance high in cities.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Community Vibes",
-      "alignmentText": "Welcoming to newcomers; strong clubs/associations; expat communities in cities.",
-      "alignmentValue": 8
+      "key": "Pace of Life",
+      "alignmentText": "Dublin fast and pricey; Cork/Galway slower with trade‑offs on roles.",
+      "alignmentValue": 8.0
     },
     {
       "key": "Family Life",
       "alignmentText": "Safe cities; parks/playgrounds common; weather limits outdoor time some days.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Polyamory",
       "alignmentText": "Not legally recognized; social acceptance niche and discreet; assess city subcultures.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Parenting Expectations",
       "alignmentText": "Balanced; extracurriculars common; independence encouraged; verify school‑home load.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
-      "key": "Child‑Friendliness of Cities",
+      "key": "Child-Friendliness of Cities",
       "alignmentText": "Good playgrounds, libraries, family‑friendly cafes; breastfeeding generally accepted.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Schooling Options",
       "alignmentText": "English‑medium public schools; many with Catholic patronage; limited international schools; Irish taught.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Gender Roles",
       "alignmentText": "Increasingly egalitarian; traditional norms persist in pockets.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Gender Fluidity",
       "alignmentText": "Visible in urban areas; acceptance growing.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Gender Rights",
       "alignmentText": "Strong legal protections; parental leave improving; confirm details.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Femininity Norms",
       "alignmentText": "Broadly flexible; safety relatively high.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Masculinity Norms",
       "alignmentText": "Evolving; caregiving more normalized.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Friendly, community‑oriented culture; vibrant music and pub life; strong literary/history scene.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominant; Irish is co‑official; high English proficiency.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Significant liberal shifts (e.g., marriage equality, reproductive rights) alongside some conservative currents.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Niche in discourse; mainstream politics centrist/center‑left/right mix.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secularization advanced; Church influence diminished but present in schools.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Generally moderate‑liberal; sex‑ed improving; verify local norms.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Broad legal protections; social acceptance high in cities.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Welcoming to newcomers; strong clubs/associations; expat communities in cities.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "",
+      "alignmentValue": 0.0
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "",
+      "alignmentValue": 0.0
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "",
+      "alignmentValue": 0.0
     },
     {
       "key": "Common Hobbies",
       "alignmentText": "Hiking, GAA sports, soccer, cycling, music, sea‑swimming.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Boardgaming & Tabletop",
       "alignmentText": "Active scenes in cities; FLGS and clubs; cons like [Gaelcon](https://gaelcon.com) / [Warpcon](https://warpcon.ie).",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Nightlife & Music",
       "alignmentText": "Strong live music/pub culture; festivals year‑round.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Meetups & Communities",
       "alignmentText": "Active tech/game dev, parenting, LGBTQ+ groups; poly communities exist but low‑profile.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Nature Access",
       "alignmentText": "Abundant day trips by rail/bus/car from major cities.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Political System",
       "alignmentText": "Parliamentary republic; PR‑STV voting; multiparty coalition governance common.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Religion in Politics",
       "alignmentText": "Generally secular governance; residual church influence in education/health.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
-      "key": "Workers’ Rights",
+      "key": "Workers' Rights",
       "alignmentText": "EU standards; unions present; termination processes regulated; non‑competes limited/enforceability varies.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "State Ideology",
       "alignmentText": "Market‑friendly with social supports; strong MNC presence.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Healthcare (Citizens)",
-      "alignmentText": "Public system with long queues for some services; many carry private insurance.",
-      "alignmentValue": 5
-    },
-    {
-      "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Private insurance often required; access to public services depends on residency status—verify specifics.",
-      "alignmentValue": 5
-    },
-    {
-      "key": "Child Care Support",
-      "alignmentText": "Subsidies expanding (National Childcare Scheme); availability varies by city.",
-      "alignmentValue": 5
-    },
-    {
-      "key": "Family Policy (Common Family)",
-      "alignmentText": "Supports for families; verify benefits by status and income.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Authoritarian Backsliding Risk",
       "alignmentText": "Low; independent media/judiciary; EU member checks.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "State of Capitalism",
       "alignmentText": "Open economy; corporate tax reforms ongoing per OECD.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Education",
-      "alignmentText": "Strong outcomes; English instruction; higher‑ed quality; fees vary for non‑EU.",
-      "alignmentValue": 5
+      "alignmentValue": 8.0
     },
     {
       "key": "Stability",
       "alignmentText": "High political and economic stability; protest risk low‑moderate.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Propaganda Prevalence",
       "alignmentText": "Low systemic propaganda; normal political messaging.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Propaganda Messaging",
       "alignmentText": "Focus on economy, services, housing; standard partisan frames.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Social Policies",
       "alignmentText": "Robust anti‑discrimination; LGBTQ+ legal recognition; reproductive rights.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Trust in Government",
       "alignmentText": "Moderate; varies with housing/health outcomes.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Perceived Corruption",
       "alignmentText": "Low by EU standards; transparency relatively strong.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Type of Corruption",
       "alignmentText": "More administrative/planning than overt; enforcement present.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Housing Situation",
       "alignmentText": "Tight in Dublin; new supply improving; tenant protections exist; high rents.",
-      "alignmentValue": 5
-    },
-    {
-      "key": "Public Transportation",
-      "alignmentText": "Good in Dublin (bus, Luas, DART); limited intercity/regional frequencies; cars common outside cities.",
-      "alignmentValue": 5
-    },
-    {
-      "key": "Modernity & Infrastructure",
-      "alignmentText": "Fast broadband in cities; widespread contactless; decent e‑gov; reliable grid.",
-      "alignmentValue": 8
+      "alignmentValue": 5.0
     },
     {
       "key": "Safety & Crime",
       "alignmentText": "Generally safe; petty crime in city cores; rare unrest episodes.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Public system with long queues for some services; many carry private insurance.",
+      "alignmentValue": 5.0
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Private insurance often required; access to public services depends on residency status—verify specifics.",
+      "alignmentValue": 5.0
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidies expanding (National Childcare Scheme); availability varies by city.",
+      "alignmentValue": 5.0
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Supports for families; verify benefits by status and income.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Strong outcomes; English instruction; higher‑ed quality; fees vary for non‑EU.",
+      "alignmentValue": 5.0
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Good in Dublin (bus, Luas, DART); limited intercity/regional frequencies; cars common outside cities.",
+      "alignmentValue": 5.0
     },
     {
       "key": "Economic System",
       "alignmentText": "Open market economy with EU social protections.",
-      "alignmentValue": 5
+      "alignmentValue": 5.0
     },
     {
       "key": "Retirement (Immigrants)",
       "alignmentText": "State pension based on PRSI contributions over years; consider private pensions; US‑Ireland totalization agreement may help—verify.",
-      "alignmentValue": 5
+      "alignmentValue": 5.0
     },
     {
       "key": "How Taxes Are Handled",
       "alignmentText": "PAYE with USC and PRSI; yearly self‑assessment if needed; credits for couples.",
-      "alignmentValue": 5
+      "alignmentValue": 5.0
     },
     {
       "key": "Expected Tax Rate (Our Family)",
       "alignmentText": "Progressive bands; mid‑to‑high effective rates when including USC/PRSI—model scenarios.",
-      "alignmentValue": 5
+      "alignmentValue": 5.0
     },
     {
       "key": "Banking & Payments",
       "alignmentText": "PPSN typically needed to open accounts; major banks plus fintechs; contactless ubiquitous.",
-      "alignmentValue": 5
+      "alignmentValue": 5.0
     },
     {
       "key": "Cost of Living (Optional)",
       "alignmentText": "Housing/childcare expensive in Dublin; groceries/utilities moderate EU‑level—verify local indices.",
-      "alignmentValue": 5
+      "alignmentValue": 5.0
     },
     {
       "key": "Visa Paths",
       "alignmentText": "Critical Skills Employment Permit (CSEP), General Employment Permit (GEP), intra‑company transfer, student, family routes; Startup programmes via Enterprise Ireland.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Welcoming of US Migrants",
       "alignmentText": "Generally positive; high presence of US companies; straightforward processes.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Enterprise Ireland/LEO supports, New Frontiers, Imirt network; publishers/services in Dublin.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Residency Types & Durations",
       "alignmentText": "Stamps (1/1G/4 etc.); CSEP can lead to Stamp 4 after a period; GEP longer path.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Path to Citizenship",
       "alignmentText": "Naturalisation typically after ~5 years of reckonable residence (with continuity requirements); dual citizenship allowed.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Family Members",
       "alignmentText": "Partner work authorization often available (e.g., Stamp 1G with CSEP spouse); confirm current policy.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Timelines & Costs",
       "alignmentText": "Processing times vary by route; expect weeks to months; fees apply.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
     },
     {
       "key": "Compliance & Risks",
       "alignmentText": "Track tax residency days; keep GNIB/IRP renewals current; maintain health insurance as required.",
-      "alignmentValue": 8
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Small ecosystem; mix of indie, middleware, services.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "[Keywords Studios](https://www.keywordsstudios.com) (HQ Dublin), [Vela Games](https://velagames.com) (Dublin), [WarDucks](https://warducks.com) (AR/VR); plus indies.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "[Imirt — Irish Game Makers](https://www.imirt.ie) (national association/network).",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Enterprise Ireland/LEO supports, New Frontiers, Imirt network; publishers/services in Dublin.",
+      "alignmentValue": 8.0
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fast broadband in cities; widespread contactless; decent e‑gov; reliable grid.",
+      "alignmentValue": 8.0
     }
-  ],
-  "cityShortlist": [
-    {
-      "city": "Dublin",
-      "reason": "Deepest tech/game ecosystem; Azure presence; best transit; highest costs."
-    },
-    {
-      "city": "Cork",
-      "reason": "Slower pace, good amenities and schools; growing tech; better affordability than Dublin."
-    },
-    {
-      "city": "Galway",
-      "reason": "Creative vibe, family-friendly, access to nature; smaller job market; consider remote/hybrid."
-    }
-  ],
-  "risksAndMitigations": [
-    {
-      "risk": "Housing scarcity in Dublin",
-      "mitigation": "Expand search radius; consider Cork/Galway; engage relocation agents; time move with lease cycle."
-    },
-    {
-      "risk": "Healthcare wait times",
-      "mitigation": "Maintain private insurance; choose area with GP availability; plan for private clinics."
-    },
-    {
-      "risk": "Childcare cost/availability",
-      "mitigation": "Apply early; target neighborhoods with multiple providers; leverage subsidies."
-    }
-  ],
-  "openQuestions": [
-    "What are the current (2025) minimum wage and tax band thresholds?",
-    "Which neighborhoods balance walkability, school ethos (ET/non-denominational), and rent in each target city?",
-    "Which grants/incubators are most suitable for an indie game studio this year (EI/LEO/New Frontiers timing)?",
-    "What are current processing times and spouse work authorization details for CSEP/GEP?"
-  ],
-  "executiveSummary": {
-    "topPositives": "English-first, stable EU democracy, mild climate, friendly culture, strong tech presence (Dublin), Azure region locally, good nature access.",
-    "keyConcerns": "High housing and childcare costs (esp. Dublin), healthcare wait times, rainy/overcast weather, smaller Ruby and game-dev job markets.",
-    "unknownsToResearch": "Current minimum wage and tax brackets, childcare subsidies in target cities, game-dev grants timeline and eligibility, permit processing times.",
-    "bottomLine": "Good cultural/political fit and language; quality-of-life balanced by cost and healthcare access. Worth a scouting trip focused on Dublin/Cork/Galway."
-  }
+  ]
 }

--- a/main.json
+++ b/main.json
@@ -1,0 +1,159 @@
+{
+  "Categories": [
+    {
+      "Category": "Environment & Climate",
+      "Keys": [
+        {"Key": "Environment", "Guidance": "Overall environmental quality; protected areas; biodiversity."},
+        {"Key": "Global Warming Risk", "Guidance": "Sea-level, heatwaves, drought, wildfire, flood risk."},
+        {"Key": "Seasonal Weather", "Guidance": "Temp/precip by season; humidity; daylight; storms."},
+        {"Key": "Air Quality", "Guidance": "PM2.5 annual average; seasonal spikes."},
+        {"Key": "Natural Disasters", "Guidance": "Earthquake/volcano/hurricane exposure; building codes."}
+      ]
+    },
+    {
+      "Category": "Nature & Outdoors",
+      "Keys": [
+        {"Key": "Beach Life", "Guidance": "Access, cleanliness, crowding, amenities, safety."},
+        {"Key": "Seasonal Beach Water Temp", "Guidance": "Monthly SST; comfortable swim months."},
+        {"Key": "Natural Beauty", "Guidance": "Landscapes, parks, hiking, diving; ease of access."}
+      ]
+    },
+    {
+      "Category": "Work Opportunities",
+      "Keys": [
+        {"Key": "Minimum Wage", "Guidance": "National/sectoral; enforcement; living wage comparison."},
+        {"Key": "Typical Software Salaries", "Guidance": ".NET / Ruby / Game dev ranges; senior vs. mid."},
+        {"Key": ".NET Work Prospects", "Guidance": "Market demand; top employers; remote vs. onsite."},
+        {"Key": "Ruby Work Prospects", "Guidance": "Market demand; key sectors; frameworks in use."},
+        {"Key": "Employer Visa Sponsorship", "Guidance": "Common/rare; processing reliability."},
+        {"Key": "Economic Health", "Guidance": "GDP growth, unemployment, inflation snapshot."},
+        {"Key": "Remote-Friendly Culture", "Guidance": "Hybrid norms; coworking; time-zone alignment."}
+      ]
+    },
+    {
+      "Category": "Work-Life Balance",
+      "Keys": [
+        {"Key": "Work-Life Balance", "Guidance": "Cultural norms; after-hours boundaries."},
+        {"Key": "Work Week Hours", "Guidance": "Statutory vs. typical; overtime norms."},
+        {"Key": "Vacation Days (Minimum)", "Guidance": "Legal floor incl. public holidays."},
+        {"Key": "Vacation Days (Typical)", "Guidance": "Common practice for tech roles."},
+        {"Key": "Pace of Life", "Guidance": "City vs. regional differences; commute times."}
+      ]
+    },
+    {
+      "Category": "Family Friendliness",
+      "Keys": [
+        {"Key": "Family Life", "Guidance": "Family-friendly amenities; school schedules; work-family balance."},
+        {"Key": "Polyamory", "Guidance": "Social acceptance; legal risks; custody implications."},
+        {"Key": "Parenting Expectations", "Guidance": "Discipline norms; extracurricular load; autonomy."},
+        {"Key": "Child-Friendliness of Cities", "Guidance": "Playgrounds, parks, cafes; breastfeeding norms."},
+        {"Key": "Schooling Options", "Guidance": "Public vs. private; language tracks; international schools."}
+      ]
+    },
+    {
+      "Category": "Gender Equality & Norms",
+      "Keys": [
+        {"Key": "Gender Roles", "Guidance": "Traditional vs. egalitarian norms."},
+        {"Key": "Gender Fluidity", "Guidance": "Social visibility; non-binary recognition."},
+        {"Key": "Gender Rights", "Guidance": "Legal protections; workplace equality; parental leave."},
+        {"Key": "Femininity Norms", "Guidance": "Appearance, behavior expectations; safety."},
+        {"Key": "Masculinity Norms", "Guidance": "Work, emotion, caregiving expectations."}
+      ]
+    },
+    {
+      "Category": "Culture & Values Fit",
+      "Keys": [
+        {"Key": "What Is Intriguing", "Guidance": "Unique cultural draws; lifestyle perks."},
+        {"Key": "Language & English Ubiquity", "Guidance": "English proficiency; necessity of local language."},
+        {"Key": "Progressivism", "Guidance": "Social liberalism; civil liberties; inclusion."},
+        {"Key": "Marxism (Societal Attitudes)", "Guidance": "Public discourse; historical context."},
+        {"Key": "Atheism", "Guidance": "Prevalence; social acceptance; religious diversity."},
+        {"Key": "Sex (Attitudes)", "Guidance": "Public norms; sex education; media openness."},
+        {"Key": "LGBTQ+ Attitudes", "Guidance": "Social acceptance; legal protections (see Rights below)."},
+        {"Key": "Community Vibes", "Guidance": "Friendliness to newcomers; social clubs; expat density."},
+        {"Key": "View of self", "Guidance": "How do they generally view themselves."},
+        {"Key": "View of Neighboring Countries", "Guidance": "How do they generally view their neighboring countries."},
+        {"Key": "View of Them by Neighboring Countries", "Guidance": "How do neighboring countries generally view them."}
+      ]
+    },
+    {
+      "Category": "Entertainment & Community",
+      "Keys": [
+        {"Key": "Common Hobbies", "Guidance": "Popular pastimes; outdoor/indoor balance."},
+        {"Key": "Boardgaming & Tabletop", "Guidance": "FLGS density; clubs; conventions; cafes."},
+        {"Key": "Nightlife & Music", "Guidance": "Venues; noise norms; live scenes."},
+        {"Key": "Meetups & Communities", "Guidance": "Tech, game dev, parenting, LGBTQ+, poly groups."},
+        {"Key": "Nature Access", "Guidance": "Day-trip options; weekend getaways."}
+      ]
+    },
+    {
+      "Category": "Governance & Stability",
+      "Keys": [
+        {"Key": "Political System", "Guidance": "Structure; party dynamics; electoral fairness."},
+        {"Key": "Religion in Politics", "Guidance": "Secularism; clerical influence."},
+        {"Key": "Workers' Rights", "Guidance": "Unions, protections, termination norms, non-competes."},
+        {"Key": "State Ideology", "Guidance": "Marxism/Socialism/Capitalism in practice and rhetoric."},
+        {"Key": "Authoritarian Backsliding Risk", "Guidance": "Media freedom; judiciary independence."},
+        {"Key": "State of Capitalism", "Guidance": "Market competition; monopolies; SME friendliness."},
+        {"Key": "Stability", "Guidance": "Political and economic stability; protest risk."},
+        {"Key": "Propaganda Prevalence", "Guidance": "State/private media narratives; disinfo exposure."},
+        {"Key": "Propaganda Messaging", "Guidance": "Common themes; impact on daily life."},
+        {"Key": "Social Policies", "Guidance": "Reproductive rights; LGBTQ+ rights; antidiscrimination."},
+        {"Key": "Trust in Government", "Guidance": "Surveys; participation; service reliability."},
+        {"Key": "Perceived Corruption", "Guidance": "CPI rank; enforcement; transparency."},
+        {"Key": "Type of Corruption", "Guidance": "Petty vs. grand; sectors affected."},
+        {"Key": "Housing Situation", "Guidance": "Availability; renting norms; tenant protections; prices."},
+        {"Key": "Safety & Crime", "Guidance": "Violent/property crime; hate crime risk; policing."}
+      ]
+    },
+    {
+      "Category": "Public Services (Health/Edu/Transit)",
+      "Keys": [
+        {"Key": "Healthcare (Citizens)", "Guidance": "Coverage model; quality; access times; costs."},
+        {"Key": "Healthcare (Visa Holders)", "Guidance": "Eligibility; insurance requirements; wait times."},
+        {"Key": "Child Care Support", "Guidance": "Subsidies; availability; quality; costs."},
+        {"Key": "Family Policy (Common Family)", "Guidance": "Typical household structures; benefits."},
+        {"Key": "Education", "Guidance": "K-12 quality; higher ed; language of instruction; costs."},
+        {"Key": "Public Transportation", "Guidance": "Coverage, frequency, reliability; car dependency."}
+      ]
+    },
+    {
+      "Category": "Financial & Tax",
+      "Keys": [
+        {"Key": "Economic System", "Guidance": "Market characteristics; social safety nets."},
+        {"Key": "Retirement (Immigrants)", "Guidance": "Access to pensions; portability; private options."},
+        {"Key": "How Taxes Are Handled", "Guidance": "Filing process; PAYE; joint vs. individual."},
+        {"Key": "Expected Tax Rate (Our Family)", "Guidance": "Income bands; social contributions; credits."},
+        {"Key": "Banking & Payments", "Guidance": "Account access for migrants; fees; mobile wallets."},
+        {"Key": "Cost of Living (Optional)", "Guidance": "Housing, groceries, transit vs. benchmark city."}
+      ]
+    },
+    {
+      "Category": "Migration & Residency",
+      "Keys": [
+        {"Key": "Visa Paths", "Guidance": "Work, startup, family, student; eligibility and quotas."},
+        {"Key": "Welcoming of US Migrants", "Guidance": "Social attitudes; official stance."},
+        {"Key": "Residency Types & Durations", "Guidance": "TRP/PR; renewals; physical presence rules."},
+        {"Key": "Path to Citizenship", "Guidance": "Timelines; tests; dual citizenship policy."},
+        {"Key": "Family Members", "Guidance": "Work authorization for partner; dependents' schooling."},
+        {"Key": "Timelines & Costs", "Guidance": "Processing times; fees; legal assistance norms."},
+        {"Key": "Compliance & Risks", "Guidance": "Overstay penalties; tax residency triggers."}
+      ]
+    },
+    {
+      "Category": "Startup & Game Dev Ecosystem",
+      "Keys": [
+        {"Key": "Game Dev Work Prospects", "Guidance": "Openings; indie vs. AAA; publishing ecosystem."},
+        {"Key": "Notable Game Studios", "Guidance": "Names, locations, size; hiring climate."},
+        {"Key": "Notable Game Development Communities", "Guidance": "Names, locations, size; value proposition."},
+        {"Key": "Opportunities for Video Game Startup", "Guidance": "Visas, grants, incubators, publishers."}
+      ]
+    },
+    {
+      "Category": "Modernity & Infrastructure",
+      "Keys": [
+        {"Key": "Modernity & Infrastructure", "Guidance": "Internet speed; payments; e-gov; grid."}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `main.json` defining scorecard categories and guidance keys
- flatten `ireland_report.json` to a single values collection with float `alignmentValue`s

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c36d2038748321821a896434642d73