### PR TITLE
Align propaganda guidance with family values

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Perform the following loop for every `Key` (use the worksheet order to avoid ski
    - Reference the family’s needs (“polyamory-positive communities”, “quality public schools”, etc.).
    - Cite concrete factors or trade-offs. Mention sourcing context in plain language; add short Markdown links only when necessary.
    - Make it clear why the chosen score fits the guide (e.g., “Transit is efficient but rural gaps keep it at a 7 per the guide’s caution tier”).
+   - Keep the justification in plain language—describe the evidence and impact without name-checking the rating guide explicitly.
 5. **Document gaps.** If reliable data is missing, set `alignmentValue` to `0` and `alignmentText` to `""`. Call this out in your worksheet so a future pass can research it.
 
 ## 3. Apply Updates to the JSON

--- a/family_profile.json
+++ b/family_profile.json
@@ -102,7 +102,7 @@
     "quality_of_life_priority": "high",
     "climate_preference": "mild weather",
     "language_preference": "English ubiquity important; willing to learn local language",
-    "media_propoganda_interest": "wants to understand state narratives and intent",
+    "media_propoganda_interest": "curious about how political systems communicate but prefers daily life with pluralistic, independent media and minimal propaganda",
     "non_monogamy_acceptance_importance": "high (legal/social acceptance matters)",
     "pace_of_life": "prefer slower than typical US metro (esp. for Sarah)",
     "work_life_balance": "family‑friendly policies valued",

--- a/rating_guides.json
+++ b/rating_guides.json
@@ -3244,43 +3244,43 @@
     "ratingGuide": [
       {
         "rating": 10,
-        "guidance": "Independent media thrives; propaganda is minimal and easily challenged."
+        "guidance": "Pluralistic, independent outlets thrive; propaganda is rare and quickly challenged, supporting empathetic civic dialogue."
       },
       {
         "rating": 9,
-        "guidance": "Media landscape is mostly free; isolated propaganda attempts face scrutiny."
+        "guidance": "Media is broadly free with occasional spin that watchdogs or public broadcasters debunk before it shapes opinion."
       },
       {
         "rating": 8,
-        "guidance": "Occasional state messaging appears but diverse outlets provide balance."
+        "guidance": "Some state or corporate narratives emerge, but diverse outlets and history education keep facts centered."
       },
       {
         "rating": 7,
-        "guidance": "Propaganda surfaces during elections or crises; media literacy mitigates impact."
+        "guidance": "Election cycles or crises trigger noticeable propaganda, yet media literacy and alternative voices offer relief."
       },
       {
         "rating": 6,
-        "guidance": "Noticeable state narratives require cross-checking information."
+        "guidance": "Persistent state or concentrated private narratives require regular fact-checking to avoid bias."
       },
       {
         "rating": 5,
-        "guidance": "Propaganda is common; independent media struggles financially."
+        "guidance": "Propaganda is common; independent media struggles for reach while partisan or nationalist framing dominates headlines."
       },
       {
         "rating": 4,
-        "guidance": "State propaganda dominates prime channels; alternative voices move online."
+        "guidance": "State or oligarch-owned outlets control prime channels, pushing patriotic reframing and sidelining dissent."
       },
       {
         "rating": 3,
-        "guidance": "Propaganda saturates daily life; dissenting media faces censorship."
+        "guidance": "Propaganda saturates daily life, censoring empathy-focused narratives and intimidating alternative media."
       },
       {
         "rating": 2,
-        "guidance": "All major media repeat state narratives with little deviation."
+        "guidance": "All major media repeat orchestrated narratives; history is rewritten to serve regime or elite interests."
       },
       {
         "rating": 1,
-        "guidance": "Total propaganda environment; independent journalism is banned or imprisoned."
+        "guidance": "Total propaganda environment; independent journalism is banned, and messaging crowds every public and private space."
       }
     ]
   },
