### PR TITLE
Add Austria country report

### DIFF
--- a/main.json
+++ b/main.json
@@ -557,6 +557,10 @@
       "file": "reports/australia_report.json"
     },
     {
+      "name": "Austria",
+      "file": "reports/austria_report.json"
+    },
+    {
       "name": "Switzerland",
       "file": "reports/switzerland_report.json"
     },

--- a/reports/austria_report.json
+++ b/reports/austria_report.json
@@ -1,0 +1,540 @@
+{
+  "iso": "AT",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Austria pairs strict EU environmental rules with abundant alpine forests, lakes, and city green belts, giving an outdoorsy family clean air and walkable parks right in Vienna or Graz.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Alpine glaciers are shrinking and heatwaves have increased since 2018, yet Vienna sits inland with robust flood defenses, keeping near-term climate risk moderate compared with coastal countries.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Central European seasons mean mild springs and falls, warm (occasionally hot) summers, and winters that are cool and gray rather than brutally cold—still a step gentler than Kansas City swings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Most cities meet EU PM2.5 targets; inversions in alpine valleys bring winter wood-smoke spikes, but Vienna’s monitoring and low-emission zones keep routine exposure low for kids.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes and hurricanes are absent; the main hazards are alpine avalanches and Danube flooding, both managed with warning systems and infrastructure the family can plan around.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March–May days hover around 5–18°C (41–64°F) with light rain and increasing sun, comfortable for park time once you pack layers.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "June–August sees 15–27°C (59–81°F) highs with occasional 32°C (90°F) heatwaves; lakes and shaded streets offer relief but humid spikes are possible.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September–November typically runs 8–18°C (46–64°F) with crisp mornings, colorful vineyards, and some fog in valleys—good sweater weather.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "December–February averages −2 to 5°C (28–41°F); snow shows up but rarely piles above knee height in cities, though skies stay gray.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Landlocked Austria relies on alpine lakes and public lidos rather than oceans; summer swimming is scenic but limited to short seasons.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Lake water hits 20–25°C (68–77°F) in July–August but stays chilly the rest of the year, so swimming windows are brief.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "The Alps, Danube valleys, and UNESCO-protected national parks make weekend hikes, skiing, and lake trips easy for an outdoorsy family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "No statutory minimum wage exists, yet collective agreements set most tech salaries well above living wage levels, giving some security with a bureaucratic learning curve.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers in Vienna commonly earn €60–75k plus 13th/14th month pay—comfortable locally, though below US equivalents and requiring adjustment for high taxes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Banks, industrial firms, and consultancies keep steady demand for .NET talent, with Vienna and Linz hosting most openings and some remote-friendly teams.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles exist in startups and agencies but hiring volume is thin compared with Java/.NET, so Sarah may rely on remote contracts or language flexibility.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "The Red-White-Red Card lets employers sponsor skilled workers, yet quotas, German-language paperwork, and salary thresholds mean persistence is required.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Austria’s diversified economy keeps unemployment near 5% with strong manufacturing and services; inflation cooled after 2022 energy spikes, signaling resilience.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Post-pandemic Austria normalized hybrid weeks, and Vienna offers coworking hubs with solid broadband, though some firms still expect office presence.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Collective agreements limit overtime, lunch breaks are respected, and managers generally expect employees to log off—supportive of Sarah’s lower-stress goals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Standard contracts run 38.5 hours with overtime premium; crunch culture is rare outside peak project pushes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Employees receive at least 25 paid days plus about 13 public holidays, giving ample downtime for family travel.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Many tech firms grant 25–30 days and company-wide bridges around holidays, so extended US visits are feasible.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Vienna balances urban amenities with slower café culture and reliable transit, easing Sarah into a calmer rhythm than US metros.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Offices often run 8:30–17:00; primary schools end around 13:00 with optional afternoon Betreuung that needs booking, so logistics require planning.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends highlight parks, alpine day trips, and museums, but Sunday retail closures mean stocking up early and embracing leisure routines.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Austria scores high on safety, playground density, and parental leave norms, giving families predictable support networks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "While Vienna’s queer scene is tolerant, polyamory lacks legal recognition and remains niche socially, so openness depends on carefully chosen communities.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Parents are expected to engage closely with schools and extracurriculars, yet dual-earner households are common, offering flexibility once childcare is arranged.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Vienna’s traffic-calmed streets, pram-friendly transit, and public play spaces make day-to-day errands with young kids easier than most US cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public schools are free with growing bilingual tracks; international schools exist but come with tuition and waitlists.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Municipal Kita spots have expanded, yet demand still exceeds supply in popular districts, requiring early applications and backup plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive subsidized childcare fees and family allowances that offset costs for toddlers like Alasdair.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Non-EU residents can access municipal childcare once registered, but subsidies may hinge on residency duration and German documentation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Primary and secondary schooling is guaranteed, with free textbooks and special support for German learners.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children can enroll in public schools, yet integration classes and paperwork in German add administrative friction.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Catholic and international schools offer alternative tracks, but spaces are limited and tuition rivals US private rates.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Generous parental leave up to 24 months with income-sharing and monthly Familienbeihilfe strengthen the safety net for local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Red-White-Red card holders can claim many benefits after residence registration, though processing can be slow and documentation strict.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Public universities charge minimal fees and offer broad study options, making future tuition manageable for Trey and Sarah’s kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students pay higher—but still modest—fees (~€1,500 per semester) and must meet German or English proficiency requirements.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Austria promotes gender equality laws, yet part-time work among mothers remains common, reflecting moderately traditional expectations outside cities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal gender change is available and Vienna hosts visible queer events, though rural attitudes skew conservative, so acceptance varies.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "EU protections cover reproductive rights and workplace equality, but pay gaps and leadership imbalances persist.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Women are expected to present polished European style yet everyday fashion remains practical, with societal pressure lower than in southern Europe.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Men face modest expectations around breadwinning and understated style; emotional openness is improving but still lagging Nordic norms.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Coffeehouse culture, classical music institutions, and thriving indie art scenes give Trey and Sarah plenty to explore beyond work.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Urban Austrians speak solid English, yet bureaucracy, schools, and social integration expect German—making language study a must.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Vienna votes left-of-center and pushes LGBTQ+ inclusion, though national politics sees strong conservative blocs and a rising far-right FPÖ.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Social democracy shaped modern Austria, with trade unions influential and Marxist ideas debated academically but not dominant.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Roughly a quarter of residents report no religion, and practical secularism is common in cities despite Catholic heritage.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Sex education is comprehensive, but public attitudes remain more reserved than in Scandinavia, so open non-monogamy may stay discreet.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Same-sex marriage and anti-discrimination laws are in place, with Vienna Pride drawing large crowds, yet rural regions can feel cautious.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighborhood associations, co-housing projects, and parent groups foster community, though German fluency unlocks deeper connections.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Austrians prize cultural heritage and social order, often describing themselves as pragmatic, music-loving, and reserved with newcomers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Relations with EU neighbors are cordial, with active cross-border commuting and shared Alpine initiatives.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Austria as stable and cultured, yet sometimes insular, expecting outsiders to adapt to local norms quickly.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Vienna offers late-night bars, classical venues, and techno clubs, but closing times and Sunday quiet hours keep things calmer than Berlin.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart-casual European tailoring—dark jeans, blazers, quality footwear—is typical, so Trey can blend in with polished basics.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women favor minimalist chic with seasonal layers; practical outerwear for transit and alpine trips keeps expectations realistic for Sarah.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Skiing, hiking, cycling, and café meetups dominate leisure time, offering ready-made ways to meet locals with similar interests.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "German-speaking board-game culture is strong—Vienna hosts Spielbar cafés and clubs where Eurogames and RPGs are mainstream.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Classical halls, jazz clubs, and a modest but lively electronic scene give plenty of evening options without overwhelming crowds.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Meetup groups span tech, parenting, LGBTQ+, and international circles; proactive German learning accelerates belonging.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "From Vienna, trains reach alpine trails and Danube bike paths within an hour, satisfying the family’s hiking and outdoors goals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Austria is a federal parliamentary republic with proportional representation and independent courts, supporting democratic resilience.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Catholic heritage informs holidays, yet policymaking is largely secular with church influence limited to specific social debates.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Collective bargaining coverage near 98% secures paid leave, notice periods, and protections that suit the family’s desire for stability.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A social market model blends welfare with private enterprise, aligning reasonably with Trey’s preference for supportive yet innovative environments.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Democratic institutions are strong, but far-right gains and surveillance debates warrant attention for a family wary of authoritarian drift.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Markets operate within regulated frameworks, offering entrepreneurship support alongside higher taxes and compliance steps.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Austria enjoys low crime, predictable governance, and EU backing, making geopolitical and economic shocks relatively rare.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A public broadcaster and diverse press keep narratives plural, though tabloids like Kronen Zeitung can sensationalize politics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government messaging emphasizes social cohesion and neutrality; immigration rhetoric can swing hard during elections, so media literacy remains useful.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Strong welfare, health insurance, and subsidized housing coexist with tighter asylum policies, blending solidarity with cautious borders.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher than the US but dented by recent corruption probes, encouraging civic engagement and watchdog media.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Austria ranks well on Transparency International, yet party finance scandals surface periodically, signaling a need for ongoing vigilance.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "When corruption appears it often involves patronage in public contracts or party appointments rather than street-level bribery.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Vienna’s social housing keeps rents stable, but newcomers face deposit-heavy private leases and limited larger flats in trendy districts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Austria is one of Europe’s safest countries; violent crime is rare and public transit feels secure even at night.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Universal statutory insurance delivers quick access to family doctors and hospitals with modest co-pays and strong maternity care.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Once employed, non-EU residents join the same Krankenkasse system; private insurance may bridge initial waits but quality remains high.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Families receive monthly child allowances, tax credits, and subsidized daycare slots, though navigating benefits requires German paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Generous parental leave schemes and flexible part-time rights for parents fit the household’s desire for work-life balance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Austria delivers solid academic outcomes, strong vocational pathways, and free university, tempered by early tracking that may pressure younger students.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Nationwide rail, integrated city transit, and low-cost KlimaTickets make car-free living practical for the family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A regulated market economy couples private enterprise with strong public services, supporting entrepreneurial experiments with a safety net.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Progressive income taxes and mandatory social contributions fund benefits but require quarterly prepayments and local registration steps for newcomers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual professional incomes would land in the 35–45% bracket plus social insurance, a noticeable jump from Missouri’s effective rate.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Modern banking apps, SEPA transfers, and widespread contactless payments coexist with a lingering cash preference in small shops.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Vienna housing and groceries cost less than major US coasts but more than Kansas City; family budgets benefit from subsidized transit and healthcare.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Defined-benefit pensions and employer supplements keep elderly poverty low, backed by mandatory contributions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Non-citizens accrue pension rights after five years of contributions, yet portability to the US is limited without bilateral agreements.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Skilled workers can pursue the Red-White-Red Card or EU Blue Card with proof of qualifications, language basics, and salary thresholds.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Locals are polite toward Americans, but administrative offices expect German and strict adherence to rules, which can feel chilly.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Initial residence permits typically last two years with renewal pathways toward permanent residency after five years of continuous stay.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization generally requires 10 years, B1 German, and proof of integration, with limited exceptions for extraordinary contributions.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Dependents can be included on Red-White-Red cards if income and housing thresholds are met, ensuring the whole household stays together.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Permit processing can take 2–4 months and involves fees, apostilles, and in-person biometrics—manageable but paperwork-heavy.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Registration deadlines, health insurance proof, and income audits are enforced; missed steps risk fines or permit denial.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Austria rarely allows dual citizenship outside special cases, so naturalization would likely require renouncing the US passport.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Expect German integration courses, rental contract requirements for residency, and annual income reviews before upgrades to long-term permits.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "The local game industry is small but steady, with studios in Vienna, Salzburg, and Innsbruck hiring for Unity and Unreal roles.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like THQ Nordic (HQ), Mi'pu'mi Games, and rare indie successes (e.g., The Lion's Song) signal an ecosystem Trey could plug into.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Events such as Game Dev Days Graz and Coworking Salzburg foster mentorship and jams, helping Trey find collaborators.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Austria Wirtschaftsservice grants, EU Creative Europe funds, and Vienna Business Agency support give indie studios seed capital plus affordable coworking.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Transit, healthcare, and utilities are world-class, yet digital bureaucracy still trails the Nordics, requiring occasional in-person appointments.",
+      "alignmentValue": 7
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a comprehensive Austria country report with scores and context for every category in the migration dashboard
- register Austria in the country list so it can be selected in the UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df13804fb883218165539897d61eca