### PR TITLE
Add Netherlands migration profile

### DIFF
--- a/main.json
+++ b/main.json
@@ -595,6 +595,10 @@
     {
       "name": "Taiwan",
       "file": "reports/taiwan_report.json"
+    },
+    {
+      "name": "Netherlands",
+      "file": "reports/netherlands_report.json"
     }
   ],
   "People": [

--- a/reports/netherlands_report.json
+++ b/reports/netherlands_report.json
@@ -1,0 +1,540 @@
+{
+  "iso": "NL",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Dense but carefully managed landscapes; strong cycling culture and green planning offset intensive agriculture pressures.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Below-sea-level regions face sea-level rise, yet the Delta Programme and dike upgrades keep current risk well-mitigated.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Marine climate brings frequent clouds, drizzle, and mild temperatures; little thermal extremes but limited sunshine.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Generally good EU-standard air, though nitrogen emissions from traffic and agriculture spike near ports and farms.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Very low seismic or storm threats; primary concern is flooding, managed by world-class water defenses and warning systems.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March-May averages roughly 6-16°C (43-61°F); breezy with showers and rapid daylight gains.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "June-August highs around 20-24°C (68-75°F) with occasional humid heatwaves but mostly comfortable.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September-November hover 8-16°C (46-61°F); wetter and windy but rarely severe.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "December-February average 0-6°C (32-43°F); damp cold with light snow or ice spells.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North Sea beaches are wide with dunes and family amenities; often windy and better for strolls than swimming.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Water ranges ~5°C in winter to ~20°C (68°F) in rare summer peaks; short comfortable swim season.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Flat polders, wetlands, and historic towns offer subtle beauty; limited mountains but strong park accessibility.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Monthly statutory minimum about €2,000 gross in 2024 with indexation; supports baseline security but high costs remain.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers in Amsterdam/Utrecht earn roughly €65-90k plus bonuses; purchasing power moderate after tax.",
+      "alignmentValue": 7
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Plentiful enterprise and government .NET roles, especially via consultancies and fintech hubs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Smaller scene concentrated in startups and agencies; roles exist in Amsterdam but competition tighter.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "IND-recognized sponsors regularly hire internationals under the Highly Skilled Migrant program with predictable processing.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Stable, diversified economy with low unemployment and resilient trade/logistics sectors despite global headwinds.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid work widely adopted post-2020; coworking plentiful and CET time zone overlaps US mornings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Dutch work culture prizes leaving on time and part-time options; parental schedules are respected.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Typical full-time around 36-40 hours with many four-day contracts; overtime uncommon.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Legal minimum is four times weekly hours (~20 days) plus 8% holiday allowance and public holidays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers often grant 25-30 days plus collective shutdowns, enabling extended family travel.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Cities are efficient yet calmer than US metros; cycling commutes reduce stress though housing hunts feel hectic.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run ~8:30-15:00; offices 9-5 with lunch at desks; after-school BSO care bridges to 18:00.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends feature biking, markets, and museums; many shops close early Sunday so plan errands Saturday.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Strong social support, child benefits, and community sports clubs create a family-friendly baseline.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Social tolerance is high and non-monogamous groups exist, but legal recognition is limited to cohabitation contracts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Culture emphasizes child autonomy, low homework pressure, and cooperative school-parent relationships.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Cycling infrastructure, playground density, and traffic calming make urban cores manageable with kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public schools include diverse pedagogies (Dalton, Montessori) and bilingual streams; enrollment via municipal lotteries.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Daycare and preschool spots exist but waitlists common in big cities; quality regulated with Dutch/English options.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Income-based childcare allowance reimburses large share once both parents working; reforms expanding coverage.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Eligible once registered and paying Dutch taxes, though upfront costs high until allowances paid quarterly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Free public primary/secondary with strong outcomes and inclusive special-needs support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Non-Dutch kids can attend local public schools; bilingual bridges help but placement depends on address.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Few elite private schools; most so-called special schools are state-funded faith or pedagogy-based with minimal fees.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Paid parental leave, child benefits, and flexible work rights support dual-career households.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Residence permit holders access leave and benefits after municipal registration, though paperwork is Dutch-centric.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Universities are high-quality with low tuition and generous student finance options.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students welcome but pay higher tuition; many English-taught programs in tech/business.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Society expects gender equality, yet many mothers work part-time by choice; partners share caregiving.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal gender change simplified and public discourse increasingly supportive though rural awareness varies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Strong protections for reproductive rights, workplace equality, and anti-discrimination enforcement.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Low emphasis on formal dress; practical, athletic styles align with cycling culture.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Men expected to be hands-on parents and emotionally open; macho posturing uncommon.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Blend of historic canals, design-forward culture, and experimentation with urban living.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English proficiency is among the world’s highest; Dutch lessons easily available for integration.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Policy debates center on social liberalism, climate action, and inclusion despite a vocal right-wing minority.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Broadly social-democratic pragmatism; radical left small but labor cooperatives respected.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Over 50% non-religious; faith communities coexist but secular norms dominate public life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education and normalized discussion of sexuality from early schooling.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Early adopter of marriage equality; pride events mainstream, though rural pockets show occasional pushback.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighborhood associations, cafes, and parent co-ops create approachable yet privacy-respecting communities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Dutch identity prizes directness, pragmatism, and global trade outlook.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Cooperative with EU neighbors, especially Belgium and Germany; occasional competitiveness with UK post-Brexit.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Seen as reliable, progressive partners with occasional critiques about tax rulings and drug tourism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Amsterdam and Rotterdam host late-night clubs, festivals, and relaxed alcohol/cannabis norms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Cycling-friendly layers, tailored denim, and smart-casual streetwear dominate urban looks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Minimalist silhouettes, sustainable fabrics, and practical footwear for biking commutes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Cycling, sailing, football, and creative workshops are widely accessible for families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Active boardgame cafes (e.g., TonTon Club) and Spiel-style conventions nearby in Essen.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Electronic music hubs, jazz venues, and family-friendly festivals throughout the year.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "International tech meetups, expat parents’ groups, and LGBTQ+ networks abundant in major cities.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Quick train rides to dunes, national parks, and Wadden Sea islands offer respite from city life.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Constitutional monarchy with proportional parliament requiring consensus coalitions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Religion has limited policy sway; Christian parties exist but operate within secular governance norms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong unions, collective bargaining coverage, and protections for contractors and employees alike.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Centrist mix of social welfare and open-market trade; policy shifts via coalition compromises.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Institutions resilient with free press and judiciary, though populist parties monitor immigration anxieties.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Social market economy balancing entrepreneurship with regulation and safety nets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Highly stable rule of law and low civil unrest; protests tend to be peaceful.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Independent media landscape; public broadcasters transparent though debates over farm emissions can polarize.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government messaging emphasizes consensus and evidence-based policy rather than nationalist narratives.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Comprehensive welfare state covering healthcare, housing allowances, and inclusive education.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Public trust moderate-high but dipped during childcare benefits scandal; transparency initiatives ongoing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Ranks among least corrupt globally, with strong oversight bodies.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Issues arise in lobbying/tax rulings or municipal planning, rarely outright bribery.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Severe housing shortage, high rents, and bidding wars in Randstad; social housing queues years long.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Low violent crime; petty theft and bike stealing common in tourist zones.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Universal mandatory insurance with high-quality GPs and hospitals; queues manageable.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Highly skilled migrants must buy Dutch insurance within 4 months; coverage equal once enrolled.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "National reforms aim for near-free childcare by 2027; current allowances cover 70-96% depending on income.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Standard benefits include child allowances, parental leave credits, and flexible work rights.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "OECD-top performer with bilingual tracks and strong STEM; some overcrowding in Amsterdam schools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Dense rail/tram/bus network with nationwide OV-chipkaart; biking integrates seamlessly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Highly globalized mixed economy with emphasis on logistics, tech, and services.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers income tax and social premiums; annual returns digital and streamlined (MijnBelastingdienst).",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual tech incomes likely fall in 37-49% brackets; 30% ruling can exempt part of income for first five years.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Easy account setup with BSN; instant SEPA, iDEAL, and contactless ubiquitous.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "High housing, childcare co-pays, and groceries offset by cycling and public transport savings.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "State AOW pension plus mandatory employer schemes provide solid baseline security.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Access to AOW requires long-term residency; expats rely on employer pensions and private savings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Highly Skilled Migrant, EU Blue Card, startup visa, and self-employed routes cover most scenarios.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "IND accustomed to US applicants; American Dutch Friendship Treaty offers entrepreneur path though bureaucracy exists.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Residence permits typically 2-5 years, extendable; permanent residency after 5 years continuous stay.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization possible after 5 years residence and integration exam; dual nationality generally requires renunciation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and children included on permits; registered partnerships recognized, but polycules limited to one partner.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Highly skilled migrant approvals typically 2-4 weeks after submission; fees around €350-400 per person.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Must maintain salary thresholds, municipal registration, and Dutch health insurance; IND audits manageable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Generally not; US citizens must renounce unless qualifying for limited exemptions (e.g., Dutch spouse).",
+      "alignmentValue": 3
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Need BSN registration, Dutch-language paperwork, and housing contracts to activate benefits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Moderate market with AAA (Guerrilla) and indie studios around Amsterdam, Utrecht, and Rotterdam.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Guerrilla Games, Vertigo Games, Triumph Studios, and indie hubs linked to Dutch Game Garden.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Dutch Game Garden incubator, INDIGO festival, and active IGDA Netherlands chapter support networking.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Startup visa, innovation subsidies, and EU grants plus accessible coworking enable indie studio launches.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Nationwide fiber rollout, smart logistics, and digitized public services keep daily life friction-light.",
+      "alignmentValue": 9
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Netherlands report with scores and narrative alignment text for all 107 checklist keys
- register the Netherlands report in the Countries list so it appears in the UI

## Testing
- python -m json.tool reports/netherlands_report.json
- python -m json.tool main.json

------
https://chatgpt.com/codex/tasks/task_e_68dbf36e070483219241ff58d364d8a9