@@ -3289,43 +3289,43 @@
     "ratingGuide": [
       {
         "rating": 10,
-        "guidance": "Messaging, when present, promotes unity and civic engagement without distortions."
+        "guidance": "Public messaging centers shared wellbeing and accurate information without nationalist spin."
       },
       {
         "rating": 9,
-        "guidance": "State messaging is mild and fact-based, focusing on public service announcements."
+        "guidance": "Announcements are largely factual, spotlighting community care and inclusive civic participation."
       },
       {
         "rating": 8,
-        "guidance": "Narratives occasionally spin positive stories but remain largely truthful."
+        "guidance": "Narratives sometimes gloss over flaws but retain empathy and acknowledge multiple perspectives."
       },
       {
         "rating": 7,
-        "guidance": "Messaging pushes national pride with selective facts; critical thinking offsets bias."
+        "guidance": "Messaging leans on patriotic pride, yet counterpoints and honest data remain accessible."
       },
       {
         "rating": 6,
-        "guidance": "Propaganda frames rivals negatively and glosses over problems."
+        "guidance": "Propaganda frames rivals negatively, limiting nuance and encouraging conformity."
       },
       {
         "rating": 5,
-        "guidance": "Narratives become aggressive; dissent is labeled unpatriotic."
+        "guidance": "Narratives turn aggressive; dissent is labeled unpatriotic and empathy is sidelined."
       },
       {
         "rating": 4,
-        "guidance": "Propaganda rewrites history and targets minorities or foreigners."
+        "guidance": "Messaging rewrites history, targets marginalized groups, and rewards performative loyalty."
       },
       {
         "rating": 3,
-        "guidance": "Messaging is polarizing and manipulative, infiltrating schools and workplaces."
+        "guidance": "Propaganda dominates schools, workplaces, and leisure spaces, shaming alternative viewpoints."
       },
       {
         "rating": 2,
-        "guidance": "Propaganda includes disinformation campaigns to control public perception."
+        "guidance": "Narratives weaponize disinformation to control public perception and suppress compassion."
       },
       {
         "rating": 1,
-        "guidance": "Relentless personality cult or warlike propaganda dominates all communication channels."
+        "guidance": "Relentless personality cult or warlike propaganda overwhelms every channel, demanding constant praise."
       }
     ]
   },

