### PR TITLE
Add Denmark migration report

### DIFF
--- a/main.json
+++ b/main.json
@@ -599,6 +599,10 @@
     {
       "name": "Netherlands",
       "file": "reports/netherlands_report.json"
+    },
+    {
+      "name": "Denmark",
+      "file": "reports/denmark_report.json"
     }
   ],
   "People": [

--- a/reports/denmark_report.json
+++ b/reports/denmark_report.json
@@ -1,0 +1,540 @@
+{
+  "iso": "DK",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Denmark’s compact size mixes farmland with well-managed green belts, blue-flag beaches, and aggressive climate policy that keeps everyday environmental quality high for families who bike and walk.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Low-lying coasts face sea-level rise and storm-surge exposure, yet national dike upgrades and coastal retreat plans reduce near-term risk for settled areas.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "A temperate maritime climate brings mild but breezy seasons—plenty of clouds and drizzle, yet few temperature extremes compared with the US Midwest.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU air-quality targets are usually met; traffic and agricultural ammonia cause periodic PM spikes but coastal winds clear pollution quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "No earthquakes or tropical storms; the main hazards are North Sea windstorms and localized flooding, both mitigated by strong building codes and alerts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March–May days typically run 5–15°C (41–59°F) with lengthening daylight and occasional showers—light jackets still needed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "June–August highs hover around 20–23°C (68–73°F); humidity is moderate and evenings stay cool enough for comfortable sleep.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September–November cools to roughly 8–15°C (46–59°F) with frequent rain and rising winds, which can feel chilly on bikes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "December–February averages around −1 to 5°C (30–41°F); snow is light but damp cold and short daylight can weigh on mood.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Hundreds of public beaches rim the Baltic and North Sea; clean facilities and dunes are family-friendly though winds and chilly water limit casual swimming.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Sea surface temps climb to ~17–20°C (63–68°F) in July–August, tolerable for short dips but brisk outside midsummer.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Expect coastal cliffs, heather moors, and beech forests rather than dramatic mountains; national parks are accessible for weekend trips.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "There’s no statutory minimum wage; union agreements in tech hover near 110–130 DKK/hour, offering solid pay but relying on collective bargaining coverage.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers in Copenhagen commonly earn 550,000–700,000 DKK (€74k–94k) plus pension, which supports a family despite Denmark’s taxes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": ".NET is standard in fintech, government digitization, and logistics firms like Maersk, creating steady demand for experienced architects.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby shops exist around SaaS scaleups and agency work, but the ecosystem is smaller than .NET/Java, so roles may cluster in Copenhagen.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "The Positive List and fast-track schemes let accredited employers sponsor quickly, yet salary thresholds and documentation remain strict.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Denmark posts low unemployment (~3%), resilient GDP, and moderate inflation, signaling a stable economy for remote or local roles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Flex-working surged post-2020; fiber broadband, coworking hubs, and trust-based management make hybrid or remote schedules common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Flexicurity norms prioritize leaving by 16:00, respecting vacations, and protecting family time—ideal for Sarah’s lower-stress goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Collective agreements keep standard weeks near 37 hours with limited overtime, and employers expect you to actually use it.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Employees accrue five weeks of paid holiday under the Holiday Act plus up to 11 public holidays depending on region.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech firms often layer RTT days or flex Fridays on top of the statutory five weeks, so six weeks off isn’t unusual.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Copenhagen hums with bikes and cafés but lacks the frantic pace of US metros; Aarhus and Odense feel even calmer while staying urban.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run roughly 8:00–14:00 with SFO after-school clubs, while parents work 8:00–16:00 and enjoy communal dinners early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends lean toward kid sports, nature outings, and hygge gatherings; many shops close early Sunday, nudging intentional downtime.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Family-friendly design—pram lanes, play spaces, and safe cycling—makes daily routines smooth for young kids and parents alike.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Non-monogamy is legal and queer spaces are tolerant, yet there’s little formal recognition for multi-partner families and social norms remain monogamous.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Danish parenting is child-led with low homework loads and strong trust in kids’ autonomy, matching Trey and Sarah’s gentle approach.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Playgrounds, child-friendly cafés, and libraries abound; Copenhagen’s traffic-calmed streets let five-year-olds bike with supervision.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Folkeskole public schools are free and secular; international tracks exist in major cities but have waitlists and higher tuition.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Municipal vuggestue and børnehave spots are plentiful with play-based pedagogy; expect waitlists in central Copenhagen but subsidies keep costs moderate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Municipalities cap parent fees near 25% of actual cost, with low-income discounts and guaranteed places from age one.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once the family secures CPR numbers and municipal registration, they access the same daycare subsidies, though documentation is paperwork-heavy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens attend local folkeskole without tuition; project-based learning and strong student services suit creative kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident non-citizens enroll for free, but instruction is Danish with newcomer language classes—extra effort for English-speaking kids.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Private friskoler and international schools offer bilingual or IB tracks; fees are subsidized but still €3k–€8k annually per child.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Parents receive 52 weeks of paid leave to share plus monthly child benefits (~DKK 4,746 quarterly per young child).",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Temporary residents qualify for parental leave pay and child benefits after tax registration, though proof of residency and employment is scrutinized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Universities are tuition-free with generous SU stipends, keeping future costs minimal if kids naturalize or hold EU status.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students face tuition of €6k–€16k per year unless they gain permanent residency or scholarships via English-language programs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Workplace and household norms emphasize equality; paternity leave uptake and shared chores are socially expected.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal gender change is self-declared and trans health care is covered, yet non-binary recognition is still evolving socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Robust anti-discrimination laws, pay-transparency rules, and political representation make Denmark a leader in gender equity.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Casual, practical fashion dominates; women move confidently in public spaces and harassment rates are low by EU standards.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Danish men are expected to be nurturing—taking leave, cooking, and openly supporting egalitarian relationships.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Design-forward cities, hygge culture, and world-class cycling infrastructure create a cozy-yet-modern lifestyle.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Over 85% speak excellent English; government digital services and workplaces routinely accommodate English speakers while offering Danish classes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Social policies champion LGBTQ+ rights, reproductive freedom, and secular governance—aligned with a progressive household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Public discourse favors social-democratic pragmatism: strong welfare without revolutionary rhetoric, keeping debates moderate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Despite a state Lutheran church, weekly attendance is under 5%; secularism dominates schooling and politics.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education and open discussion of sexuality are standard, though public affection stays tasteful.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination protections, and Pride events across cities reflect high social acceptance.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Danes value privacy; joining associations or parent networks takes time, but once inside the communities are loyal and supportive.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "They see themselves as egalitarian, environmentally conscious, and humble—Janteloven discourages boasting.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Relations with fellow Nordics and Germany are cooperative, with friendly competition in design, energy, and sport.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors generally regard Danes as trustworthy social democrats with strong welfare and progressive politics.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Copenhagen and Aarhus host lively bars and music venues, yet high alcohol taxes and early train schedules keep nights moderate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Minimalist, well-tailored streetwear—think layers, cycling-friendly outerwear, and design brands like Norse Projects.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women favor effortless layers, sneakers with dresses, and sustainability-focused Danish labels.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Cycling, cold-water dips, handball, and communal dining clubs are popular ways to connect with neighbors.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Board game cafés (Bastard Café, byENS Værksted) and Nordic LARP traditions give tabletop fans plenty of venues.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Jazz, electronic, and indie scenes thrive in Copenhagen and Roskilde, though events skew expensive compared with US cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "TechBBQ, Unity meetups, parenting groups, and queer networks meet frequently—many operate in English but expect proactive outreach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Regional trains and ferries unlock forests, islands, and Sweden day trips within 1–2 hours, making nature weekends easy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A constitutional monarchy with proportional parliament ensures multi-party coalitions, independent courts, and civil liberties.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church and state are formally linked but clergy wield little power; policy debates stay secular.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "High union density secures dismissal protections, collective bargaining, and paid leave that apply equally to foreigners in covered sectors.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Policy blends market openness with redistributive welfare and strong co-ops—supportive for entrepreneurship with safety nets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Free media, active courts, and civic engagement keep risks low, though far-right parties periodically test migration policy boundaries.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Competitive markets and ease of doing business rank high, yet regulation and taxes stay heavier than US norms.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Political transitions are peaceful; currency is pegged to the euro; strikes are rare and negotiated.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters are independent and media literacy is emphasized; state messaging is transparent but not pushy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government campaigns focus on health, sustainability, and cohesion; little heavy-handed narrative-shaping.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Comprehensive anti-discrimination, reproductive rights, and LGBTQ+ protections align with the family’s progressive values.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show over 70% of Danes trust national institutions thanks to efficient digital services and responsive municipalities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International routinely ranks Denmark #1–2 for clean governance and robust oversight.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "When issues arise they’re typically policy favoritism or procurement scrutiny rather than petty bribes affecting residents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Copenhagen rents are high and vacancy under 1%; co-ops and long waitlists demand planning or settling in secondary cities.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime is rare; kids walk and bike independently, and community policing keeps neighborhoods calm.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Universal GP registration, hospital care, and maternity services are free; waits for elective specialists can stretch weeks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "After obtaining CPR numbers and NemID, residents access the same free GP system, though initial processing can delay specialist referrals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Municipal subsidies, capped fees, and abundant after-school clubs reduce childcare stress for dual-working parents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical families share year-long parental leave, monthly child allowances, and flexible work policies baked into employment contracts.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Public schools emphasize collaboration and STEM literacy; PISA scores are above OECD average with strong language support.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "S-tog trains, metro extensions, and frequent buses make car-free living feasible in major cities, though fares are high.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Flexicurity balances employer freedom with social safety nets, supporting entrepreneurship while guaranteeing benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Withholding and automatic annual settlements via TastSelv/NemKonto minimize bureaucracy—even for expats once NemID is set up.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual tech incomes would quickly hit 37–42% effective tax plus 8% labor market contributions, reducing take-home pay compared with the US.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "NemID/MitID access, MobilePay ubiquity, and fee-free bank transfers make finances seamless once residency is established.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Housing, groceries, and dining rank among Europe’s most expensive, pressuring budgets until salaries adjust.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Citizens accrue state pensions plus mandatory ATP and occupational schemes, providing solid old-age security.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Foreign workers pay into ATP and employer pensions; benefits are portable after leaving but require administrative follow-up.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Residence options include the Positive List, Pay Limit scheme, Startup Denmark, and EU Blue Card, each with salary or investment thresholds.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Danes are polite and curious about Americans, yet bureaucracy expects self-sufficiency and there’s limited hand-holding.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Initial work permits last up to four years with renewals tied to employment; permanent residency requires 8 years, Danish exams, and full-time work history.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization typically takes 9 years (or 8 with integration credits) plus language and civic tests—long for families seeking faster certainty.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and children obtain dependent permits with the right to work and attend school, provided income and housing requirements are met.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing runs 1–3 months; fees range DKK 3,000–4,000 per adult plus biometrics—manageable but not trivial.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Strict reporting on salary, address changes, and Danish lessons is enforced; missing requirements risks permit revocation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Since 2015 Denmark permits dual citizenship, letting the family retain US passports while naturalizing later.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Securing housing before arrival, registering for CPR, and waiting for MitID can take weeks—plan bridging funds and patience.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios in Copenhagen and Aarhus hire Unity/C# talent for mobile, VR, and indie titles, though the scene is smaller than Sweden’s.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "IO Interactive (Hitman), SYBO (Subway Surfers), Ghost Ship Games (Deep Rock Galactic), and Tactile Games anchor the ecosystem.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Nordic Game Jam, Copenhagen Game Collective, and Unity meetups offer collaborative spaces for prototyping and networking.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Startup Denmark grants founder visas and the Danish Film Institute and Nordic Game grants support prototypes, but salaries and rent raise burn rates.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "World-class digitization (NemID, e-Boks), nationwide fiber, and 5G networks keep daily life efficient for tech-heavy households.",
+      "alignmentValue": 9
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a comprehensive Denmark country report with alignment scoring across all categories
- register Denmark in the countries list so it appears in the UI

## Testing
- `jq empty reports/denmark_report.json`
- `jq empty main.json`


------
https://chatgpt.com/codex/tasks/task_e_68dc218cf4f483219c00e39680654dd4