### PR TITLE
Refresh Portugal report with updated ratings and guidance

### DIFF
--- a/reports/portugal_report.json
+++ b/reports/portugal_report.json
@@ -1,544 +1,545 @@
 {
+  "version": 2,
   "iso": "PT",
   "values": [
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Used in enterprises with moderate demand.",
+      "alignmentText": "Banks, utilities, and consultancies keep .NET teams in Lisbon and Porto hiring steadily, but many projects are hybrid Portuguese-English and skew to maintenance rather than greenfield builds.",
       "alignmentValue": 6
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Generally good across the country.",
+      "alignmentText": "Prevailing coastal winds and low heavy industry keep annual PM2.5 around WHO targets, with the main watch-outs being wildfire smoke or Saharan dust alerts a few days each year.",
       "alignmentValue": 8
     },
     {
       "key": "Atheism",
-      "alignmentText": "Catholic heritage with rising secularism.",
+      "alignmentText": "Most Portuguese identify culturally Catholic, but urban life is secular enough that nonreligious families meet little friction.",
       "alignmentValue": 6
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Low; stable democracy.",
+      "alignmentText": "Independent courts, EU oversight, and active civil society keep far-right gains contained even amid cost-of-living protests.",
       "alignmentValue": 8
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "Modern banking with MB Way mobile payments.",
+      "alignmentText": "MB Way instant transfers, widespread contactless payments, and EU IBAN access make daily finances easy once we secure a NIF and local account.",
       "alignmentValue": 8
     },
     {
       "key": "Beach Life",
-      "alignmentText": "Extensive beaches with active surf culture.",
+      "alignmentText": "Blue Flag beaches line the coast with lifeguards and boardwalk cafés; we mainly navigate summer crowding near Lisbon by timing trips or exploring the Alentejo coast.",
       "alignmentValue": 9
     },
     {
       "key": "Boardgaming & Tabletop",
-      "alignmentText": "Small but growing hobby stores.",
+      "alignmentText": "Lisbon and Porto host dedicated board-game cafés and monthly meetups, but smaller towns rely on informal groups Trey would help organize.",
       "alignmentValue": 6
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Subsidies exist but availability limited.",
+      "alignmentText": "National policy caps creche fees and expands free slots, yet availability and hours vary, so dual-working parents still juggle backups.",
       "alignmentValue": 6
     },
     {
       "key": "Child-Friendliness of Cities",
-      "alignmentText": "Parks and playgrounds make cities welcoming to children.",
-      "alignmentValue": 8
+      "alignmentText": "Safe streets and playground upgrades help, yet Lisbon’s hills, cobblestones, and limited elevators mean strollers need extra planning.",
+      "alignmentValue": 7
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "Child benefit (Abono de Família), expanding free creche, parental leave allowances; municipal subsidies; documentation and income rules apply.",
-      "alignmentValue": 8.0
+      "alignmentText": "Citizens access paid parental leave, child benefits, and expanding free creche spots, which covers much of the daily cost if paperwork is current.",
+      "alignmentValue": 8
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Residents paying into social security generally access many supports; visa/status and documentation affect eligibility; coverage improving.",
-      "alignmentValue": 6.0
+      "alignmentText": "Resident visa holders can tap into subsidies after securing NISS numbers, but eligibility hinges on contributions history and permanent status.",
+      "alignmentValue": 6
     },
     {
       "key": "Common Hobbies",
-      "alignmentText": "Football, surfing, and festivals.",
+      "alignmentText": "Surfing, hiking, futebol, and community festivals keep weekends active and offer easy entry points for making friends.",
       "alignmentValue": 8
     },
     {
       "key": "Community Vibes",
-      "alignmentText": "Welcoming and friendly locals.",
+      "alignmentText": "Neighbors linger at cafés and kids roam plazas, giving newcomers room to plug into local associations with a bit of Portuguese.",
       "alignmentValue": 8
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Need to maintain stay requirements and income proof.",
+      "alignmentText": "Staying compliant means tracking passive-income thresholds, health insurance, and minimum stay days; missing renewals can force reapplication.",
       "alignmentValue": 6
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Lower than many EU countries, especially outside major cities.",
-      "alignmentValue": 7
+      "alignmentText": "Groceries and childcare remain cheaper than the U.S., but housing and electricity inflation in Lisbon/Porto erode the overall affordability pitch.",
+      "alignmentValue": 6
     },
     {
       "key": "Dual Citizenship Allowed",
-      "alignmentText": "Yes—Portugal permits dual nationality.",
-      "alignmentValue": 9.0
+      "alignmentText": "Portugal permits dual nationality, so the family can naturalize without surrendering U.S. passports.",
+      "alignmentValue": 9
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Recovering economy reliant on tourism and services.",
+      "alignmentText": "GDP growth is steady and inflation cooling, yet productivity and wages trail the EU core, so long-term upside hinges on tourism and green investment.",
       "alignmentValue": 6
     },
     {
       "key": "Economic System",
-      "alignmentText": "Open economy integrated with the EU.",
+      "alignmentText": "An EU-integrated service economy supports entrepreneurship with EU funds, while bureaucracy still slows new business filings.",
       "alignmentValue": 7
     },
     {
       "key": "Education",
-      "alignmentText": "Improving schools and affordable higher education.",
+      "alignmentText": "Portugal’s steady climb in PISA rankings and inclusive special-education reforms make public schools solid, though outcomes dip in underfunded rural districts.",
       "alignmentValue": 7
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Tech visas available and relatively accessible.",
-      "alignmentValue": 6
+      "alignmentText": "Larger tech employers sponsor D-type work visas, but most firms expect hires to arrive on the job-seeker or digital-nomad routes first because AIMA processing is slow.",
+      "alignmentValue": 5
     },
     {
       "key": "Environment",
-      "alignmentText": "Pleasant Mediterranean climate with scenic coastlines and low pollution.",
-      "alignmentValue": 9
+      "alignmentText": "EU Natura 2000 protections and aggressive renewables targets keep coastal air, water, and urban parks in good shape for the kids, though drought-stressed forests in the interior mean summer fire bans and water-saving habits are still necessary.",
+      "alignmentValue": 8
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "Moderate income tax and social contributions.",
+      "alignmentText": "Dual tech incomes around €60–70k each would sit near the 28–37% brackets plus 11% social security, yielding a moderate but predictable burden.",
       "alignmentValue": 6
     },
     {
       "key": "Fall Temperature Range (C/F)",
-      "alignmentText": "Pleasant shoulder season; ~14–22 °C (57–72 °F); more Atlantic fronts/rain by Nov; Algarve stays mild.",
-      "alignmentValue": 8.0
+      "alignmentText": "September stays beach-friendly before sliding to 14–22 °C (57–72 °F) and more Atlantic fronts by November, which matches the family’s love of mild shoulder seasons.",
+      "alignmentValue": 8
     },
     {
       "key": "Family Life",
-      "alignmentText": "Family-oriented culture with strong support networks.",
+      "alignmentText": "Multigenerational support and child-friendly public spaces make settling with two young boys smooth, even if extended family expectations can feel traditional.",
       "alignmentValue": 8
     },
     {
       "key": "Family Members",
-      "alignmentText": "Family reunification straightforward with work rights.",
-      "alignmentValue": 8
+      "alignmentText": "Reunification covers spouses and dependent kids, yet appointments for residence cards can stretch several months, so staggered arrivals need planning.",
+      "alignmentValue": 7
     },
     {
       "key": "Family Policy (Citizens)",
-      "alignmentText": "Parental leave allowances (mother/father/shared), child benefits/tax credits; flexible work rights growing; varies by employer/municipality.",
-      "alignmentValue": 7.0
+      "alignmentText": "Parents receive 120–180 days of paid leave, flexible hours, and child allowances, though uptake depends on employer culture.",
+      "alignmentValue": 7
     },
     {
       "key": "Family Policy (Common Family)",
-      "alignmentText": "Supports families via child benefits.",
+      "alignmentText": "Mainstream families lean on subsidized childcare, 14 public holidays, and extended kin networks, giving us a template for balanced routines.",
       "alignmentValue": 7
     },
     {
       "key": "Family Policy (Visa Holders)",
-      "alignmentText": "Many family supports available to residents with contributions; exact eligibility linked to residence class and duration.",
-      "alignmentValue": 6.0
+      "alignmentText": "Non-citizen residents qualify for many benefits after a year of contributions, but proving income and status for each renewal is paperwork-heavy.",
+      "alignmentValue": 6
     },
     {
       "key": "Fashion Trends (Female)",
-      "alignmentText": "Casual chic; dresses/linens in summer; layered outerwear in cooler months; minimalist to boho influences.",
-      "alignmentValue": 7.0
+      "alignmentText": "Women favor relaxed Mediterranean styles—linen, denim, layered knits—leaving room for Sarah’s low-maintenance wardrobe with occasional smart-casual touches.",
+      "alignmentValue": 6
     },
     {
       "key": "Fashion Trends (Male)",
-      "alignmentText": "Casual Mediterranean smart‑casual; linen/cotton in summer; sneakers/loafers; weather‑appropriate layers.",
-      "alignmentValue": 7.0
+      "alignmentText": "Men balance casual sneakers and linen with polished jackets in offices, so Trey can stay comfortable while dressing up for client meetings.",
+      "alignmentValue": 6
     },
     {
       "key": "Femininity Norms",
-      "alignmentText": "Casual and diverse expressions.",
-      "alignmentValue": 7
+      "alignmentText": "Style expectations range from polished office wear to relaxed coastal looks, with moderate pressure toward traditional grooming.",
+      "alignmentValue": 6
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Small but emerging game development scene.",
+      "alignmentText": "A handful of studios and outsourcing shops hire Unity and Unreal talent, but most senior roles still rely on remote-friendly employers abroad.",
       "alignmentValue": 5
     },
     {
       "key": "Gender Fluidity",
-      "alignmentText": "Legal recognition but small communities.",
+      "alignmentText": "Legal gender self-determination and growing Pride events provide support, but small-town communities remain conservative.",
       "alignmentValue": 6
     },
     {
       "key": "Gender Rights",
-      "alignmentText": "Legal protections including parental leave.",
-      "alignmentValue": 7
+      "alignmentText": "Equal pay laws, reproductive healthcare, and anti-discrimination protections are strong, backed by active ombuds services.",
+      "alignmentValue": 8
     },
     {
       "key": "Gender Roles",
-      "alignmentText": "Improving equality though traditional in some areas.",
+      "alignmentText": "Women lead in education and politics, yet household labor still skews traditional outside big metros, so sharing domestic duties may draw mild surprise.",
       "alignmentValue": 6
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "NIF, bank account, social security number (NISS), SNS registration; AIMA residence procedures; driver licence exchange timelines; health cover until SNS access.",
-      "alignmentValue": 6.0
+      "alignmentText": "Securing NIF, NISS, SNS numbers, and exchanging U.S. driver’s licenses within 90 days are key admin tasks once we land.",
+      "alignmentValue": 6
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Increasing drought and wildfire risk in summer months.",
+      "alignmentText": "Lisbon and Porto are modeling sea-level rise while inland heatwaves and wildfire seasons already strain reservoirs, so we would invest in cooling and evacuation plans rather than assume climate impacts stay distant.",
       "alignmentValue": 5
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal SNS system with good coverage.",
+      "alignmentText": "The SNS covers primary and hospital care with modest copays, though specialty appointments can mean waits without private insurance top-ups.",
       "alignmentValue": 8
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Access with residency or private insurance.",
+      "alignmentText": "Resident visas unlock SNS access after registration, but newcomers often bridge the first months with private plans until paperwork clears.",
       "alignmentValue": 7
     },
     {
       "key": "Higher Education Access (Citizens)",
-      "alignmentText": "Low public tuition vs US; scholarships/grants; universities in Lisbon, Porto, Coimbra; polytechnics nationwide.",
-      "alignmentValue": 7.0
+      "alignmentText": "Universities like Coimbra and Porto keep tuition low and reserve quotas for Portuguese students, so long-term planning for the boys stays affordable.",
+      "alignmentValue": 7
     },
     {
       "key": "Higher Education Access (Visa Holders)",
-      "alignmentText": "International tuition higher; scholarships limited; options improve with EU/PR status.",
-      "alignmentValue": 5.0
+      "alignmentText": "International tuition runs several thousand euros per year and scholarships are limited until the family gains EU long-term resident status.",
+      "alignmentValue": 5
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Rising rents in Lisbon and Porto due to tourism.",
+      "alignmentText": "Lisbon and Porto face tight supply, rising rents, and multiple months’ deposit, pushing many expats toward suburbs or longer house hunts.",
       "alignmentValue": 4
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "PAYE plus annual filing with moderate complexity.",
+      "alignmentText": "The Finanças portal handles e-filing, yet progressive brackets, solidarity surtaxes, and municipal levies mean we’d likely hire an accountant the first year.",
       "alignmentValue": 6
     },
     {
       "key": "K-12 Education Access (Citizens)",
-      "alignmentText": "Free, secular public schooling; zoning applies; Portuguese + English taught early; school quality varies by municipality.",
-      "alignmentValue": 8.0
+      "alignmentText": "Compulsory schooling is free, secular, and includes early English, though families still monitor school rankings when moving districts.",
+      "alignmentValue": 8
     },
     {
       "key": "K-12 Education Access (Visa Holders)",
-      "alignmentText": "Resident children typically enroll in public schools; Portuguese‑as‑second‑language supports available; documentation required.",
-      "alignmentValue": 7.0
+      "alignmentText": "Resident children enroll in public schools with Portuguese-as-second-language support, yet immigration backlogs can delay official placement paperwork.",
+      "alignmentValue": 7
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "Portuguese is primary; good English in cities.",
+      "alignmentText": "English is common in tech hubs and tourist districts, but daily life still rewards leaning into Portuguese classes to integrate.",
       "alignmentValue": 7
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Strong legal protections and social acceptance.",
+      "alignmentText": "Marriage equality, adoption rights, and Pride celebrations in Lisbon and Porto create an affirming environment for queer-friendly parenting.",
       "alignmentValue": 8
     },
     {
       "key": "Marxism (Societal Attitudes)",
-      "alignmentText": "Left parties present but market economy prevails.",
-      "alignmentValue": 6
+      "alignmentText": "Communist and Left Bloc parties keep labor issues visible, yet the mainstream still backs EU-style social democracy over state ownership.",
+      "alignmentValue": 5
     },
     {
       "key": "Masculinity Norms",
-      "alignmentText": "Family-oriented; machismo declining.",
+      "alignmentText": "Machismo has faded in cities, yet sports chatter and family-provider ideals still shape expectations in smaller towns.",
       "alignmentValue": 6
     },
     {
       "key": "Meetups & Communities",
-      "alignmentText": "Tech meetups and expat groups are active.",
+      "alignmentText": "Tech meetups, maker spaces, and English-speaking parenting groups meet regularly, though RSVPs fill fast due to venue size.",
       "alignmentValue": 7
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "Lower than Western European peers.",
-      "alignmentValue": 4
+      "alignmentText": "The €820 monthly minimum wage lags urban living costs, so entry-level families rely on subsidies or roommates despite solid enforcement.",
+      "alignmentValue": 5
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "Good roads and fiber in cities though rural areas lag.",
+      "alignmentText": "Cities boast fiber internet, modern hospitals, and updated airports, while rural areas still face slower rail and occasional power blips.",
       "alignmentValue": 7
     },
     {
       "key": "Natural Beauty",
-      "alignmentText": "Historic towns, cliffs, and vineyards offer charm.",
+      "alignmentText": "Weekend drives reach Arrábida cliffs, Douro vineyards, and Azores-like landscapes on Madeira, though popular trails near Sintra need early starts to avoid crowds.",
       "alignmentValue": 8
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Earthquake risk near Lisbon and wildfires in rural areas.",
-      "alignmentValue": 5
+      "alignmentText": "Families plan around rural wildfire evacuations most summers and the remote but high-consequence Lisbon quake scenario, so go-bags and insurance riders are prudent.",
+      "alignmentValue": 6
     },
     {
       "key": "Nature Access",
-      "alignmentText": "Close access to beaches and hiking areas.",
+      "alignmentText": "Within an hour you can reach beaches, Serra de Sintra hikes, or river kayak spots, keeping outdoor days easy even without a car.",
       "alignmentValue": 8
     },
     {
       "key": "Nightlife & Music",
-      "alignmentText": "Vibrant nightlife in Lisbon and Porto.",
+      "alignmentText": "Fado, indie clubs, and summer festivals like NOS Alive bring diverse music scenes without compromising safety.",
       "alignmentValue": 8
     },
     {
       "key": "Nightlife Culture",
-      "alignmentText": "Lisbon/Porto lively (bars, fado, clubs); coastal towns quieter; generally safe; later evenings.",
-      "alignmentValue": 7.0
+      "alignmentText": "Lisbon and Porto keep bars and fado houses open late with safe streets, while coastal towns wind down earlier for family life.",
+      "alignmentValue": 7
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "Events like Lisboa Games Week support the scene.",
+      "alignmentText": "Lisboa Games Week, Polygon community meetups, and Porto Indie Games Showcase provide networking, though events are still annual or quarterly.",
       "alignmentValue": 6
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Miniclip and Lockwood have operations in Lisbon.",
-      "alignmentValue": 6
+      "alignmentText": "Studios like Miniclip Lisbon, Saber, and indie teams (e.g., Nerd Monkeys) anchor the scene, yet Portugal lacks marquee AAA employers.",
+      "alignmentValue": 5
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "StartUP Portugal and EU funds offer support.",
-      "alignmentValue": 7
+      "alignmentText": "StartUP Portugal grants, EU Creative Europe funds, and low operating costs help, but raising venture rounds often means pitching Berlin or London investors.",
+      "alignmentValue": 6
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Laid-back, especially outside major cities.",
+      "alignmentText": "Cafés, evening promenades, and slower bureaucratic tempo deliver the gentler daily rhythm Sarah craves, while Lisbon still offers urban energy.",
       "alignmentValue": 8
     },
     {
       "key": "Parenting Expectations",
-      "alignmentText": "Emphasis on family time and relaxed schedules.",
+      "alignmentText": "Schools and neighbors value close family time and respectful kids, giving flexibility for progressive parenting as long as routines stay structured.",
       "alignmentValue": 7
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Five years residency plus language test.",
+      "alignmentText": "Five years of legal residency plus an A2 Portuguese exam secure citizenship, but applicants budget months for background checks and AIMA interviews.",
       "alignmentValue": 7
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Moderate levels with improvements in recent years.",
+      "alignmentText": "Transparency International scores Portugal mid-pack; bribery is rare day-to-day, yet procurement scandals still break headlines.",
       "alignmentValue": 6
     },
     {
       "key": "Political System",
-      "alignmentText": "Semi-presidential parliamentary republic.",
-      "alignmentValue": 7
+      "alignmentText": "A semi-presidential republic with proportional representation delivers stable coalitions, albeit with occasional corruption scandals to watch.",
+      "alignmentValue": 8
     },
     {
       "key": "Polyamory",
-      "alignmentText": "Limited awareness but tolerant in urban areas.",
+      "alignmentText": "Urban queer circles are broadly tolerant, but poly families remain niche and we’d rely on discreet community groups rather than mainstream acceptance.",
       "alignmentValue": 4
     },
     {
       "key": "Pre-K / Early Childcare Landscape",
-      "alignmentText": "Creche (0–3) increasingly free (national rollout) with public/subsidized places; preschool (3–6) widely available; availability varies by city.",
-      "alignmentValue": 7.0
+      "alignmentText": "The creche network is rolling out universal coverage by 2025, yet popular municipally backed centers in Lisbon still have waitlists that require early registration.",
+      "alignmentValue": 7
     },
     {
       "key": "Private Education",
-      "alignmentText": "Private and international schools in Lisbon/Porto/Algarve; fees moderate vs US; admissions selective at top schools.",
-      "alignmentValue": 6.0
+      "alignmentText": "International and bilingual schools exist in Lisbon, Cascais, and Porto with mid-tier tuition, but admissions are competitive and commutes can grow.",
+      "alignmentValue": 6
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Progressive on social issues including LGBTQ rights.",
+      "alignmentText": "Coalition governments center-left on social policy—legal abortion, LGBTQ+ rights, and drug decriminalization—matching the family’s values.",
       "alignmentValue": 8
     },
     {
       "key": "Propaganda Messaging",
-      "alignmentText": "Public broadcasting focuses on culture and news.",
-      "alignmentValue": 6
+      "alignmentText": "Government campaigns lean on national pride but usually pair it with data on climate goals, public health, and inclusion.",
+      "alignmentValue": 8
     },
     {
       "key": "Propaganda Prevalence",
-      "alignmentText": "Independent media with low state propaganda.",
+      "alignmentText": "Independent press and public broadcaster RTP provide pluralistic coverage, though concentrated media ownership still nudges narratives during elections.",
       "alignmentValue": 8
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Good urban transit and national rail network.",
+      "alignmentText": "Lisbon’s metro, trams, and regional rail work well, but national trains are slower and smaller towns require buses or car shares.",
       "alignmentValue": 7
     },
     {
       "key": "Religion in Politics",
-      "alignmentText": "Secular state with low religious influence.",
-      "alignmentValue": 7
+      "alignmentText": "Church influence stays cultural rather than legislative, so policy debates focus on economics and social welfare.",
+      "alignmentValue": 8
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Popular with digital nomads and remote workers.",
+      "alignmentText": "Portugal leans into remote work with coworking hubs, the digital nomad visa, and time zones compatible with both U.S. coasts, even if some legacy firms still prefer on-site.",
       "alignmentValue": 8
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Temporary residence leading to permanent after five years.",
-      "alignmentValue": 7
-    },
-    {
-      "key": "Retirement (Citizens)",
-      "alignmentText": "State pension via Segurança Social; adequacy depends on career contributions; private savings useful.",
-      "alignmentValue": 6.0
-    },
-    {
-      "key": "Retirement (Immigrants)",
-      "alignmentText": "Non-habitual resident program offers tax benefits.",
-      "alignmentValue": 7
-    },
-    {
-      "key": "Retirement (Visa Holders)",
-      "alignmentText": "Eligibility/portability tied to residence and contributions; treaties may help; private savings recommended.",
-      "alignmentValue": 5.0
-    },
-    {
-      "key": "Ruby Work Prospects",
-      "alignmentText": "Small but active startup community in Lisbon and Porto.",
+      "alignmentText": "Initial residence cards run two years before a three-year renewal, requiring six-month presence per year to stay on track for permanence.",
       "alignmentValue": 6
     },
     {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "State pensions replace a modest share of wages, so most households supplement with employer plans or property.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Portugal’s new targeted tax incentives for incoming retirees are narrower than the old NHR regime, so comfortable retirement leans on private savings or remote income.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Access to Portuguese pensions depends on decade-long contributions, and U.S. Social Security taxation requires bilateral planning.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby shows up in startup and agency stacks around Lisbon, yet openings are sporadic enough that Trey would network with remote-friendly firms or polyglot teams.",
+      "alignmentValue": 5
+    },
+    {
       "key": "Safety & Crime",
-      "alignmentText": "One of Europe's safest countries.",
+      "alignmentText": "Portugal’s low violent-crime rates and visible community policing let kids roam plazas with modest precautions against petty theft.",
       "alignmentValue": 9
     },
     {
       "key": "Schooling Options",
-      "alignmentText": "Decent public schools and international options in Lisbon/Porto.",
+      "alignmentText": "Public schools improved in PISA scores, but bilingual or alternative programs cluster in Lisbon and Porto, so we’d vet neighborhoods carefully.",
       "alignmentValue": 6
     },
     {
       "key": "Seasonal Beach Water Temp",
-      "alignmentText": "Atlantic waters are cooler but warm in southern summer.",
-      "alignmentValue": 6
+      "alignmentText": "Atlantic water stays brisk—Porto averages 16–18 °C (61–64 °F) even in summer—so comfortable swimming is mostly a May–September Algarve treat with short dips elsewhere.",
+      "alignmentValue": 5
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "Mild winters and hot dry summers.",
+      "alignmentText": "Atlantic breezes keep most of the year in a mild 50–80 °F band that suits Sarah’s pace, yet July–August spikes inland still call for AC days or escaping to the coast.",
       "alignmentValue": 8
     },
     {
       "key": "Sex (Attitudes)",
-      "alignmentText": "Generally liberal attitudes toward sexuality.",
+      "alignmentText": "Sex education and public conversations are fairly open, though intimacy norms stay discreet compared with Northern Europe.",
       "alignmentValue": 7
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Progressive on healthcare and LGBTQ rights.",
+      "alignmentText": "Universal healthcare, decriminalized drugs, and gender identity protections reflect a social safety net aligned with the family’s values.",
       "alignmentValue": 8
     },
     {
       "key": "Spring Temperature Range (C/F)",
-      "alignmentText": "Mild; Lisbon/Porto ~12–20 °C (54–68 °F); showers; north cooler, Algarve warmer; increasing sunshine.",
-      "alignmentValue": 8.0
+      "alignmentText": "March–May in Lisbon runs roughly 10–20 °C (50–68 °F) with light rain, giving plenty of park days for the kids while we keep a layer handy for Atlantic breezes.",
+      "alignmentValue": 8
     },
     {
       "key": "Stability",
-      "alignmentText": "Politically stable with low crime.",
+      "alignmentText": "Portugal ranks among Europe’s safest and most peaceful countries, with low political violence and rare large-scale strikes.",
       "alignmentValue": 8
     },
     {
       "key": "State Ideology",
-      "alignmentText": "Social democracy with liberal market.",
+      "alignmentText": "Governments mix social-democratic welfare with pragmatic market reforms, keeping public services in play while courting investment.",
       "alignmentValue": 7
     },
     {
       "key": "State of Capitalism",
-      "alignmentText": "Open market with some state involvement.",
+      "alignmentText": "An open EU market economy with strategic state stakes in energy and transport balances competition with safety nets.",
       "alignmentValue": 7
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "Coasts warm/dry ~22–28 °C (72–82 °F) with sea breeze; interior (Alentejo) can exceed 35 °C (95 °F); humidity moderate on coasts.",
-      "alignmentValue": 6.0
+      "alignmentText": "Coastal highs hover near 27 °C (80 °F) with dry air, but the Alentejo and interior valleys frequently top 35 °C (95 °F), so we’d pick neighborhoods with sea influence or reliable cooling.",
+      "alignmentValue": 6
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Moderate fees but bureaucratic delays common.",
-      "alignmentValue": 5
+      "alignmentText": "Visa fees are modest, but biometrics slots often take 6–12 months and legal help or translation costs add up quickly.",
+      "alignmentValue": 4
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Moderate public trust.",
+      "alignmentText": "Surveys show middling trust after corruption probes, so reforms are ongoing but skepticism remains in daily conversation.",
       "alignmentValue": 6
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Occasional political scandals.",
+      "alignmentText": "Influence flows through party patronage and public-contract favoritism rather than street-level graft, so due diligence on partners matters.",
       "alignmentValue": 6
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Growing tech scene yet wages remain modest.",
-      "alignmentValue": 5
+      "alignmentText": "Senior dev roles in Lisbon average €40–55k, meaning U.S.-style comfort demands remote pay or equity rather than local offers.",
+      "alignmentValue": 4
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Family meals, parks, beaches/trails; shops open weekends; later evening dining; community festivals seasonal.",
-      "alignmentValue": 8.0
+      "alignmentText": "Weekends revolve around park picnics, futebol matches, and festivals, with shops open late so the family can explore without rushing.",
+      "alignmentValue": 8
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "Primary ~09:00–15:30 (varies), secondary ~08:30–17:00; offices ~09:00–18:00 with lunch; ATL/after‑school care common.",
-      "alignmentValue": 7.0
+      "alignmentText": "Primary schools run roughly 09:00–15:30 with ATL after-care, offices default to 09:00–18:00, and a long lunch means parents coordinate pickups or rely on grandparents.",
+      "alignmentValue": 7
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "22 working days plus public holidays.",
+      "alignmentText": "Law guarantees 22 paid days plus holidays, and courts back employees who actually take them, provided notice is planned ahead.",
       "alignmentValue": 7
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Often more time off with tenure.",
-      "alignmentValue": 7
+      "alignmentText": "Tenure or collective agreements frequently lift annual leave to 25–28 days, letting the family schedule U.S. visits and shoulder-season travel.",
+      "alignmentValue": 8
     },
     {
       "key": "View of Neighboring Countries",
-      "alignmentText": "Good relations with Spain and other EU members.",
+      "alignmentText": "Relations with Spain and the wider EU are friendly, with occasional football rivalry jokes more than real friction.",
       "alignmentValue": 7
     },
     {
       "key": "View of self",
-      "alignmentText": "Proud of maritime history and cultural heritage.",
+      "alignmentText": "Portugal leans into its seafaring heritage and resilience after the 2008 crisis, fostering quiet pride rather than nationalism.",
       "alignmentValue": 7
     },
     {
       "key": "View of Them by Neighboring Countries",
-      "alignmentText": "Seen as friendly and relaxed.",
+      "alignmentText": "Portugal is seen as warm, safe, and cooperative, helping expats feel welcome across Schengen travel.",
       "alignmentValue": 8
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "D7 passive income and startup visas popular.",
-      "alignmentValue": 7
+      "alignmentText": "D7, job-seeker, and startup visas provide clear routes, yet documentation demands (income proof, housing leases) and AIMA wait times make early preparation crucial.",
+      "alignmentValue": 6
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Generally welcoming with growing expat communities.",
-      "alignmentValue": 8
+      "alignmentText": "Locals are generally friendly and English-capable, though rising housing pressure in Lisbon means expats are encouraged to show cultural sensitivity.",
+      "alignmentValue": 7
     },
     {
       "key": "What Is Intriguing",
-      "alignmentText": "Affordable coastal living and rich history.",
+      "alignmentText": "Portugal blends Atlantic light, progressive politics, and accessible EU travel—an appealing base for Trey's indie ambitions and the family’s coastal lifestyle.",
       "alignmentValue": 8
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "Mild along coasts ~8–15 °C (46–59 °F); interior cooler; rain/showers; mountain snow in Serra da Estrela.",
-      "alignmentValue": 7.0
+      "alignmentText": "Winters are 8–15 °C (46–59 °F) along the coast—great for playground time—but homes can feel chilly without heat pumps because damp Atlantic rain lingers.",
+      "alignmentValue": 7
     },
     {
       "key": "Work Week Hours",
-      "alignmentText": "Standard 40-hour workweek with regulated overtime.",
+      "alignmentText": "The statutory 40-hour week is enforced, but salaried tech teams often stretch into the evening sprint cycle unless boundaries are negotiated.",
       "alignmentValue": 7
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Relaxed lifestyle with long lunch breaks.",
+      "alignmentText": "Late lunches and protected vacations signal real downtime, though public-sector pace differs from fast-scaling startups.",
       "alignmentValue": 8
     },
     {
       "key": "Workers' Rights",
-      "alignmentText": "Strong labor laws though enforcement varies.",
+      "alignmentText": "Strong unions, collective bargaining, and new remote-work laws help employees, though enforcement is uneven in hospitality and gig roles.",
       "alignmentValue": 7
     }
   ]


### PR DESCRIPTION
## Summary
- add the version 2 marker and recalibrate Portugal’s climate, environment, and seasonal weather scores with updated wildfire, air quality, and sea-level risk context
- rewrite economic, housing, and tech job sections to reflect current salary realities, cost pressures, and remote-work norms for the family
- revise residency, visa, and family policy guidance to capture present-day wait times, compliance steps, and benefits accessibility for citizens and long-term visa holders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e309b955988321a291d8ddc66083b4