### PR TITLE
Add placeholder reports for Korea, Thailand, and Taiwan

### DIFF
--- a/main.json
+++ b/main.json
@@ -563,6 +563,22 @@
     {
       "name": "Cuba",
       "file": "reports/cuba_report.json"
+    },
+    {
+      "name": "South Korea",
+      "file": "reports/south_korea_report.json"
+    },
+    {
+      "name": "North Korea",
+      "file": "reports/north_korea_report.json"
+    },
+    {
+      "name": "Thailand",
+      "file": "reports/thailand_report.json"
+    },
+    {
+      "name": "Taiwan",
+      "file": "reports/taiwan_report.json"
     }
   ]
 }

--- a/reports/north_korea_report.json
+++ b/reports/north_korea_report.json
@@ -1,0 +1,540 @@
+{
+  "iso": "KP",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "No private tech sector; programming jobs are state-assigned, leaving no path for .NET careers.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Coal heating and outdated industry leave urban air dusty, a concern for our kids.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "State atheism removes religious pressure but reflects oppressive control rather than pluralism.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Totalitarian rule eliminates civil liberties and risks our family values.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Sanctions and state banks make cards useless; cash rationing dominates daily life.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Coastline exists but public beach access and amenities are nearly nonexistent.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Hobby markets are banned and gatherings monitored, stifling board-game communities.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "State-run nurseries exist but resources and autonomy are limited.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Urban infrastructure is crumbling and surveillance heavy, making cities unfriendly for kids.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Work units may provide childcare but quality is poor and indoctrination heavy.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Foreign families rarely reside here and receive no childcare support.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Few leisure activities are permitted, leaving little overlap with our interests.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Social life is dictated by the state; trust outside assigned groups is risky.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Minor infractions can lead to severe punishment under pervasive surveillance.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Prices can be low but goods are scarce and often require bribes.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Dual citizenship is not recognized by the regime.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Sanctions and central planning keep the economy stagnant with little opportunity.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A strict command economy leaves no room for market entrepreneurship.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Schools focus on ideology with limited resources and poor global outcomes.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Foreign employment is nearly impossible; there is no sponsorship channel.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Deforestation and pollution outweigh limited scenic areas.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Income for foreigners is uncommon and tax rules are opaque and arbitrary.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn runs about 5–20°C (41–68°F), crisp but data is limited.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "State dictates family roles and discourages alternative relationship structures.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Bringing dependents is discouraged; foreign families are rare.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Pro-natalist benefits exist but depend on political loyalty.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Policies support only state-approved nuclear families.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Foreign families receive no meaningful support or recognition.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Conservative, state-approved dress leaves little room for expression.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Uniform styles are expected, curbing personal style.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Traditional roles are enforced, limiting gender expression.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "There is no commercial game industry or indie scene.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Gender nonconformity is repressed by law and custom.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Women have nominal equality but face strict expectations and limited rights.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Rigid patriarchal roles dominate daily life.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Foreigners face constant monitoring and severe movement restrictions.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Floods and droughts may intensify, and infrastructure is ill-prepared.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Universal in name but medicine and equipment shortages are common.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Foreigners rely on limited clinics with minimal capabilities.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "University access hinges on political loyalty rather than merit.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Foreign students are rarely admitted outside propaganda programs.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Housing is allocated by work units, often cramped and poorly maintained.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Personal taxes are opaque; the state extracts resources through work units.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "State schools exist nationwide but are heavily indoctrinating.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "No international schools for outsiders; enrollment is exceptional.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Homosexuality is unacknowledged and severely repressed.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English is rarely spoken; Korean is mandatory everywhere.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Juche draws from Marxism-Leninism but is enforced dogma rather than open discourse.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Militaristic culture prizes traditional masculinity and conformity.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Unauthorized gatherings are prohibited, hindering any community events.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "State wages are symbolic and inadequate for family needs.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Infrastructure is antiquated with frequent power and service outages.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Mountain landscapes and rivers are scenic yet largely inaccessible.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Typhoons and floods regularly cause damage due to poor mitigation.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Travel restrictions make it hard to reach natural areas.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Entertainment is state-run and lacks diversity or spontaneity.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Curfews and surveillance prevent normal nightlife.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "No known game development communities operate openly.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Only small propaganda studios exist; none suit indie goals.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Private startups are forbidden under the command economy.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Rationing slows daily life but surveillance keeps stress high.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Parents are expected to raise loyal citizens under heavy state oversight.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization is virtually impossible for foreigners.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Bribery is commonplace despite official denials.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A hereditary one-party state offers no democratic participation.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Non-monogamous relationships are illegal and harshly punished.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "State nurseries provide care but are underfunded and ideological.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Private schools are banned outright.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "The regime promotes ultraconservative nationalism, not progressive values.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "The state saturates all media with propaganda, giving rich material to study.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Propaganda is ubiquitous in schools, workplaces, and public spaces.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Pyongyang has a metro but travel elsewhere is tightly restricted.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Religion is absent but replaced with ideological cults, not secular pluralism.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Open internet and remote work are forbidden.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Only short, highly controlled visas are available.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "State pensions exist but are small and unreliable.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "No pathways exist for foreign retirees.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "No market for Ruby developers or modern software roles.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Street crime is low, but political risk and arbitrary detention are high.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Only state-run schools with propaganda are available.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Coastal waters are cool much of the year and facilities are minimal.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Hot humid summers and freezing winters clash with our mild-climate preference.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Sex outside marriage is taboo and heavily censored.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Policies prioritize regime control over personal freedoms.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "5–17°C (41–63°F) with frequent dust storms from China.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "The regime is rigid but economic shocks and isolation create uncertainty.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Juche ideology demands absolute loyalty, conflicting with our values.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Markets operate only informally; capitalism is effectively banned.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "23–30°C (73–86°F) with heavy monsoon humidity.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Visa processes are opaque, expensive, and slow with few approvals.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Public trust is coerced; dissent is dangerous.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Petty bribery and elite graft are common just to access basics.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Salaries are symbolic and insufficient for supporting a family.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends include mandatory community labor and propaganda events.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Long workdays plus political meetings leave little family time.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Official leave is minimal and at the discretion of the work unit.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Even when granted, travel options are heavily restricted.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "State media portrays neighbors as hostile enemies.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighboring states view the regime with suspicion and concern.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Propaganda promotes self-reliance and superiority, discouraging openness.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Only short tourist visas exist; no immigration pathways.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Americans are rarely admitted and tightly controlled.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "The closed system offers unique study in propaganda but little else appealing for family life.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "-13–3°C (8–37°F) with biting winds beyond our comfort.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Workers face long hours plus ideological sessions.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "State demands override personal and family time.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "No independent unions; forced labor and punishments are common.",
+      "alignmentValue": 1
+    }
+  ]
+}

