### PR TITLE
Add Italy migration report

### DIFF
--- a/main.json
+++ b/main.json
@@ -599,6 +599,10 @@
     {
       "name": "Netherlands",
       "file": "reports/netherlands_report.json"
+    },
+    {
+      "name": "Italy",
+      "file": "reports/italy_report.json"
     }
   ],
   "People": [

--- a/reports/italy_report.json
+++ b/reports/italy_report.json
@@ -1,0 +1,540 @@
+{
+  "iso": "IT",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Varied landscapes from alpine valleys to Mediterranean coasts give options for mild microclimates, though industrial northern plains feel less pristine.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Mediterranean heatwaves, Alpine glacier melt, and rising Adriatic flood risk require adaptation planning for a climate-sensitive family.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Central Italy delivers spring and fall shoulder seasons but summers can swing hot and humid, especially in the Po Valley.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Cities like Milan and Turin see PM2.5 spikes in winter inversions, so cleaner air would mean targeting coastal or hill towns.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Earthquakes along the Apennines plus occasional flooding and volcanic risk near Naples demand location-specific mitigation.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Rome averages ~8–20°C (46–68°F) with breezy showers, comfortable for outdoor time with light layers.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Many regions hit 20–32°C (68–90°F) and humidity builds in July–August, making shade and siesta culture important.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn cools to roughly 12–24°C (54–75°F) with crisp evenings and grape harvest festivals, aligning with their mild-climate wish.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Coastal cities hover 3–12°C (37–54°F) with damp chill, while the north can drop below freezing and see snow.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Hundreds of Blue Flag beaches and Ligurian/Tuscan coasts offer clean water, though peak season crowds require planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Mediterranean waters warm to 23–26°C (73–79°F) June–September, giving a solid summer swim window even if winters are chilly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Dolomites, Tuscan hills, and Amalfi cliffs pack world-class scenery within train reach for weekend escapes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "No national minimum wage; sectoral contracts set pay and can lag behind living costs, challenging for newcomers.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Mid-level devs often earn €35–45k in Milan/Rome—lower than Northern Europe, so remote USD income would stretch further.",
+      "alignmentValue": 4
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Banking, telecom, and public-sector vendors rely on .NET, but roles concentrate in Milan/Rome and expect Italian fluency.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby scenes exist in fintech and agencies yet remain niche; many teams pivot to JavaScript or Java stacks.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Quota-driven work permits and paperwork-heavy employers make sponsorship inconsistent unless joining multinationals.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Italy’s GDP growth is modest with high debt, yet unemployment is trending down and inflation stabilized within EU norms.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Post-pandemic hybrid policies exist in tech hubs, but many firms still expect office presence and Italian working hours.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Long lunches, protected vacation time, and strong labor rules reinforce boundaries Sarah would appreciate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Contracts mandate ~40 hours, but some offices expect extra availability despite union protections.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Statutory leave is at least four weeks plus ~11 public holidays, giving ample family recharge time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Most staff take extended August breaks and bridge holidays, though startups may temper that flexibility.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Outside Milan, daily rhythms favor slower meals and evening passeggiata, matching their desire for a calmer vibe.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools often end by early afternoon, so parents juggle midday pickups unless after-school programs are secured.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends revolve around markets, parks, and Sunday closures, encouraging family time but requiring planning for errands.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Family-centric culture means kids are welcome almost everywhere, yet expectations lean on extended relatives for support.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Social norms remain Catholic-influenced; consensual non-monogamy is largely private and lacks legal recognition.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and neighbors assume traditional parenting roles, which can feel judgmental toward unconventional family structures.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Playgrounds and pedestrian zones are improving, though narrow sidewalks and car traffic complicate stroller use.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public schools are free and solid academically, but bilingual or alternative models cluster in big cities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Municipal asili nido are affordable yet oversubscribed; private nurseries fill gaps at higher cost.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Assegno Unico allowances and expanding nursery subsidies help, though coverage still trails Northern Europe.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Resident visa holders can apply for subsidies, but proving income and status involves extra paperwork.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Compulsory schooling guarantees placement with no tuition, and curricula are nationally standardized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Foreign children have the right to enroll, yet enrollment offices may require in-person visits and translated documents.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Catholic and international schools exist but charge €10–20k annually and can have waitlists.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Cash allowances and parental leave exist yet benefits are modest and bureaucracy is significant.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Non-EU families can access some benefits after residency, but delays and documentation hurdles reduce usefulness.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Universities like Politecnico di Milano and Sapienza offer low tuition and strong STEM/game design tracks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International tuition is higher but still affordable versus US, though lectures often in Italian.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Gender gaps in employment and household labor persist, signaling lingering traditional expectations.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition for gender-diverse people exists but social acceptance is limited outside progressive enclaves.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Anti-discrimination laws cover gender and workplaces, yet enforcement lags and political debates are ongoing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Appearance-focused media and expectations for maternal caregiving can pressure women like Sarah.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Machismo tropes survive in some workplaces, though younger urban men adopt more egalitarian attitudes.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "World-leading art, food culture, and historic cities would feed the family’s curiosity and weekend adventures.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English proficiency is moderate in tourist centers but scarce with officials, making Italian study essential.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Urban voters back progressive coalitions, yet national politics swings centrist-to-conservative with Catholic influence.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist traditions remain in unions and cooperatives, but mainstream discourse is pragmatic rather than ideological.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Religious practice is declining and secular public life is common, though Catholic symbols remain visible.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Dating norms are liberal in cities, but open conversations about non-traditional relationships are still rare.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Civil unions are legal and Pride events thrive in Milan/Rome, yet legal gaps on adoption and surrogacy remain.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighborhood associations and local festivals foster tight-knit communities, though integrating takes patience.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Italians take pride in regional identity and craftsmanship, projecting warmth but also strong local loyalties.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Generally pro-EU with light rivalries toward France and Austria, rarely affecting day-to-day life.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors admire Italian culture yet critique bureaucracy and politics, influencing some stereotypes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Aperitivo bars, late dinners, and music venues keep city centers lively without always turning into loud club scenes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Tailored streetwear and attention to grooming set high style norms that can be fun for fashion-minded folks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Bold yet classic looks dominate, offering plenty of inspiration for anyone enjoying expressive fashion.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Football fandom, cycling, and food-centric gatherings dominate leisure time, with growing interest in outdoor fitness.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Board game cafés exist in Milan, Turin, and Bologna, though scenes are smaller than in Germany or the UK.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Live jazz, opera, and DJ sets dot major cities, providing adult nights out when childcare is lined up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Expat and tech meetups meet regularly in Milan/Rome, yet secondary cities have thinner calendars.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Trains reach Alps, lakes, and national parks within hours, making weekend hikes or climbs realistic.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Parliamentary democracy with proportional representation encourages pluralism but creates complex coalitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Secular constitution holds, yet Catholic values influence debates on family and bioethics.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Unions negotiate strong protections, and collective bargaining enforces notice periods and severance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A social-market blend supports welfare basics while maintaining private enterprise and EU integration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Populist rhetoric surfaces, but institutions, EU oversight, and active civil society keep checks in place.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Entrepreneurship coexists with state-influenced sectors and cooperatives, offering mixed opportunities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Frequent government turnover creates policy swings even though civil institutions remain steady.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Media ownership is concentrated, yet independent outlets and EU norms provide counterpoints.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters balance cultural programming with occasional nationalist framing, especially on migration.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Welfare reforms target families and low-income workers, though benefits lag behind Northern Europe.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show low institutional trust, reflecting frustration with bureaucracy and political churn.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International scores highlight persistent corruption risks, especially in procurement.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Clientelism and organized crime-linked patronage shape certain regions, demanding diligence from newcomers.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Homeownership is high but rentals in Florence/Milan are tight; smaller towns offer better value.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime is low; petty theft in tourist zones is the main concern to manage.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "The Servizio Sanitario Nazionale delivers universal care with strong preventive services and modest co-pays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents can enroll once holding a permesso, but the registration process requires patience.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Means-tested vouchers and expanding nursery slots exist, yet availability varies widely by municipality.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Parental leave and the new single allowance help, though benefit amounts may not cover Milan living costs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic rigor is strong but teaching methods skew traditional, so project-based learners may need extracurriculars.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "High-speed rail and metro networks in Rome/Milan make car-free living feasible, though southern service is patchier.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "EU single-market access and diversified SMEs create stability despite bureaucracy.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "High payroll taxes and complex filings require a commercialista, adding overhead for freelancers.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Combined income taxes and social contributions can approach 35–40% for middle-class households.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "SEPA instant transfers, widespread contactless payments, and modern fintech apps support daily life.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Housing and groceries cost less than coastal US cities, but Milan tech hubs feel pricier than Iberia.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Public pensions are reliable yet under demographic pressure, prompting reforms to benefits and age.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Non-EU residents need years of contributions for pensions, making private savings essential.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Elective residency suits retirees, while startup and digital nomad visas demand high income proofs and patience.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Locals are friendly to Americans, yet limited English and bureaucratic offices can feel unwelcoming initially.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Permessi di soggiorno start at 1–2 years with renewals before a 5-year long-term permit.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization requires 10 years’ legal residency plus language certification and can take years to process.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Family reunification is allowed and dependents can share residency status once documentation is approved.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Permesso renewals can take months, with revenue stamps, translations, and postal kits adding recurring costs.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Strict address registration, annual income proofs, and regional rule variations create tripwires for overstays.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Italy permits dual nationality, so US citizenship can be retained when naturalizing.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Expect in-person appointments, Italian-only portals, and the need for local helpers to navigate paperwork.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Industry is growing with studios in Milan and Rome, but total headcount remains limited compared to UK/France.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Milestone, Ubisoft Milan, 505 Games, and Nacon Italy offer recognizable AAA or AA opportunities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Events like Milan Games Week, First Playable in Florence, and indie meetups provide networking albeit infrequently.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "EU Creative Europe grants and local incubators exist, yet bureaucracy and small domestic market require export focus.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fiber broadband covers major cities and high-speed rail links north-south, while some southern infrastructure still lags.",
+      "alignmentValue": 6
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a fully populated migration alignment report for Italy that covers all 107 evaluation keys
- register Italy in the country list so it appears in the selection menu

## Testing
- python -m json.tool main.json
- python -m json.tool reports/italy_report.json

------
https://chatgpt.com/codex/tasks/task_e_68dc217b170c83218f660fc60e26edba