### PR TITLE
Refresh Denmark report to version 2 with family-specific context

### DIFF
--- a/reports/denmark_report.json
+++ b/reports/denmark_report.json
@@ -1,539 +1,540 @@
 {
+  "version": 2,
   "iso": "DK",
   "values": [
     {
       "key": "Environment",
-      "alignmentText": "Denmark’s compact size mixes farmland with well-managed green belts, blue-flag beaches, and aggressive climate policy that keeps everyday environmental quality high for families who bike and walk.",
-      "alignmentValue": 8
+      "alignmentText": "Denmark’s compact size mixes farmland with well-managed green belts, blue-flag beaches, and aggressive climate policy that keeps everyday environmental quality high for families who bike and walk. For the Kansas City family, the protected coastlines, urban green belts, and easy bike access keep everyday nature plans effortless, which aligns with the guide's 9-tier description of only minor localized impacts.",
+      "alignmentValue": 9
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Low-lying coasts face sea-level rise and storm-surge exposure, yet national dike upgrades and coastal retreat plans reduce near-term risk for settled areas.",
+      "alignmentText": "Low-lying coasts face sea-level rise and storm-surge exposure, yet national dike upgrades and coastal retreat plans reduce near-term risk for settled areas. That still fits a 6 because rising seas mean constant monitoring for coastal housing, so the family would plan inland neighborhoods even though national flood schemes are strong.",
       "alignmentValue": 6
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "A temperate maritime climate brings mild but breezy seasons—plenty of clouds and drizzle, yet few temperature extremes compared with the US Midwest.",
+      "alignmentText": "A temperate maritime climate brings mild but breezy seasons—plenty of clouds and drizzle, yet few temperature extremes compared with the US Midwest. For this Kansas City family, that steady 6-tier weather means investing in rain gear but escaping the harsher swings they know from home.",
       "alignmentValue": 6
     },
     {
       "key": "Air Quality",
-      "alignmentText": "EU air-quality targets are usually met; traffic and agricultural ammonia cause periodic PM spikes but coastal winds clear pollution quickly.",
+      "alignmentText": "EU air-quality targets are usually met; traffic and agricultural ammonia cause periodic PM spikes but coastal winds clear pollution quickly. That lands at an 8 because clean-air norms support lots of biking with the kids while the family simply watches for short ammonia spikes near farmland.",
       "alignmentValue": 8
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "No earthquakes or tropical storms; the main hazards are North Sea windstorms and localized flooding, both mitigated by strong building codes and alerts.",
+      "alignmentText": "No earthquakes or tropical storms; the main hazards are North Sea windstorms and localized flooding, both mitigated by strong building codes and alerts. A progressive family prioritizing stability can live with the occasional North Sea storm, which keeps this safely in the 8 band of low but present risk.",
       "alignmentValue": 8
     },
     {
       "key": "Spring Temperature Range (C/F)",
-      "alignmentText": "March–May days typically run 5–15°C (41–59°F) with lengthening daylight and occasional showers—light jackets still needed.",
+      "alignmentText": "Spring arrives slowly with highs in the 50s°F and lingering North Sea winds. The family can enjoy biking with light jackets, yet the cool drizzle keeps this in the 7 range instead of a truly mild spring.",
       "alignmentValue": 7
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "June–August highs hover around 20–23°C (68–73°F); humidity is moderate and evenings stay cool enough for comfortable sleep.",
+      "alignmentText": "June–August highs hover around 20–23°C (68–73°F); humidity is moderate and evenings stay cool enough for comfortable sleep. Highs in the low 70s°F with long daylight give the family mild summers ideal for park days, aligning with an 8 where heat is rarely a limiting factor.",
       "alignmentValue": 8
     },
     {
       "key": "Fall Temperature Range (C/F)",
-      "alignmentText": "September–November cools to roughly 8–15°C (46–59°F) with frequent rain and rising winds, which can feel chilly on bikes.",
+      "alignmentText": "September–November cools to roughly 8–15°C (46–59°F) with frequent rain and rising winds, which can feel chilly on bikes. Autumn cools quickly into the 40s°F with gray skies, so the family trades vibrant foliage for drizzle, a balanced 6-tier experience.",
       "alignmentValue": 6
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "December–February averages around −1 to 5°C (30–41°F); snow is light but damp cold and short daylight can weigh on mood.",
+      "alignmentText": "Winters hover near freezing with damp winds that feel colder than Kansas City’s dry snaps. The family will bundle up for the 5-tier chill even if heavy snow is rare, so playground time shifts indoors.",
       "alignmentValue": 5
     },
     {
       "key": "Beach Life",
-      "alignmentText": "Hundreds of public beaches rim the Baltic and North Sea; clean facilities and dunes are family-friendly though winds and chilly water limit casual swimming.",
+      "alignmentText": "Hundreds of public beaches rim the Baltic and North Sea; clean facilities and dunes are family-friendly though winds and chilly water limit casual swimming. Weekend trips to Jutland beaches are fun but chilly most of the year, so the family gets reliable amenities without the warm-water ease that would push this higher than a 6.",
       "alignmentValue": 6
     },
     {
       "key": "Seasonal Beach Water Temp",
-      "alignmentText": "Sea surface temps climb to ~17–20°C (63–68°F) in July–August, tolerable for short dips but brisk outside midsummer.",
+      "alignmentText": "Water temperatures barely break 64°F even in August, meaning only quick dips for the kids. The family gets beach walks rather than long swims, exactly what the 4-tier guidance warns about.",
       "alignmentValue": 4
     },
     {
       "key": "Natural Beauty",
-      "alignmentText": "Expect coastal cliffs, heather moors, and beech forests rather than dramatic mountains; national parks are accessible for weekend trips.",
+      "alignmentText": "Expect coastal cliffs, heather moors, and beech forests rather than dramatic mountains; national parks are accessible for weekend trips. The family can hop trains to forests, dunes, and coastal national parks, yet dramatic mountains are absent, so this stays at a solid-but-not-spectacular 6.",
       "alignmentValue": 6
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "There’s no statutory minimum wage; union agreements in tech hover near 110–130 DKK/hour, offering solid pay but relying on collective bargaining coverage.",
+      "alignmentText": "There’s no statutory minimum wage; union agreements in tech hover near 110–130 DKK/hour, offering solid pay but relying on collective bargaining coverage. Sectoral bargaining delivers decent floors, but without a statutory minimum the family would need union coverage, aligning with the guide's mid-tier 5.",
       "alignmentValue": 5
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Senior developers in Copenhagen commonly earn 550,000–700,000 DKK (€74k–94k) plus pension, which supports a family despite Denmark’s taxes.",
+      "alignmentText": "Senior developers in Copenhagen commonly earn 550,000–700,000 DKK (€74k–94k) plus pension, which supports a family despite Denmark’s taxes. Senior developers clear salaries that support Denmark’s high taxes while offering stability for Trey and Sarah, fitting the 7 tier for strong but not top-paying markets.",
       "alignmentValue": 7
     },
     {
       "key": ".NET Work Prospects",
-      "alignmentText": ".NET is standard in fintech, government digitization, and logistics firms like Maersk, creating steady demand for experienced architects.",
+      "alignmentText": "Copenhagen and Aarhus host banks, public agencies, and consultancies hungry for .NET talent. That depth keeps Trey’s job hunt comfortable and justifies the 7 score the family can count on.",
       "alignmentValue": 7
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Ruby shops exist around SaaS scaleups and agency work, but the ecosystem is smaller than .NET/Java, so roles may cluster in Copenhagen.",
+      "alignmentText": "Ruby roles exist in product companies but remain niche compared with Java and .NET. Sarah can find options if she networks through meetups, yet the family treats it as a mid-tier 5 market.",
       "alignmentValue": 5
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "The Positive List and fast-track schemes let accredited employers sponsor quickly, yet salary thresholds and documentation remain strict.",
+      "alignmentText": "The Fast-track and Pay Limit schemes work well for tech professionals, yet they expect high salaries and paperwork. The family can navigate the process with employer help, which is why this stays a 6-tier support.",
       "alignmentValue": 6
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Denmark posts low unemployment (~3%), resilient GDP, and moderate inflation, signaling a stable economy for remote or local roles.",
+      "alignmentText": "Denmark posts low unemployment (~3%), resilient GDP, and moderate inflation, signaling a stable economy for remote or local roles. Low unemployment and balanced inflation give the family confidence in long-term plans, but slower GDP growth than Nordic peers keeps this in the 7 range.",
       "alignmentValue": 7
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Flex-working surged post-2020; fiber broadband, coworking hubs, and trust-based management make hybrid or remote schedules common.",
+      "alignmentText": "Hybrid schedules are normalized and co-working hubs abound. That lets the family balance US time zones and local collaboration, fitting the 8 rating for remote-friendly culture.",
       "alignmentValue": 8
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Flexicurity norms prioritize leaving by 16:00, respecting vacations, and protecting family time—ideal for Sarah’s lower-stress goals.",
+      "alignmentText": "Flexicurity norms prioritize leaving by 16:00, respecting vacations, and protecting family time—ideal for Sarah’s lower-stress goals. Protective labor laws and cultural respect for leaving early for childcare give Sarah the calm schedule she wants, matching a near-top 9.",
       "alignmentValue": 9
     },
     {
       "key": "Work Week Hours",
-      "alignmentText": "Collective agreements keep standard weeks near 37 hours with limited overtime, and employers expect you to actually use it.",
+      "alignmentText": "Collective agreements keep standard weeks near 37 hours with limited overtime, and employers expect you to actually use it. Thirty-seven-hour norms and enforced overtime caps make the family’s rhythm sustainable, perfectly aligning with the guide’s 9-level short workweeks.",
       "alignmentValue": 9
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Employees accrue five weeks of paid holiday under the Holiday Act plus up to 11 public holidays depending on region.",
+      "alignmentText": "Employees accrue five weeks of paid holiday under the Holiday Act plus up to 11 public holidays depending on region. Five weeks of statutory leave plus generous holidays let the family plan long US visits, hitting the 9 tier for guaranteed rest time.",
       "alignmentValue": 9
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Tech firms often layer RTT days or flex Fridays on top of the statutory five weeks, so six weeks off isn’t unusual.",
+      "alignmentText": "Tech firms often layer RTT days or flex Fridays on top of the statutory five weeks, so six weeks off isn’t unusual. Tech employers often top up to six weeks and respect complete disconnection, so the family enjoys the guide’s 9-rated generous norm.",
       "alignmentValue": 9
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Copenhagen hums with bikes and cafés but lacks the frantic pace of US metros; Aarhus and Odense feel even calmer while staying urban.",
+      "alignmentText": "Cities feel calm with short commutes and bike-first planning. The family gets the slower rhythm they crave while keeping urban amenities, so the score stays at an 8.",
       "alignmentValue": 8
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "Schools run roughly 8:00–14:00 with SFO after-school clubs, while parents work 8:00–16:00 and enjoy communal dinners early.",
+      "alignmentText": "Schools run roughly 8:00–14:00 with SFO after-school clubs, while parents work 8:00–16:00 and enjoy communal dinners early. School runs start around 8 and wrap by 15:00, aligning with 37-hour workweeks so parents can handle pickup, which matches the guide’s 8 rating for family-aligned routines.",
       "alignmentValue": 8
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Weekends lean toward kid sports, nature outings, and hygge gatherings; many shops close early Sunday, nudging intentional downtime.",
+      "alignmentText": "Weekends lean toward kid sports, nature outings, and hygge gatherings; many shops close early Sunday, nudging intentional downtime. Weekends lean toward museums, forest schools, and hygge gatherings, giving ample family time and aligning with an 8-tier relaxed yet active rhythm.",
       "alignmentValue": 8
     },
     {
       "key": "Family Life",
-      "alignmentText": "Family-friendly design—pram lanes, play spaces, and safe cycling—makes daily routines smooth for young kids and parents alike.",
+      "alignmentText": "Family-friendly design—pram lanes, play spaces, and safe cycling—makes daily routines smooth for young kids and parents alike. Community centers, parenting leave, and child-friendly cafes make it simple for the polyamory-positive family to plug in, justifying a 9 for supportive family culture.",
       "alignmentValue": 9
     },
     {
       "key": "Polyamory",
-      "alignmentText": "Non-monogamy is legal and queer spaces are tolerant, yet there’s little formal recognition for multi-partner families and social norms remain monogamous.",
+      "alignmentText": "Non-monogamy is legal and queer spaces are tolerant, yet there’s little formal recognition for multi-partner families and social norms remain monogamous. Danish society is tolerant of non-monogamy in urban circles but offers little explicit legal recognition, so the family gets social acceptance without formal protections, fitting a 5.",
       "alignmentValue": 5
     },
     {
       "key": "Parenting Expectations",
-      "alignmentText": "Danish parenting is child-led with low homework loads and strong trust in kids’ autonomy, matching Trey and Sarah’s gentle approach.",
+      "alignmentText": "Danish parenting is child-led with low homework loads and strong trust in kids’ autonomy, matching Trey and Sarah’s gentle approach. Parenting norms emphasize equality and shared leave, aligning with the family’s progressive outlook and matching an 8-level supportive expectation set.",
       "alignmentValue": 8
     },
     {
       "key": "Child-Friendliness of Cities",
-      "alignmentText": "Playgrounds, child-friendly cafés, and libraries abound; Copenhagen’s traffic-calmed streets let five-year-olds bike with supervision.",
+      "alignmentText": "Stroller-friendly transit, safe bike lanes, and plentiful playgrounds let the kids roam confidently. The family can lean on neighbors and schools for support, earning an 8-tier rating.",
       "alignmentValue": 8
     },
     {
       "key": "Schooling Options",
-      "alignmentText": "Folkeskole public schools are free and secular; international tracks exist in major cities but have waitlists and higher tuition.",
+      "alignmentText": "Folkeskole public schools are free and secular; international tracks exist in major cities but have waitlists and higher tuition. Public folkeskole quality is strong but there’s limited language-stream variety, so the family sees a 7-level mix of dependable public routes with fewer alternates.",
       "alignmentValue": 7
     },
     {
       "key": "Pre-K / Early Childcare Landscape",
-      "alignmentText": "Municipal vuggestue and børnehave spots are plentiful with play-based pedagogy; expect waitlists in central Copenhagen but subsidies keep costs moderate.",
+      "alignmentText": "Municipal daycare slots are guaranteed after one year with capped fees. That reliability anchors the family’s work plans and matches an 8 rating for early childcare.",
       "alignmentValue": 8
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "Municipalities cap parent fees near 25% of actual cost, with low-income discounts and guaranteed places from age one.",
+      "alignmentText": "Citizens enjoy heavy subsidies and home-care grants that keep fees manageable. The family’s Danish friends model generous support, illustrating why this remains a 9-tier benefit.",
       "alignmentValue": 9
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Once the family secures CPR numbers and municipal registration, they access the same daycare subsidies, though documentation is paperwork-heavy.",
+      "alignmentText": "Once the family secures CPR numbers and municipal registration, they access the same daycare subsidies, though documentation is paperwork-heavy. Non-EU residents access daycare once registered, yet must budget higher copays initially, keeping support at a solid 7.",
       "alignmentValue": 7
     },
     {
       "key": "K-12 Education Access (Citizens)",
-      "alignmentText": "Citizens attend local folkeskole without tuition; project-based learning and strong student services suit creative kids.",
+      "alignmentText": "Free public schooling with strong PISA results gives local peers excellent options. The family sees how citizens benefit from this 8-level system when comparing neighborhoods.",
       "alignmentValue": 8
     },
     {
       "key": "K-12 Education Access (Visa Holders)",
-      "alignmentText": "Resident non-citizens enroll for free, but instruction is Danish with newcomer language classes—extra effort for English-speaking kids.",
+      "alignmentText": "Resident non-citizens enroll for free, but instruction is Danish with newcomer language classes—extra effort for English-speaking kids. International and bilingual tracks exist but waitlists appear in Copenhagen, so the family should apply early—typical of the 7 tier.",
       "alignmentValue": 7
     },
     {
       "key": "Private Education",
-      "alignmentText": "Private friskoler and international schools offer bilingual or IB tracks; fees are subsidized but still €3k–€8k annually per child.",
+      "alignmentText": "Friskoler and international schools offer alternative pedagogy but charge moderate tuition. The family has backup options if Danish immersion feels slow, which fits a 6-tier landscape.",
       "alignmentValue": 6
     },
     {
       "key": "Family Policy (Citizens)",
-      "alignmentText": "Parents receive 52 weeks of paid leave to share plus monthly child benefits (~DKK 4,746 quarterly per young child).",
+      "alignmentText": "Universal child benefits, shared parental leave, and flexible schedules define the welfare state. Observing citizen friends reassures the family that a 9-level support system is real.",
       "alignmentValue": 9
     },
     {
       "key": "Family Policy (Visa Holders)",
-      "alignmentText": "Temporary residents qualify for parental leave pay and child benefits after tax registration, though proof of residency and employment is scrutinized.",
+      "alignmentText": "Temporary residents qualify for parental leave pay and child benefits after tax registration, though proof of residency and employment is scrutinized. Once the family holds CPR numbers they tap most benefits, though some cash allowances require permanent residency, so the score stays at 7.",
       "alignmentValue": 7
     },
     {
       "key": "Higher Education Access (Citizens)",
-      "alignmentText": "Universities are tuition-free with generous SU stipends, keeping future costs minimal if kids naturalize or hold EU status.",
+      "alignmentText": "University is tuition-free with living stipends for Danes. Planning ahead, the family notes that local classmates enjoy a 9-tier path into higher ed.",
       "alignmentValue": 9
     },
     {
       "key": "Higher Education Access (Visa Holders)",
-      "alignmentText": "Non-EU students face tuition of €6k–€16k per year unless they gain permanent residency or scholarships via English-language programs.",
+      "alignmentText": "Non-EU students pay tuition unless they gain permanent residency. The family knows their kids must either naturalize or budget for fees, matching the 5-tier guidance.",
       "alignmentValue": 5
     },
     {
       "key": "Gender Roles",
-      "alignmentText": "Workplace and household norms emphasize equality; paternity leave uptake and shared chores are socially expected.",
+      "alignmentText": "Workplace and household norms emphasize equality; paternity leave uptake and shared chores are socially expected. Shared parental leave and normalized dual-income households mirror the family’s expectations, securing a 9-level egalitarian culture.",
       "alignmentValue": 9
     },
     {
       "key": "Gender Fluidity",
-      "alignmentText": "Legal gender change is self-declared and trans health care is covered, yet non-binary recognition is still evolving socially.",
+      "alignmentText": "Legal recognition exists and urban spaces are welcoming, yet rural debates linger. The family still finds affirming communities, keeping acceptance at a 7-tier level.",
       "alignmentValue": 7
     },
     {
       "key": "Gender Rights",
-      "alignmentText": "Robust anti-discrimination laws, pay-transparency rules, and political representation make Denmark a leader in gender equity.",
+      "alignmentText": "Robust anti-discrimination laws, pay-transparency rules, and political representation make Denmark a leader in gender equity. Strong anti-discrimination enforcement and comprehensive healthcare access meet the family’s priorities, aligning with a 9 rating.",
       "alignmentValue": 9
     },
     {
       "key": "Femininity Norms",
-      "alignmentText": "Casual, practical fashion dominates; women move confidently in public spaces and harassment rates are low by EU standards.",
+      "alignmentText": "Women participate broadly in leadership without rigid beauty expectations. That gives Sarah role models who match the family’s egalitarian outlook, supporting an 8 rating.",
       "alignmentValue": 8
     },
     {
       "key": "Masculinity Norms",
-      "alignmentText": "Danish men are expected to be nurturing—taking leave, cooking, and openly supporting egalitarian relationships.",
+      "alignmentText": "Danish men are expected to be nurturing—taking leave, cooking, and openly supporting egalitarian relationships. Men commonly take leave and embrace caregiving, giving Trey social support to prioritize family time and warranting an 8.",
       "alignmentValue": 8
     },
     {
       "key": "What Is Intriguing",
-      "alignmentText": "Design-forward cities, hygge culture, and world-class cycling infrastructure create a cozy-yet-modern lifestyle.",
+      "alignmentText": "Design-forward cities, hygge culture, and world-class cycling infrastructure create a cozy-yet-modern lifestyle. The blend of cooperative housing, design-forward cities, and robust civic engagement offers new experiments for the family, fitting an 8-level intrigue.",
       "alignmentValue": 8
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "Over 85% speak excellent English; government digital services and workplaces routinely accommodate English speakers while offering Danish classes.",
+      "alignmentText": "Over 85% speak excellent English; government digital services and workplaces routinely accommodate English speakers while offering Danish classes. Near-universal English proficiency and bilingual schooling make arrival easy while the family slowly learns Danish, perfectly matching the 9 tier.",
       "alignmentValue": 9
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Social policies champion LGBTQ+ rights, reproductive freedom, and secular governance—aligned with a progressive household.",
+      "alignmentText": "Social policies champion LGBTQ+ rights, reproductive freedom, and secular governance—aligned with a progressive household. Denmark’s social democracy, LGBTQ+ protections, and coalition politics align tightly with the family’s progressive expectations, sustaining a 9.",
       "alignmentValue": 9
     },
     {
       "key": "Marxism (Societal Attitudes)",
-      "alignmentText": "Public discourse favors social-democratic pragmatism: strong welfare without revolutionary rhetoric, keeping debates moderate.",
+      "alignmentText": "Public discourse favors social-democratic pragmatism: strong welfare without revolutionary rhetoric, keeping debates moderate. Left parties frame debates around welfare and labor rights without broad revolutionary zeal, delivering a measured 7 that still appeals to the family’s curiosity.",
       "alignmentValue": 7
     },
     {
       "key": "Atheism",
-      "alignmentText": "Despite a state Lutheran church, weekly attendance is under 5%; secularism dominates schooling and politics.",
+      "alignmentText": "Despite a state Lutheran church, weekly attendance is under 5%; secularism dominates schooling and politics. Church attendance is low and secularism defines policy, giving the family comfortable freedom of belief typical of a 9.",
       "alignmentValue": 9
     },
     {
       "key": "Sex (Attitudes)",
-      "alignmentText": "Comprehensive sex education and open discussion of sexuality are standard, though public affection stays tasteful.",
+      "alignmentText": "Comprehensive sex education and open conversation suit a sex-positive household. The family can speak openly with friends, but suburban discretion keeps this grounded at an 8-tier comfort.",
       "alignmentValue": 8
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Marriage equality, anti-discrimination protections, and Pride events across cities reflect high social acceptance.",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride events set the tone. The family’s poly-friendly values slot easily into this 9-tier acceptance.",
       "alignmentValue": 9
     },
     {
       "key": "Community Vibes",
-      "alignmentText": "Danes value privacy; joining associations or parent networks takes time, but once inside the communities are loyal and supportive.",
+      "alignmentText": "Danes value privacy; joining associations or parent networks takes time, but once inside the communities are loyal and supportive. Danes guard personal space until relationships deepen, so the family should join associations to build networks—squarely a 6-level social adjustment.",
       "alignmentValue": 6
     },
     {
       "key": "View of self",
-      "alignmentText": "They see themselves as egalitarian, environmentally conscious, and humble—Janteloven discourages boasting.",
+      "alignmentText": "They see themselves as egalitarian, environmentally conscious, and humble—Janteloven discourages boasting. Most Danes pride themselves on egalitarianism and modesty, encouraging the family to embrace communal success narratives that align with a 7.",
       "alignmentValue": 7
     },
     {
       "key": "View of Neighboring Countries",
-      "alignmentText": "Relations with fellow Nordics and Germany are cooperative, with friendly competition in design, energy, and sport.",
+      "alignmentText": "Friendly rivalry with Sweden and Germany fuels lighthearted comparisons. The family can join those conversations without tension, so the outlook holds at a balanced 7.",
       "alignmentValue": 7
     },
     {
       "key": "View of Them by Neighboring Countries",
-      "alignmentText": "Neighbors generally regard Danes as trustworthy social democrats with strong welfare and progressive politics.",
+      "alignmentText": "Neighbors generally regard Danes as trustworthy social democrats with strong welfare and progressive politics. Denmark’s reputation for trust and design earns respect across the EU, helping the family benefit from positive stereotypes typical of an 8.",
       "alignmentValue": 8
     },
     {
       "key": "Nightlife Culture",
-      "alignmentText": "Copenhagen and Aarhus host lively bars and music venues, yet high alcohol taxes and early train schedules keep nights moderate.",
+      "alignmentText": "Copenhagen’s late-night bars and live music give Trey and Sarah options once childcare is covered. The family experiences a 7-tier nightlife scene that’s lively but not overwhelming.",
       "alignmentValue": 7
     },
     {
       "key": "Fashion Trends (Male)",
-      "alignmentText": "Minimalist, well-tailored streetwear—think layers, cycling-friendly outerwear, and design brands like Norse Projects.",
+      "alignmentText": "Minimalist streetwear and cycling-friendly layers define men’s fashion. Trey can blend in with practical gear, proving the 7 rating meets the family’s expectations.",
       "alignmentValue": 7
     },
     {
       "key": "Fashion Trends (Female)",
-      "alignmentText": "Women favor effortless layers, sneakers with dresses, and sustainability-focused Danish labels.",
+      "alignmentText": "Women mix practical outerwear with Scandinavian design labels. Sarah enjoys stylish yet comfortable choices that fit the family’s 7-tier expectations.",
       "alignmentValue": 7
     },
     {
       "key": "Common Hobbies",
-      "alignmentText": "Cycling, cold-water dips, handball, and communal dining clubs are popular ways to connect with neighbors.",
+      "alignmentText": "Cycling, cold-water dips, handball, and communal dining clubs are popular ways to connect with neighbors. Outdoor swimming, cycling clubs, and creative workshops align with the family’s interests, keeping hobbies at a well-rounded 7.",
       "alignmentValue": 7
     },
     {
       "key": "Boardgaming & Tabletop",
-      "alignmentText": "Board game cafés (Bastard Café, byENS Værksted) and Nordic LARP traditions give tabletop fans plenty of venues.",
+      "alignmentText": "Aarhus and Copenhagen host active board-game cafes and conventions. Trey finds kindred spirits for family game nights, making the 7 score feel right.",
       "alignmentValue": 7
     },
     {
       "key": "Nightlife & Music",
-      "alignmentText": "Jazz, electronic, and indie scenes thrive in Copenhagen and Roskilde, though events skew expensive compared with US cities.",
+      "alignmentText": "From jazz clubs to electronic festivals, options are plentiful but clustered in major cities. With childcare lined up, the family can sample shows that fit the 7-tier vibrancy.",
       "alignmentValue": 7
     },
     {
       "key": "Meetups & Communities",
-      "alignmentText": "TechBBQ, Unity meetups, parenting groups, and queer networks meet frequently—many operate in English but expect proactive outreach.",
+      "alignmentText": "TechBBQ, Unity meetups, parenting groups, and queer networks meet frequently—many operate in English but expect proactive outreach. Tech, parenting, and international meetups convene regularly, so the family can plug into groups quickly—an approachable 7 tier.",
       "alignmentValue": 7
     },
     {
       "key": "Nature Access",
-      "alignmentText": "Regional trains and ferries unlock forests, islands, and Sweden day trips within 1–2 hours, making nature weekends easy.",
+      "alignmentText": "Regional trains and ferries unlock forests, islands, and Sweden day trips within 1–2 hours, making nature weekends easy. Trains reach forests and coastlines in under an hour, letting the family trade Kansas City road trips for low-carbon day outings, which suits an 8.",
       "alignmentValue": 8
     },
     {
       "key": "Political System",
-      "alignmentText": "A constitutional monarchy with proportional parliament ensures multi-party coalitions, independent courts, and civil liberties.",
+      "alignmentText": "A constitutional monarchy with proportional parliament ensures multi-party coalitions, independent courts, and civil liberties. A constitutional monarchy with coalition parliaments keeps checks strong, matching the family’s demand for a 9-level democratic system.",
       "alignmentValue": 9
     },
     {
       "key": "Religion in Politics",
-      "alignmentText": "Church and state are formally linked but clergy wield little power; policy debates stay secular.",
+      "alignmentText": "Church and state are formally linked but clergy wield little power; policy debates stay secular. Secular policymaking dominates despite a state church, assuring the family that laws stay inclusive and rating this a 9.",
       "alignmentValue": 9
     },
     {
       "key": "Workers' Rights",
-      "alignmentText": "High union density secures dismissal protections, collective bargaining, and paid leave that apply equally to foreigners in covered sectors.",
+      "alignmentText": "Collective bargaining and strong safety nets protect employees. The family sees how unions secure humane schedules, validating the 9 rating.",
       "alignmentValue": 9
     },
     {
       "key": "State Ideology",
-      "alignmentText": "Policy blends market openness with redistributive welfare and strong co-ops—supportive for entrepreneurship with safety nets.",
+      "alignmentText": "Policy blends market openness with redistributive welfare and strong co-ops—supportive for entrepreneurship with safety nets. The state blends market capitalism with robust welfare, an 8-level mix that aligns with the family’s preference for pragmatic progressivism.",
       "alignmentValue": 8
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Free media, active courts, and civic engagement keep risks low, though far-right parties periodically test migration policy boundaries.",
+      "alignmentText": "Free media, active courts, and civic engagement keep risks low, though far-right parties periodically test migration policy boundaries. Broad trust in institutions and proportional representation keep extremism at bay, so the family sees only moderate vigilance needs—an 8-tier security.",
       "alignmentValue": 8
     },
     {
       "key": "State of Capitalism",
-      "alignmentText": "Competitive markets and ease of doing business rank high, yet regulation and taxes stay heavier than US norms.",
+      "alignmentText": "The flexicurity model encourages entrepreneurship with safety nets, yet high taxes and regulation slow rapid scaling. Trey balances those trade-offs with the family’s runway in mind, fitting a 7-tier climate.",
       "alignmentValue": 7
     },
     {
       "key": "Stability",
-      "alignmentText": "Political transitions are peaceful; currency is pegged to the euro; strikes are rare and negotiated.",
+      "alignmentText": "Decades of steady governance and low inflation give long-term certainty. That reliability helps the family invest in Denmark, confirming the 9 score.",
       "alignmentValue": 9
     },
     {
       "key": "Propaganda Prevalence",
-      "alignmentText": "Public broadcasters are independent and media literacy is emphasized; state messaging is transparent but not pushy.",
+      "alignmentText": "Public broadcasters are independent and media literacy is emphasized; state messaging is transparent but not pushy. Public broadcasters are independent with strong press freedom rankings, so the family encounters minimal spin, matching an 8.",
       "alignmentValue": 8
     },
     {
       "key": "Propaganda Messaging",
-      "alignmentText": "Government campaigns focus on health, sustainability, and cohesion; little heavy-handed narrative-shaping.",
+      "alignmentText": "Government campaigns focus on health, sustainability, and cohesion; little heavy-handed narrative-shaping. State messaging focuses on public health and cohesion rather than ideology, aligning with the family’s desire for pluralistic news in the 8 tier.",
       "alignmentValue": 8
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Comprehensive anti-discrimination, reproductive rights, and LGBTQ+ protections align with the family’s progressive values.",
+      "alignmentText": "Comprehensive anti-discrimination, reproductive rights, and LGBTQ+ protections align with the family’s progressive values. Universal healthcare, housing supports, and LGBTQ+ protections match nearly every family priority, justifying the 9 score.",
       "alignmentValue": 9
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Surveys show over 70% of Danes trust national institutions thanks to efficient digital services and responsive municipalities.",
+      "alignmentText": "High civic trust means institutions respond quickly, though immigrants sometimes navigate extra verification. The family accepts those checks as the price of an 8-tier trust environment.",
       "alignmentValue": 8
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Transparency International routinely ranks Denmark #1–2 for clean governance and robust oversight.",
+      "alignmentText": "Transparency International ranks Denmark at the top, ensuring day-to-day bureaucracy stays clean. The family rarely worries about under-the-table demands, supporting the 9 rating.",
       "alignmentValue": 9
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "When issues arise they’re typically policy favoritism or procurement scrutiny rather than petty bribes affecting residents.",
+      "alignmentText": "When issues surface they tend to be minor procurement lapses rather than systemic graft. The family can rely on rules rather than favors, a hallmark of the 8 tier.",
       "alignmentValue": 8
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Copenhagen rents are high and vacancy under 1%; co-ops and long waitlists demand planning or settling in secondary cities.",
+      "alignmentText": "Copenhagen rents are high and vacancy under 1%; co-ops and long waitlists demand planning or settling in secondary cities. Demand in Copenhagen keeps rents high and supply tight, so the family must budget carefully—exactly what a 5 rating signals.",
       "alignmentValue": 5
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Violent crime is rare; kids walk and bike independently, and community policing keeps neighborhoods calm.",
+      "alignmentText": "Violent crime is rare; kids walk and bike independently, and community policing keeps neighborhoods calm. Violent crime is rare and kids walk or bike independently, aligning with the 9-tier safety profile the family wants.",
       "alignmentValue": 9
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal GP registration, hospital care, and maternity services are free; waits for elective specialists can stretch weeks.",
+      "alignmentText": "Citizens enjoy universal coverage and strong outcomes, though rural waitlists exist. The family sees neighbors navigate the system smoothly, which keeps this at an 8 rating.",
       "alignmentValue": 8
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "After obtaining CPR numbers and NemID, residents access the same free GP system, though initial processing can delay specialist referrals.",
+      "alignmentText": "After registration, expats access the same GP network but face delays for specialist referrals. The family budgets extra time for appointments, aligning with a 7-tier experience.",
       "alignmentValue": 7
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Municipal subsidies, capped fees, and abundant after-school clubs reduce childcare stress for dual-working parents.",
+      "alignmentText": "Generous leave policies and municipal daycare mean both parents can balance work and caregiving. The family experiences that safety net directly, so the 8 rating holds.",
       "alignmentValue": 8
     },
     {
       "key": "Family Policy (Common Family)",
-      "alignmentText": "Typical families share year-long parental leave, monthly child allowances, and flexible work policies baked into employment contracts.",
+      "alignmentText": "Typical families share year-long parental leave, monthly child allowances, and flexible work policies baked into employment contracts. Average households benefit from child allowances, subsidized activities, and flexible workplaces—firmly a 9-tier family policy mix.",
       "alignmentValue": 9
     },
     {
       "key": "Education",
-      "alignmentText": "Public schools emphasize collaboration and STEM literacy; PISA scores are above OECD average with strong language support.",
+      "alignmentText": "Strong literacy scores and inclusive classrooms serve the kids well, though Danish immersion takes time. The family counts on extra language support, fitting the 8-tier assessment.",
       "alignmentValue": 8
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "S-tog trains, metro extensions, and frequent buses make car-free living feasible in major cities, though fares are high.",
+      "alignmentText": "S-tog trains, metro extensions, and frequent buses make car-free living feasible in major cities, though fares are high. Trains and metro coverage are extensive but pricey and occasionally delayed, so the family gets dependable service with minor hassles, a 7-tier outcome.",
       "alignmentValue": 7
     },
     {
       "key": "Economic System",
-      "alignmentText": "Flexicurity balances employer freedom with social safety nets, supporting entrepreneurship while guaranteeing benefits.",
+      "alignmentText": "Flexicurity balances employer freedom with social safety nets, supporting entrepreneurship while guaranteeing benefits. A social-market model balances entrepreneurship with safety nets, fitting the family’s desire for predictability and matching a 7.",
       "alignmentValue": 7
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "Withholding and automatic annual settlements via TastSelv/NemKonto minimize bureaucracy—even for expats once NemID is set up.",
+      "alignmentText": "Automatic reporting and digital tools keep compliance simple even with high rates. The family files returns with minimal friction, supporting the 8 rating for administration.",
       "alignmentValue": 8
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "Dual tech incomes would quickly hit 37–42% effective tax plus 8% labor market contributions, reducing take-home pay compared with the US.",
+      "alignmentText": "Dual tech incomes would quickly hit 37–42% effective tax plus 8% labor market contributions, reducing take-home pay compared with the US. Dual earners at tech salaries pay around 42–45% marginal tax, so the family trades take-home pay for services, which is why this stays at the 4 level.",
       "alignmentValue": 4
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "NemID/MitID access, MobilePay ubiquity, and fee-free bank transfers make finances seamless once residency is established.",
+      "alignmentText": "MobilePay ubiquity and instant transfers make daily life seamless for digital-native parents. The family pays rent, childcare, and utilities effortlessly, reinforcing the 9 score.",
       "alignmentValue": 9
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Housing, groceries, and dining rank among Europe’s most expensive, pressuring budgets until salaries adjust.",
+      "alignmentText": "Housing, groceries, and dining rank among Europe’s most expensive, pressuring budgets until salaries adjust. Housing and groceries run high relative to Kansas City, so the family needs a larger budget—squarely the guide’s 4-tier affordability.",
       "alignmentValue": 4
     },
     {
       "key": "Retirement (Citizens)",
-      "alignmentText": "Citizens accrue state pensions plus mandatory ATP and occupational schemes, providing solid old-age security.",
+      "alignmentText": "Citizens combine public pensions with occupational plans, keeping seniors comfortable. The family notes how neighbors rely on this 8-tier system for security.",
       "alignmentValue": 8
     },
     {
       "key": "Retirement (Visa Holders)",
-      "alignmentText": "Foreign workers pay into ATP and employer pensions; benefits are portable after leaving but require administrative follow-up.",
+      "alignmentText": "Expats must contribute for years before qualifying for full pensions, so long-term residency matters. The family plans private savings to bridge the 6-tier limitations.",
       "alignmentValue": 6
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Residence options include the Positive List, Pay Limit scheme, Startup Denmark, and EU Blue Card, each with salary or investment thresholds.",
+      "alignmentText": "Work-based permits and the Start-up Denmark visa are accessible for skilled professionals, yet paperwork is exacting. The family can qualify but must plan for a 6-tier administrative load.",
       "alignmentValue": 6
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Danes are polite and curious about Americans, yet bureaucracy expects self-sufficiency and there’s limited hand-holding.",
+      "alignmentText": "Danes are polite and curious about Americans, yet bureaucracy expects self-sufficiency and there’s limited hand-holding. Danes are polite but cautious with newcomers until trust is built, giving the family a moderate 6-level welcome.",
       "alignmentValue": 6
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Initial work permits last up to four years with renewals tied to employment; permanent residency requires 8 years, Danish exams, and full-time work history.",
+      "alignmentText": "Temporary permits renew in two-year increments with language and integration checkpoints. The family works toward permanence methodically, matching the 6 rating.",
       "alignmentValue": 6
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Naturalization typically takes 9 years (or 8 with integration credits) plus language and civic tests—long for families seeking faster certainty.",
+      "alignmentText": "Naturalization typically takes 9 years (or 8 with integration credits) plus language and civic tests—long for families seeking faster certainty. Naturalization usually takes nine years plus language and culture exams, so the family faces a lengthy route that fits the 4 range.",
       "alignmentValue": 4
     },
     {
       "key": "Family Members",
-      "alignmentText": "Spouses and children obtain dependent permits with the right to work and attend school, provided income and housing requirements are met.",
+      "alignmentText": "Spouses and children obtain dependent permits with the right to work and attend school, provided income and housing requirements are met. Spousal and child reunification is straightforward once income thresholds are met, supporting a 7-level family-friendly stance.",
       "alignmentValue": 7
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Processing runs 1–3 months; fees range DKK 3,000–4,000 per adult plus biometrics—manageable but not trivial.",
+      "alignmentText": "Application fees are moderate and decisions take a few months. The family sets aside savings and calendar reminders, which feels exactly like a 6-tier process.",
       "alignmentValue": 6
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Strict reporting on salary, address changes, and Danish lessons is enforced; missing requirements risks permit revocation.",
+      "alignmentText": "Strict reporting on salary, address changes, and Danish lessons is enforced; missing requirements risks permit revocation. Authorities expect strict documentation of housing, savings, and Danish lessons, which the family can handle with diligence, aligning with a 6.",
       "alignmentValue": 6
     },
     {
       "key": "Dual Citizenship Allowed",
-      "alignmentText": "Since 2015 Denmark permits dual citizenship, letting the family retain US passports while naturalizing later.",
+      "alignmentText": "Since 2015 Denmark permits dual citizenship, letting the family retain US passports while naturalizing later. Since 2015 Denmark permits dual nationality, letting the family retain US passports—an 8-level benefit.",
       "alignmentValue": 8
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Securing housing before arrival, registering for CPR, and waiting for MitID can take weeks—plan bridging funds and patience.",
+      "alignmentText": "Securing housing before arrival, registering for CPR, and waiting for MitID can take weeks—plan bridging funds and patience. CPR registration unlocks services but demands in-person appointments and Danish forms, so the family should budget time, consistent with a 6.",
       "alignmentValue": 6
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Studios in Copenhagen and Aarhus hire Unity/C# talent for mobile, VR, and indie titles, though the scene is smaller than Sweden’s.",
+      "alignmentText": "Studios like IO Interactive, SYBO, and Ghost Ship hire internationally, giving Trey mid-sized industry depth. The family sees a clear 7-tier ladder for staying in Denmark’s game scene.",
       "alignmentValue": 7
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "IO Interactive (Hitman), SYBO (Subway Surfers), Ghost Ship Games (Deep Rock Galactic), and Tactile Games anchor the ecosystem.",
+      "alignmentText": "High-profile studios ship global titles from Copenhagen, offering networking credibility. The family benefits from that 8-tier cluster when pitching projects.",
       "alignmentValue": 8
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "Nordic Game Jam, Copenhagen Game Collective, and Unity meetups offer collaborative spaces for prototyping and networking.",
+      "alignmentText": "Game jams, Filmbyen events, and Nordic Game conferences keep the scene collaborative. The family plugs into those 7-tier communities for both work and social life.",
       "alignmentValue": 7
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Startup Denmark grants founder visas and the Danish Film Institute and Nordic Game grants support prototypes, but salaries and rent raise burn rates.",
+      "alignmentText": "Public grants and incubators exist but competition is steep. Trey maps out funding applications knowing the family faces a 6-tier challenge for new studios.",
       "alignmentValue": 6
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "World-class digitization (NemID, e-Boks), nationwide fiber, and 5G networks keep daily life efficient for tech-heavy households.",
+      "alignmentText": "World-class digitization (NemID, e-Boks), nationwide fiber, and 5G networks keep daily life efficient for tech-heavy households. Fiber broadband, smart public services, and climate-adaptive urban design give the family future-proof infrastructure, consistent with a 9-tier rating.",
       "alignmentValue": 9
     }
   ]


### PR DESCRIPTION
## Summary
- mark the Denmark country file as version 2 and raise the Environment score to 9 with updated justification
- rewrite category narratives so each metric ties its score to the Kansas City family’s priorities across climate, work-life balance, education, and governance
- clarify immigration, financial, and game-development sections to explain trade-offs the family should plan for

## Testing
- python -m json.tool reports/denmark_report.json

------
https://chatgpt.com/codex/tasks/task_e_68e2f12274588321bec3c0bb2b88c957