--- a/reports/south_korea_report.json
+++ b/reports/south_korea_report.json
@@ -1,0 +1,540 @@
+{
+  "iso": "KR",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Mountainous terrain and well-kept parks offer plentiful outdoor escapes despite dense cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heatwaves and rising seas threaten coastal zones though mitigation planning is active.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Four distinct seasons bring humid summers and cold winters, challenging our mild-climate preference.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Frequent fine-dust episodes from industry and China degrade urban air.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Typhoons and occasional quakes occur but building standards reduce impact.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "10–20°C (50–68°F) with yellow dust and cherry blossoms.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "22–30°C (72–86°F) and humid monsoon rains.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "10–22°C (50–72°F) dry and clear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "-2–5°C (28–41°F) with occasional snow.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Busan and Jeju offer beaches but not year-round swimming.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Summer waters near 24°C (75°F) cool by fall.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "National parks, islands, and seasonal blossoms are scenic.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "2024 rate about ₩9,860/hour (~$7.50) provides modest baseline.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Seoul devs earn roughly $45k–$70k USD, lower than US but livable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Enterprise and game studios use .NET but market is smaller than Java.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby is niche with limited openings outside startups.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "E‑7 and other work visas exist yet require sponsorship and degree.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Advanced high-income economy with strong exports and tech sector.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Pandemic normalized some remote work but office presence remains standard.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Long hours culture clashes with our family’s balance goals despite reforms.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Legal 40 but overtime often pushes weeks toward 50–60.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "15 days after first year by labor law.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Workers often take fewer than allowed due to culture.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Seoul’s pace is fast and competitive; smaller cities slower.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Parents often return after 7 pm; kids attend after-school hagwons.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Family outings to parks, cafes, or hiking; catch up on rest.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Strong family emphasis but work hours limit together time.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Non-monogamy has little social or legal acceptance.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "High academic expectations and structured extracurriculars.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Safe with many kid cafes and parks yet space is limited.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public schools high-performing but intense; international schools costly.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Government expanding daycare though spots in Seoul fill quickly.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Monthly subsidies and free preschool for ages 3–5.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Foreign residents can access some subsidies but coverage varies.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Universal and high quality with strong outcomes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Public schools open to foreigners though Korean fluency is expected.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Heavy reliance on hagwons adds cost and pressure.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Parental leave and child allowances exist but uptake low for fathers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Some benefits extend to residents yet bureaucracy can limit use.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Top universities like Seoul National offer world-class programs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Many universities have English tracks and scholarships for internationals.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Traditional expectations persist though younger generations push change.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Nonbinary identities receive limited recognition outside activist circles.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Legal equality but wage gap and glass ceiling remain issues.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Strong beauty culture and modesty expectations.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Professional success and military service shape male roles.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Blend of cutting-edge tech, pop culture, and ancient heritage.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English taught widely; proficiency moderate outside tourist areas.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Democratic politics with active civil society yet conservative social views linger.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Cold War legacy fosters skepticism toward Marxism.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "About half the population identifies with no religion.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Public discourse is modest; sex education improving slowly.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Activism growing but legal recognition and social acceptance remain limited.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Tight-knit circles form around schools and workplaces; integration takes effort.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Strong national pride tied to rapid development and cultural exports.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Historical tensions with Japan and North Korea; pragmatic with China.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Respected for economic success yet viewed through security lens.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Seoul’s nightlife is vibrant with late-night dining and entertainment.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Streetwear and grooming-focused styles set regional trends.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "K-fashion blends modesty with cutting-edge looks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Hiking, gaming, and cafe socializing are popular.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Board-game cafes and PC bangs support a growing tabletop scene.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "K-pop concerts and clubs provide abundant music venues.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Expat and tech meetups occur regularly in Seoul.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Mountains and rivers are reachable even from major cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Presidential republic with regular competitive elections.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Religious groups exert limited direct influence on policy.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Labor laws exist but enforcement against overwork is weak.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Liberal democracy paired with strong anti-communist stance.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Institutions are stable though past military rule prompts vigilance.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Market economy dominated by chaebols yet entrepreneurial scene growing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Domestic stability high but North Korea remains a security concern.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Media is largely free though national security messages are common.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Emphasis on anti-North sentiment and national unity.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Gradual expansion of welfare and child incentives.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Varies with scandals; moderate overall.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Chaebol-political ties continue to raise concerns.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Influence peddling and favoritism linked to conglomerates.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Seoul housing costly with heavy reliance on jeonse deposits.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime rates are low and streets feel safe.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Universal National Health Insurance offers affordable care.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Foreign residents can enroll after registration and pay into the system.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Government subsidies help with daycare but long waits in cities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Support improving yet not as generous as Nordic models.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Students excel in OECD rankings but pressure and rote learning are concerns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Subways and buses are extensive, punctual, and affordable.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Advanced mixed economy with strong export base.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Income tax withheld monthly with annual reconciliation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Middle-income families face roughly 10–20% effective rates.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Highly digitized banking; mobile payments ubiquitous.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Seoul living costs are high relative to local wages.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "National Pension Service provides modest old-age benefits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Foreign workers contribute and may reclaim pension when leaving.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Multiple work and business visas exist but paperwork is detailed.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Generally neutral reception; cultural adaptation expected.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "E and D visas typically valid 1–3 years before renewal.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Requires 5+ years residency, language test, and renouncing prior citizenship.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and children can accompany on dependent visas.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing takes several months with moderate legal fees.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Strict immigration checks; overstays result in fines or bans.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Generally not allowed except in rare talent or marriage cases.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Must maintain employment and address changes; bureaucracy in Korean.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Large online and mobile game sector offers many roles.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Home to Nexon, NCSoft, Netmarble, and others.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Indie meetups and university clubs support collaboration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Government incubators and esports culture aid startups, though competition is stiff.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "World-class broadband, transit, and smart-city tech everywhere.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/taiwan_report.json
+++ b/reports/taiwan_report.json
@@ -1,0 +1,540 @@
+{
+  "iso": "TW",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Microsoft stack appears in finance and government, though Java and web frameworks dominate.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "West coast cities see winter PM2.5 spikes, yet regulations are gradually improving air quality.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "High religious pluralism and a sizeable non-religious population foster tolerance for atheists.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Vibrant democracy and active civil society keep autocratic drift low despite pressure from China.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Modern banks, ubiquitous ATMs, and contactless systems like EasyCard make transactions easy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Accessible beaches line the east and south coasts, though they are more weekend escape than daily life.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Board game cafes and local publishers sustain an active tabletop scene in Taipei.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidies and new public centers help but many families still rely on private care or relatives.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Cities feature playgrounds, safe transit, and family-friendly night markets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive monthly subsidies and expanding public preschool options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Foreign residents can access subsidies after registration but English services are limited.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Hiking, night-market snacking, and gaming align well with the family's interests.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Friendly locals and organized expat groups create welcoming communities despite language gaps.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Visa renewals and business filings require Chinese paperwork, adding moderate bureaucratic friction.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Housing is pricey in Taipei, but food and transit remain affordable compared to U.S. cities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Naturalization typically demands renouncing prior citizenship with narrow exceptions.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "An export-driven tech economy maintains steady growth and low unemployment.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Capitalist market complemented by strategic state guidance and strong SMEs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Public schools rank well internationally but emphasize rote learning and long hours.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Tech firms sponsor work permits, though openings often favor Mandarin speakers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Mountains and parks offer greenery, yet industrial zones reduce overall environmental quality.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Progressive income tax around 5–20% plus NHI premiums keeps overall burden moderate.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn days sit near 22–28°C (72–82°F) as typhoon season winds down, making it comfortable.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Family is culturally central, though long work hours can limit shared time.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spousal and dependent visas are commonly approved, enabling the whole family to stay together.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Parental leave up to six months and child allowances support citizen parents.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Standard households receive basic tax deductions and education subsidies.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Foreign families access NHI and schools but miss some cash benefits.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Urban women blend East Asian streetwear with modest business attire.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men favor casual street fashion alongside smart office wear.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Traditional expectations persist but younger generations show more gender flexibility.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "A small yet growing sector hosts events like the Taipei Game Developers Forum.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal gender change is possible, though understanding outside Taipei remains limited.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Same-sex marriage and anti-discrimination laws put Taiwan ahead of most of Asia.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Work-centric culture still expects mothers to manage childcare, though attitudes slowly shift.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "ARC applications are straightforward but rely on Mandarin documentation and local sponsors.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Rising seas and stronger typhoons threaten coastal and low-lying areas.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "National Health Insurance delivers broad coverage with low out-of-pocket costs.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Foreigners join NHI after six months, accessing the same clinics at modest fees.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Universities are plentiful and affordable though highly competitive.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International programs exist, but most instruction remains in Mandarin.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Urban housing is compact and expensive, making family-sized units harder to afford.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Annual filing can be done online but is largely in Mandarin, often requiring an agent.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "High enrollment and quality public schools with strong STEM focus.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Foreign children may attend public schools, yet language support varies by district.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Major cities host large Pride events and social acceptance is relatively high.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Mandarin dominates and outside tourist areas English proficiency can be limited.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Public opinion favors liberal democracy, and Marxist ideas are rare.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Men face moderate expectations to be breadwinners, though metro fashion softens stereotypes.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech, gaming, and language-exchange groups flourish in Taipei.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Monthly minimum wage near NT$27k (~USD900) signals baseline labor protections.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "High-speed rail, 5G coverage, and smart-city projects indicate advanced infrastructure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "From Taroko Gorge to Alishan forests, the island offers striking landscapes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Regular earthquakes and typhoons pose significant risk.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Trailheads are reachable by public transit, making weekend hikes easy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Live houses, KTV, and festivals provide diverse evening entertainment.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Night markets and late eateries create a social yet family-friendly nightlife.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Groups like Taipei IGDA and local forums connect developers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios such as Rayark and Red Candle show local creativity.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Innovation grants and the Taiwan Gold Card support entrepreneurial founders.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Taipei moves fast, while smaller cities like Tainan offer a slower rhythm.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "School-centric culture pressures parents toward after-school tutoring.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Requires over five years' residence, language tests, and renouncing prior citizenship.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Taiwan relatively clean with strong anti-graft agencies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Multi-party democratic republic with regular competitive elections.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Polyamorous relationships lack legal recognition and remain largely taboo.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public preschools are expanding but urban waitlists are common.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Private and international schools exist but command high tuition.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Digital democracy initiatives and LGBTQ rights reflect a broadly progressive society.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government messaging focuses on civic campaigns rather than ideology.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Free press and vibrant media limit state-controlled narratives.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Taipei MRT and intercity rail are clean, reliable, and extensive.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Religion rarely influences policy, keeping governance largely secular.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Co-working spaces support remote work, though many employers prefer office presence.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Work visas, spousal ARCs, and three-year Gold Cards provide varied stay options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "State pension offers modest payouts, supplemented by private savings.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Foreigners may retire but receive limited pension benefits unless contributing long-term.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby on Rails is used in some startups and fintech but isn't mainstream.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Taiwan ranks among the world's safest countries with very low violent crime.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Bilingual programs and international schools give alternatives to standard Mandarin instruction.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Coastal waters range roughly 22°C in winter to 29°C in summer (72–84°F).",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Subtropical climate means hot, humid summers and mild winters with frequent rain.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Public discussions of sexuality remain conservative despite some urban liberalization.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive on healthcare and LGBTQ rights but conservative on drugs and conscription.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Spring sees 18–26°C (64–79°F) with blossoms and occasional rain.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Domestic stability is high though cross-strait tensions persist.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Emphasis on democratic values and a market economy rather than a single ideology.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Entrepreneurial environment with strong private sector and venture support.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summer highs reach about 33°C (91°F) with high humidity and typhoon threats.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Gold Card processing finishes in 1–2 months with moderate fees.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Public confidence rose after effective pandemic response and open data efforts.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Issues mainly involve petty bribery or influence peddling and are generally prosecuted.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Mid-level developers earn around NT$1–1.5M yearly (USD33–50k).",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Families explore night markets, parks, and nearby hiking trails on weekends.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Standard office jobs run 9–6 with overtime culture that can eat into evenings.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor laws guarantee 7–15 paid days depending on tenure.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Most employees take around two weeks off annually, matching legal minimums.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment is warm toward Japan but wary of China's intentions.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Japan and the U.S. view Taiwan favorably, while China claims it as territory.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Strong national identity centers on democracy and resilience.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Work visas, family reunification, entrepreneur visas, and the flexible Gold Card offer multiple routes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Close ties with the U.S. and friendly locals make Americans generally well received.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Blend of high-tech industry and vibrant traditional culture stands out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters hover around 13–18°C (55–65°F) in Taipei with cool rain.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Legal cap is 40 hours, yet overtime is common in practice.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Long hours and after-work obligations can strain family time.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Labor laws mandate overtime pay and leave, but enforcement varies in smaller firms.",
+      "alignmentValue": 5
+    }
+  ]
+}