--- a/reports/north_korea_report.json
+++ b/reports/north_korea_report.json
@@ -1,539 +1,540 @@
 {
+  "version": 2,
   "iso": "KP",
   "values": [
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "No private tech sector; programming jobs are state-assigned, leaving no path for .NET careers.",
+      "alignmentText": "For Trey's .NET career, North Korea's command economy assigns coders to state bureaus, leaving no private market or freedom to work remotely, so he'd have no viable job path.",
       "alignmentValue": 1
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Coal heating and outdated industry leave urban air dusty, a concern for our kids.",
+      "alignmentText": "Coal-fired heating, dust storms, and aging industry keep PM2.5 well above safe thresholds, leaving the boys' lungs exposed to the kind of pollution we try to avoid.",
       "alignmentValue": 2
     },
     {
       "key": "Atheism",
-      "alignmentText": "State atheism removes religious pressure but reflects oppressive control rather than pluralism.",
+      "alignmentText": "Although the regime is officially atheist, loyalty tests and punishment for dissent turn secularism into coercion, so our preference for freely chosen beliefs would be impossible.",
       "alignmentValue": 3
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Totalitarian rule eliminates civil liberties and risks our family values.",
+      "alignmentText": "A hereditary totalitarian state with no civil liberties directly violates our family's insistence on resilient democracies.",
       "alignmentValue": 1
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "Sanctions and state banks make cards useless; cash rationing dominates daily life.",
+      "alignmentText": "Sanctions and ration cards dominate commerce, and foreigners cannot rely on cards or modern payments, meaning daily transactions would be nearly impossible for us.",
       "alignmentValue": 1
     },
     {
       "key": "Beach Life",
-      "alignmentText": "Coastline exists but public beach access and amenities are nearly nonexistent.",
+      "alignmentText": "While the peninsula has coastline, militarization and lack of amenities mean our family would rarely reach a safe, pleasant beach.",
       "alignmentValue": 2
     },
     {
       "key": "Boardgaming & Tabletop",
-      "alignmentText": "Hobby markets are banned and gatherings monitored, stifling board-game communities.",
+      "alignmentText": "State surveillance and bans on unsanctioned gatherings erase the hobby scenes Trey and the kids love, leaving that community nonexistent.",
       "alignmentValue": 1
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "State-run nurseries exist but resources and autonomy are limited.",
+      "alignmentText": "Work units run nurseries with poor resources and heavy indoctrination, so even with nominal coverage we couldn't trust the care for the boys.",
       "alignmentValue": 2
     },
     {
       "key": "Child-Friendliness of Cities",
-      "alignmentText": "Urban infrastructure is crumbling and surveillance heavy, making cities unfriendly for kids.",
+      "alignmentText": "Crumbling infrastructure, blackouts, and constant surveillance make cities stressful for our boys instead of nurturing.",
       "alignmentValue": 1
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "Work units may provide childcare but quality is poor and indoctrination heavy.",
+      "alignmentText": "Citizen families get assigned childcare, but quality and autonomy are so poor that parents trade safety and enrichment for state monitoring.",
       "alignmentValue": 2
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Foreign families rarely reside here and receive no childcare support.",
+      "alignmentText": "Foreigners almost never live here long-term and would receive no childcare guarantees, leaving us without any support network.",
       "alignmentValue": 1
     },
     {
       "key": "Common Hobbies",
-      "alignmentText": "Few leisure activities are permitted, leaving little overlap with our interests.",
+      "alignmentText": "Recreational activities are dictated by propaganda, leaving no overlap with our geeky, creative interests.",
       "alignmentValue": 1
     },
     {
       "key": "Community Vibes",
-      "alignmentText": "Social life is dictated by the state; trust outside assigned groups is risky.",
+      "alignmentText": "Trust is enforced through informants, creating fearful, state-directed communities that are the opposite of the open networks we seek.",
       "alignmentValue": 1
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Minor infractions can lead to severe punishment under pervasive surveillance.",
+      "alignmentText": "Minor rule breaches can land families in labor camps, so the risk of severe punishment would hang over every routine decision.",
       "alignmentValue": 1
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Prices can be low but goods are scarce and often require bribes.",
+      "alignmentText": "Official prices seem low, but scarcity and bribes devour income, making everyday affordability wildly unstable.",
       "alignmentValue": 2
     },
     {
       "key": "Dual Citizenship Allowed",
-      "alignmentText": "Dual citizenship is not recognized by the regime.",
+      "alignmentText": "The regime does not recognize dual citizenship, so our family would lose U.S. protection with no recourse.",
       "alignmentValue": 1
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Sanctions and central planning keep the economy stagnant with little opportunity.",
+      "alignmentText": "Chronic sanctions, famine risk, and negligible growth leave the economy stagnant and offer no prospects for entrepreneurs like us.",
       "alignmentValue": 1
     },
     {
       "key": "Economic System",
-      "alignmentText": "A strict command economy leaves no room for market entrepreneurship.",
+      "alignmentText": "A rigid command economy eliminates private enterprise, blocking any path to prosperity or independent work.",
       "alignmentValue": 1
     },
     {
       "key": "Education",
-      "alignmentText": "Schools focus on ideology with limited resources and poor global outcomes.",
+      "alignmentText": "Schools emphasize ideology over learning, and materials are outdated, so our kids would miss the critical thinking and resources they need.",
       "alignmentValue": 2
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Foreign employment is nearly impossible; there is no sponsorship channel.",
+      "alignmentText": "No private employers can sponsor foreigners, shutting down any legitimate way to live and work here.",
       "alignmentValue": 1
     },
     {
       "key": "Environment",
-      "alignmentText": "Deforestation and pollution outweigh limited scenic areas.",
+      "alignmentText": "Deforestation, pollution, and limited conservation leave few healthy outdoor spaces for family time.",
       "alignmentValue": 2
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "Income for foreigners is uncommon and tax rules are opaque and arbitrary.",
+      "alignmentText": "Income rules are arbitrary and foreigners' pay is seized or rationed, so we could not rely on transparent taxation or even access to earnings.",
       "alignmentValue": 1
     },
     {
       "key": "Fall Temperature Range (C/F)",
-      "alignmentText": "Autumn runs about 5–20°C (41–68°F), crisp but data is limited.",
+      "alignmentText": "Autumn swings between chilly winds and mild afternoons (roughly 5–20°C/41–68°F), forcing constant wardrobe changes that complicate the boys' routines.",
       "alignmentValue": 3
     },
     {
       "key": "Family Life",
-      "alignmentText": "State dictates family roles and discourages alternative relationship structures.",
+      "alignmentText": "State dictates roles and punishes nonconformity, the opposite of the supportive family culture we need.",
       "alignmentValue": 1
     },
     {
       "key": "Family Members",
-      "alignmentText": "Bringing dependents is discouraged; foreign families are rare.",
+      "alignmentText": "Collective punishment can target entire families for one person's misstep, so safety for loved ones is never assured.",
       "alignmentValue": 1
     },
     {
       "key": "Family Policy (Citizens)",
-      "alignmentText": "Pro-natalist benefits exist but depend on political loyalty.",
+      "alignmentText": "While pronatalist benefits exist, they come with surveillance and ideological requirements, turning support into coercion.",
       "alignmentValue": 2
     },
     {
       "key": "Family Policy (Common Family)",
-      "alignmentText": "Policies support only state-approved nuclear families.",
+      "alignmentText": "A 'normal' family is defined rigidly as hetero and obedient, leaving no room for our polyamory-positive values.",
       "alignmentValue": 1
     },
     {
       "key": "Family Policy (Visa Holders)",
-      "alignmentText": "Foreign families receive no meaningful support or recognition.",
+      "alignmentText": "Foreign families seldom gain residency and face constant oversight, so policies effectively exclude outsiders like us.",
       "alignmentValue": 1
     },
     {
       "key": "Fashion Trends (Female)",
-      "alignmentText": "Conservative, state-approved dress leaves little room for expression.",
+      "alignmentText": "Women must follow state-issued styles and badges, smothering Sarah's personal expression.",
       "alignmentValue": 1
     },
     {
       "key": "Fashion Trends (Male)",
-      "alignmentText": "Uniform styles are expected, curbing personal style.",
+      "alignmentText": "Men are expected to wear approved haircuts and uniforms, erasing Trey's ability to present himself authentically.",
       "alignmentValue": 1
     },
     {
       "key": "Femininity Norms",
-      "alignmentText": "Traditional roles are enforced, limiting gender expression.",
+      "alignmentText": "Femininity is tied to obedience and motherhood under surveillance, far from Sarah's need for autonomy.",
       "alignmentValue": 1
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "There is no commercial game industry or indie scene.",
+      "alignmentText": "No independent studios exist, so Trey cannot build or join a game dev community.",
       "alignmentValue": 1
     },
     {
       "key": "Gender Fluidity",
-      "alignmentText": "Gender nonconformity is repressed by law and custom.",
+      "alignmentText": "Gender variance is criminalized and policed, making safety and acceptance impossible for gender-diverse friends or family.",
       "alignmentValue": 1
     },
     {
       "key": "Gender Rights",
-      "alignmentText": "Women have nominal equality but face strict expectations and limited rights.",
+      "alignmentText": "Women work and serve in the military but lack autonomy; forced loyalty keeps rights shallow and unreliable.",
       "alignmentValue": 2
     },
     {
       "key": "Gender Roles",
-      "alignmentText": "Rigid patriarchal roles dominate daily life.",
+      "alignmentText": "Roles are centrally assigned, and deviation is punished, leaving no flexibility for our household.",
       "alignmentValue": 1
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Foreigners face constant monitoring and severe movement restrictions.",
+      "alignmentText": "Foreigners live under escorts, restricted internet, and exit controls, so daily life would be untenable.",
       "alignmentValue": 1
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Floods and droughts may intensify, and infrastructure is ill-prepared.",
+      "alignmentText": "The peninsula faces worsening droughts, floods, and crop failures, so climate change is already disrupting basic safety nets.",
       "alignmentValue": 3
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal in name but medicine and equipment shortages are common.",
+      "alignmentText": "Hospitals lack medicine and power, so families rely on informal markets and still struggle to find reliable care.",
       "alignmentValue": 2
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Foreigners rely on limited clinics with minimal capabilities.",
+      "alignmentText": "Foreigners must use under-equipped clinics under surveillance, leaving us without safe medical support.",
       "alignmentValue": 1
     },
     {
       "key": "Higher Education Access (Citizens)",
-      "alignmentText": "University access hinges on political loyalty rather than merit.",
+      "alignmentText": "University slots depend on loyalty and songbun status, so merit and academic quality are routinely compromised.",
       "alignmentValue": 2
     },
     {
       "key": "Higher Education Access (Visa Holders)",
-      "alignmentText": "Foreign students are rarely admitted outside propaganda programs.",
+      "alignmentText": "Foreign students rarely enroll and face tight controls, making real higher education access practically impossible.",
       "alignmentValue": 1
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Housing is allocated by work units, often cramped and poorly maintained.",
+      "alignmentText": "Apartments are allocated by the state, often without heat or maintenance, so housing would be unreliable and uncomfortable.",
       "alignmentValue": 2
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "Personal taxes are opaque; the state extracts resources through work units.",
+      "alignmentText": "Taxes and 'patriotic donations' are arbitrary with no digital tools, turning compliance into a punitive guessing game.",
       "alignmentValue": 1
     },
     {
       "key": "K-12 Education Access (Citizens)",
-      "alignmentText": "State schools exist nationwide but are heavily indoctrinating.",
+      "alignmentText": "Schooling is universal but under-resourced and indoctrinating, so our kids would receive little actual education.",
       "alignmentValue": 2
     },
     {
       "key": "K-12 Education Access (Visa Holders)",
-      "alignmentText": "No international schools for outsiders; enrollment is exceptional.",
+      "alignmentText": "Foreign kids cannot attend regular schools and only receive monitored tutoring, which keeps them isolated and under watch.",
       "alignmentValue": 1
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Homosexuality is unacknowledged and severely repressed.",
+      "alignmentText": "Queer identities are denied by the state, making life unsafe for our polyamory-positive, LGBTQ+-affirming household.",
       "alignmentValue": 1
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "English is rarely spoken; Korean is mandatory everywhere.",
+      "alignmentText": "English is tightly controlled and interpreters are state-provided, so we would lack autonomy in even basic communication.",
       "alignmentValue": 1
     },
     {
       "key": "Marxism (Societal Attitudes)",
-      "alignmentText": "Juche draws from Marxism-Leninism but is enforced dogma rather than open discourse.",
+      "alignmentText": "The population must publicly embrace Juche-Marxist rhetoric regardless of private belief, so coerced ideology shapes every interaction.",
       "alignmentValue": 2
     },
     {
       "key": "Masculinity Norms",
-      "alignmentText": "Militaristic culture prizes traditional masculinity and conformity.",
+      "alignmentText": "Masculinity equates to military obedience, which conflicts with Trey's creative identity and emotional style.",
       "alignmentValue": 1
     },
     {
       "key": "Meetups & Communities",
-      "alignmentText": "Unauthorized gatherings are prohibited, hindering any community events.",
+      "alignmentText": "Unofficial gatherings risk arrest, leaving no safe space for the open-source or parenting meetups we rely on.",
       "alignmentValue": 1
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "State wages are symbolic and inadequate for family needs.",
+      "alignmentText": "Wages are symbolic and distributed through rationing, so pay protections mean nothing in practice.",
       "alignmentValue": 1
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "Infrastructure is antiquated with frequent power and service outages.",
+      "alignmentText": "Power outages, limited broadband, and outdated transport keep infrastructure failing when we'd need stability for remote work and schooling.",
       "alignmentValue": 1
     },
     {
       "key": "Natural Beauty",
-      "alignmentText": "Mountain landscapes and rivers are scenic yet largely inaccessible.",
+      "alignmentText": "The mountains and coasts are scenic, yet travel permits and limited maintenance restrict access, so the landscapes are hard to enjoy.",
       "alignmentValue": 4
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Typhoons and floods regularly cause damage due to poor mitigation.",
+      "alignmentText": "Floods and typhoons regularly overwhelm infrastructure, turning disasters into routine disruptions.",
       "alignmentValue": 3
     },
     {
       "key": "Nature Access",
-      "alignmentText": "Travel restrictions make it hard to reach natural areas.",
+      "alignmentText": "Even hikes require escorts and permits, so our outdoorsy family would struggle to reach nature on our own terms.",
       "alignmentValue": 2
     },
     {
       "key": "Nightlife & Music",
-      "alignmentText": "Entertainment is state-run and lacks diversity or spontaneity.",
+      "alignmentText": "Entertainment is propaganda-focused, leaving no authentic nightlife for adults to unwind.",
       "alignmentValue": 1
     },
     {
       "key": "Nightlife Culture",
-      "alignmentText": "Curfews and surveillance prevent normal nightlife.",
+      "alignmentText": "Curfews and surveillance suppress evening social life entirely, so there is no casual night culture to join.",
       "alignmentValue": 1
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "No known game development communities operate openly.",
+      "alignmentText": "There are no independent dev meetups or studios to learn from, so Trey would lose vital peer networks.",
       "alignmentValue": 1
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Only small propaganda studios exist; none suit indie goals.",
+      "alignmentText": "Only state propaganda studios exist, providing no career or mentorship for Trey.",
       "alignmentValue": 1
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Private startups are forbidden under the command economy.",
+      "alignmentText": "Private startups are illegal, so launching an indie studio would be impossible.",
       "alignmentValue": 1
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Rationing slows daily life but surveillance keeps stress high.",
+      "alignmentText": "Daily routines are rigid and punctuated by mandatory meetings, so even quiet streets feel stressful for Sarah.",
       "alignmentValue": 2
     },
     {
       "key": "Parenting Expectations",
-      "alignmentText": "Parents are expected to raise loyal citizens under heavy state oversight.",
+      "alignmentText": "Parents must enforce ideology and collective rituals, which clashes with the values we want to model for the boys.",
       "alignmentValue": 1
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Naturalization is virtually impossible for foreigners.",
+      "alignmentText": "Naturalization is effectively impossible for foreigners, keeping the door closed to permanent status.",
       "alignmentValue": 1
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Bribery is commonplace despite official denials.",
+      "alignmentText": "Every service requires bribes or loyalty, so corruption would dominate day-to-day life.",
       "alignmentValue": 1
     },
     {
       "key": "Political System",
-      "alignmentText": "A hereditary one-party state offers no democratic participation.",
+      "alignmentText": "A one-party dictatorship with dynastic leadership leaves no room for the democratic norms we require.",
       "alignmentValue": 1
     },
     {
       "key": "Polyamory",
-      "alignmentText": "Non-monogamous relationships are illegal and harshly punished.",
+      "alignmentText": "Polyamorous relationships are unthinkable and dangerous, contradicting our family's openness.",
       "alignmentValue": 1
     },
     {
       "key": "Pre-K / Early Childcare Landscape",
-      "alignmentText": "State nurseries provide care but are underfunded and ideological.",
+      "alignmentText": "State nurseries provide coverage but prioritize indoctrination over enrichment, so we'd worry about what the boys are taught.",
       "alignmentValue": 2
     },
     {
       "key": "Private Education",
-      "alignmentText": "Private schools are banned outright.",
+      "alignmentText": "Private schools are banned, leaving no alternative to ideological classrooms.",
       "alignmentValue": 1
     },
     {
       "key": "Progressivism",
-      "alignmentText": "The regime promotes ultraconservative nationalism, not progressive values.",
+      "alignmentText": "Progressive civil society does not exist; politics revolves around loyalty, so our values would have no outlet.",
       "alignmentValue": 1
     },
     {
       "key": "Propaganda Messaging",
-      "alignmentText": "The state saturates all media with propaganda, giving rich material to study.",
-      "alignmentValue": 10
+      "alignmentText": "Every broadcast, poster, and classroom lecture glorifies the Kim family and war readiness, crushing the empathetic, humanity-first narratives we value.",
+      "alignmentValue": 1
     },
     {
       "key": "Propaganda Prevalence",
-      "alignmentText": "Propaganda is ubiquitous in schools, workplaces, and public spaces.",
-      "alignmentValue": 10
+      "alignmentText": "State networks monopolize information, from neighborhood speakers to party newspapers, leaving zero room for independent or compassionate perspectives.",
+      "alignmentValue": 1
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Pyongyang has a metro but travel elsewhere is tightly restricted.",
+      "alignmentText": "Pyongyang's metro and buses reach few areas, and foreigners are restricted, leaving us with minimal usable transit.",
       "alignmentValue": 2
     },
     {
       "key": "Religion in Politics",
-      "alignmentText": "Religion is absent but replaced with ideological cults, not secular pluralism.",
+      "alignmentText": "Religion is suppressed yet replaced by quasi-spiritual loyalty to the Kim family, so ideology still intrudes on civic life.",
       "alignmentValue": 2
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Open internet and remote work are forbidden.",
+      "alignmentText": "Internet access is locked behind state intranets, making remote work impossible for Trey or Sarah.",
       "alignmentValue": 1
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Only short, highly controlled visas are available.",
+      "alignmentText": "Only tightly controlled short stays are allowed, so long-term residency plans collapse immediately.",
       "alignmentValue": 1
     },
     {
       "key": "Retirement (Citizens)",
-      "alignmentText": "State pensions exist but are small and unreliable.",
+      "alignmentText": "Elders rely on rationing and family support with little healthcare, keeping retirement insecure.",
       "alignmentValue": 2
     },
     {
       "key": "Retirement (Visa Holders)",
-      "alignmentText": "No pathways exist for foreign retirees.",
+      "alignmentText": "Foreign retirees are not permitted, leaving us no path to age in place here.",
       "alignmentValue": 1
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "No market for Ruby developers or modern software roles.",
+      "alignmentText": "There is no Ruby ecosystem or open internet, so Sarah would have no way to practice her craft.",
       "alignmentValue": 1
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Street crime is low, but political risk and arbitrary detention are high.",
+      "alignmentText": "Street crime is low, but arbitrary detention keeps us uneasy because state threats replace criminal risk.",
       "alignmentValue": 3
     },
     {
       "key": "Schooling Options",
-      "alignmentText": "Only state-run schools with propaganda are available.",
+      "alignmentText": "We would have no school choice beyond ideological classrooms, eliminating any alternative for the boys.",
       "alignmentValue": 1
     },
     {
       "key": "Seasonal Beach Water Temp",
-      "alignmentText": "Coastal waters are cool much of the year and facilities are minimal.",
+      "alignmentText": "Cold currents keep water chilly outside brief summer weeks, so family beach trips would rarely be comfortable.",
       "alignmentValue": 2
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "Hot humid summers and freezing winters clash with our mild-climate preference.",
+      "alignmentText": "Harsh winters, muggy monsoons, and dusty springs mean constant adaptation that would wear us down.",
       "alignmentValue": 3
     },
     {
       "key": "Sex (Attitudes)",
-      "alignmentText": "Sex outside marriage is taboo and heavily censored.",
+      "alignmentText": "Sex education is censored and premarital sex punished, creating a repressive environment for healthy conversations.",
       "alignmentValue": 1
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Policies prioritize regime control over personal freedoms.",
+      "alignmentText": "Policy is designed to control citizens rather than expand rights, so reforms never aim to improve personal freedom.",
       "alignmentValue": 1
     },
     {
       "key": "Spring Temperature Range (C/F)",
-      "alignmentText": "5–17°C (41–63°F) with frequent dust storms from China.",
+      "alignmentText": "Dust storms and swings between chilly mornings and mild afternoons (5–17°C/41–63°F) demand constant adjustments our family would struggle with.",
       "alignmentValue": 3
     },
     {
       "key": "Stability",
-      "alignmentText": "The regime is rigid but economic shocks and isolation create uncertainty.",
+      "alignmentText": "The regime appears stable, but sanctions and famine risk create persistent volatility we couldn't plan around.",
       "alignmentValue": 2
     },
     {
       "key": "State Ideology",
-      "alignmentText": "Juche ideology demands absolute loyalty, conflicting with our values.",
+      "alignmentText": "Juche doctrine requires absolute devotion, contradicting our pluralistic values.",
       "alignmentValue": 1
     },
     {
       "key": "State of Capitalism",
-      "alignmentText": "Markets operate only informally; capitalism is effectively banned.",
+      "alignmentText": "Only black markets operate quietly; formal capitalism is banned, so we'd rely on risky informal trade for basics.",
       "alignmentValue": 1
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "23–30°C (73–86°F) with heavy monsoon humidity.",
+      "alignmentText": "Humid monsoon highs near 30°C/86°F with little relief, plus power shortages, make summers oppressive for the whole household.",
       "alignmentValue": 2
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Visa processes are opaque, expensive, and slow with few approvals.",
+      "alignmentText": "Visa processes are opaque, expensive, and often denied, so we'd burn time and money for paperwork that rarely succeeds.",
       "alignmentValue": 1
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Public trust is coerced; dissent is dangerous.",
+      "alignmentText": "Citizens must feign trust to avoid punishment, so genuine trust and accountability are nonexistent.",
       "alignmentValue": 1
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Petty bribery and elite graft are common just to access basics.",
+      "alignmentText": "Petty bribes and elite graft permeate every service, meaning corruption shapes every transaction.",
       "alignmentValue": 1
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Salaries are symbolic and insufficient for supporting a family.",
+      "alignmentText": "Programmers earn ration coupons, not market wages, leaving tech workers without sustainable income.",
       "alignmentValue": 1
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Weekends include mandatory community labor and propaganda events.",
+      "alignmentText": "Weekends require propaganda events and community labor, leaving no family downtime.",
       "alignmentValue": 1
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "Long workdays plus political meetings leave little family time.",
+      "alignmentText": "Mandatory overtime and political meetings erase evenings, crushing family time.",
       "alignmentValue": 1
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Official leave is minimal and at the discretion of the work unit.",
+      "alignmentText": "Leave is nominal and controlled by work units, so vacations exist only on paper.",
       "alignmentValue": 1
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Even when granted, travel options are heavily restricted.",
+      "alignmentText": "Even approved leave comes with travel bans and reporting, making true rest impossible.",
       "alignmentValue": 1
     },
     {
       "key": "View of Neighboring Countries",
-      "alignmentText": "State media portrays neighbors as hostile enemies.",
+      "alignmentText": "State media vilifies neighbors, encouraging hostility that conflicts with our desire for regional openness.",
       "alignmentValue": 1
     },
     {
       "key": "View of Them by Neighboring Countries",
-      "alignmentText": "Neighboring states view the regime with suspicion and concern.",
+      "alignmentText": "Neighbors view the regime with suspicion and sanction it, so regional relationships stay strained.",
       "alignmentValue": 1
     },
     {
       "key": "View of self",
-      "alignmentText": "Propaganda promotes self-reliance and superiority, discouraging openness.",
+      "alignmentText": "Propaganda elevates self-reliance myths and discourages humility, fostering an insular national self-image.",
       "alignmentValue": 1
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Only short tourist visas exist; no immigration pathways.",
+      "alignmentText": "Only brief, escorted visits are possible, leaving no workable immigration pathway.",
       "alignmentValue": 1
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Americans are rarely admitted and tightly controlled.",
+      "alignmentText": "Americans are rarely admitted and heavily surveilled, so we'd be treated as suspects, not neighbors.",
       "alignmentValue": 1
     },
     {
       "key": "What Is Intriguing",
-      "alignmentText": "The closed system offers unique study in propaganda but little else appealing for family life.",
+      "alignmentText": "The media environment offers research value for understanding propaganda, but nearly every practical aspect of life fails our family's priorities, so we cap intrigue at a cautious 2.",
       "alignmentValue": 2
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "-13–3°C (8–37°F) with biting winds beyond our comfort.",
+      "alignmentText": "Winters plunge to -13°C/8°F with biting winds and limited heating, making the cold harsh beyond our comfort.",
       "alignmentValue": 2
     },
     {
       "key": "Work Week Hours",
-      "alignmentText": "Workers face long hours plus ideological sessions.",
+      "alignmentText": "Long hours plus mandatory sessions keep workweeks exhausting with no flexibility.",
       "alignmentValue": 1
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "State demands override personal and family time.",
+      "alignmentText": "State demands override family autonomy, leaving Sarah without the balance she needs.",
       "alignmentValue": 1
     },
     {
       "key": "Workers' Rights",
-      "alignmentText": "No independent unions; forced labor and punishments are common.",
+      "alignmentText": "Forced labor, no unions, and collective punishment strip workers of any real protections.",
       "alignmentValue": 1
     }
   ]


### PR DESCRIPTION
## Summary
- clarify the family profile to stress a preference for pluralistic, low-propaganda media environments
- revise the propaganda prevalence and messaging rating guides to highlight empathy-focused narratives and warn about concentrated spin
- downgrade North Korea's propaganda scores and rewrite the rationale to reflect the family's intolerance for pervasive propaganda

## Testing
- python -m json.tool family_profile.json
- python -m json.tool rating_guides.json
- python -m json.tool reports/north_korea_report.json

------
https://chatgpt.com/codex/tasks/task_e_68e2ea04500c83219c03e6e4c4dd1687