--- a/reports/thailand_report.json
+++ b/reports/thailand_report.json
@@ -1,0 +1,540 @@
+{
+  "iso": "TH",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Tropical forests, coral reefs, and national parks offer rich biodiversity amid urban sprawl.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Low-lying coasts and hotter seasons make climate change a serious threat despite adaptation efforts.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Hot, humid tropics with a rainy monsoon and short cool season, far from our mild preference.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Bangkok often suffers from PM2.5 pollution though smaller towns fare better.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Seasonal flooding and occasional typhoons pose recurring hazards.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "26–34°C (79–93°F) hot and dry before the monsoon.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "25–32°C (77–90°F) with heavy rain and high humidity.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "24–31°C (75–88°F) still humid but rains taper.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "22–32°C (72–90°F) drier and slightly cooler.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Islands like Phuket and Samui offer warm beaches and resort infrastructure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Seas stay around 27–30°C (81–86°F) year-round.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Karst mountains, jungles, and temples provide striking scenery.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Daily minimum varies by province around 363 THB (~$10) offering a low baseline.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Bangkok developers earn roughly $20k–$40k USD, stretching further with low costs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Multinational firms and outsourcing shops use .NET but the ecosystem is modest.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby jobs are scarce, mainly in startups.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Non-B work visas require employer sponsorship and proof of capital.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Tourism and manufacturing keep GDP growing though inequality persists.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Co-working hubs and nomad visas support remote work, especially in Bangkok and Chiang Mai.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Thai offices can run long hours yet overall culture values leisure and festivals.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Labor law caps at 48 but many firms keep near 40.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Only 6 paid days after a year, among the region’s lowest.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Multinationals offer 10–15 days and taking them is usually accepted.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Relaxed vibe outside Bangkok suits a slower lifestyle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "School and work often start around 8 a.m., with evening markets or family dinners.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends feature temple visits, outdoor markets, or beach trips.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Extended families are common and children are welcomed in public spaces.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "No legal recognition and social norms favor monogamy.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Society expects respectful, well-behaved kids; communal caretaking is normal.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Urban parks and malls cater to families though sidewalks can be rough.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public schools are basic; international schools provide quality at high cost.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Private nurseries and preschool programs are available but quality varies.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Government subsidies are limited, leaving families to self-fund.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Foreign families receive no subsidies but can access private centers.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Universal basic education through grade 9 with mixed outcomes.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Public schools accept foreign kids but language barriers and quality pose issues.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International schools deliver high standards yet tuition is steep.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Small child allowances and maternity leave exist but benefits are modest.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Most benefits exclude foreigners aside from private insurance options.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Public universities are affordable and improving.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Foreign students pay higher tuition but admissions are possible.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Traditional roles persist though urban areas show more equality.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Thai culture shows visible gender variance, especially kathoey communities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Legal protections against discrimination remain limited.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Femininity is associated with modesty and soft-spoken behavior.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Men face expectations to provide and maintain a calm demeanor.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Blend of Buddhist culture, street food, and digital nomad scene draws interest.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Tourist zones use English but proficiency drops outside cities.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Social views are moderate with some reforms but conservative institutions.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Marxism holds little sway beyond academic circles.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Buddhist majority allows private disbelief but few identify openly.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Sex work is widespread yet public conversation remains modest.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Public tolerance in urban areas contrasts with lack of legal rights.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Friendly smiles and neighborhood markets foster community.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Pride in hospitality and cultural heritage.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Generally cordial toward ASEAN neighbors but wary of Myanmar’s instability.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Seen as a tourist magnet and pragmatic partner.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Vibrant scenes from Bangkok clubs to beach parties.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Casual lightweight clothing suits the heat; business wear mostly in offices.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Blend of modest outfits and trendy street fashion.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Cooking classes, Muay Thai, and temple festivals are popular.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Growing café scene in Bangkok and Chiang Mai.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Live music bars and EDM festivals abound.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Expat and tech meetups flourish in urban hubs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Easy access to jungles, mountains, and marine parks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Constitutional monarchy with frequent military influence.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Buddhism informs culture yet the state is officially secular.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Labor unions exist but power is limited and enforcement inconsistent.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Nationalism and royalism dominate official narratives.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Military coups and party bans keep democracy fragile.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Market-driven economy with a significant informal sector.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Political protests recur but daily life remains mostly stable.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Government controls messaging around monarchy and security.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Emphasis on royal loyalty and national unity.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Basic welfare programs exist but coverage is patchy.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Many residents distrust politicians due to corruption scandals.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Bribery and patronage are commonly perceived.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Petty bribery in bureaucracy alongside high-level kickbacks.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Affordable rentals available but quality varies; expats cluster in condos.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime is low but petty theft and scams affect tourists.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Universal Coverage Scheme provides basic care with long waits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Expats rely on private hospitals offering high-quality care at moderate prices.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Limited public subsidies mean families often rely on relatives.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Policies support nuclear families modestly with maternity leave and education subsidies.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Public education quality varies; strong private and international options exist.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Bangkok's BTS/MRT and regional buses provide coverage but rural areas rely on cars.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Mixed economy with strong tourism and manufacturing sectors.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Progressive income tax filed annually; VAT collected at point of sale.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "With moderate incomes, effective income tax likely around 15%.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Modern banking apps and QR payments are widely adopted.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Low costs for food and housing stretch budgets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "State pension exists but payouts are small.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Long-stay retirement visas and affordable healthcare make retirement feasible.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Tourist, Non-B, marriage, and Elite visas offer varied routes but paperwork is heavy.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Friendly to Westerners though long-term residency requires patience.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "One-year extensions or elite packages; permanent residency after years.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization demands years of residence, language, and quotas.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and kids can be included on dependent visas.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing takes months; elite visa fees reach tens of thousands USD.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Strict reporting and overstay fines require diligence.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Thai-born can hold dual; naturalized citizens are expected to renounce.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Regular 90-day reports and address checks can be bureaucratic.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Growing indie scene and outsourcing companies but limited AAA presence.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Sanuk Games and Urnique produce regional titles.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Events in Bangkok and Chiang Mai foster small dev communities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Low living costs and emerging talent make a feasible launchpad.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "High-speed internet and modern malls coexist with patchy rural infrastructure.",
+      "alignmentValue": 6
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add initial report files for South Korea, North Korea, Thailand, and Taiwan containing all required keys
- register the four countries in main.json for UI inclusion
- populate South Korea, North Korea, Taiwan, and Thailand reports with real alignment data across all 107 keys

## Testing
- `jq empty main.json reports/thailand_report.json`


------
https://chatgpt.com/codex/tasks/task_e_68c5e7ce0dfc8321a056861f85c0d276