### PR TITLE
Refresh Canada report to version 2

### DIFF
--- a/reports/canada_report.json
+++ b/reports/canada_report.json
@@ -1,544 +1,545 @@
 {
+  "version": 2,
   "iso": "CA",
   "values": [
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Strong enterprise adoption provides solid demand.",
+      "alignmentText": "For Trey, enterprise, government, and fintech teams in Toronto, Montreal, and Vancouver keep senior .NET roles open with solid pay, though the best gigs cluster in those hubs.",
       "alignmentValue": 8
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Good overall, though wildfire smoke can occasionally reduce quality.",
-      "alignmentValue": 7
+      "alignmentText": "Trey and Sarah can usually let the kids play outside, but 2023\u201324 wildfire smoke and urban traffic require checking air-quality alerts a few times each summer.",
+      "alignmentValue": 6
     },
     {
       "key": "Atheism",
-      "alignmentText": "Secularism common with broad religious tolerance.",
-      "alignmentValue": 7
+      "alignmentText": "Secular norms dominate public life, letting the family raise the kids without religious pressure even though faith communities stay visible.",
+      "alignmentValue": 8
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Low risk with robust institutions.",
+      "alignmentText": "Canada\u2019s institutions, courts, and media remain resilient, aligning with the family\u2019s demand for a progressive, rights-protecting democracy.",
       "alignmentValue": 8
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "Stable banking with widespread digital payment options.",
+      "alignmentText": "The big-five banks, Interac, and wide contactless adoption make everyday payments smooth for the family, albeit with higher fees than U.S. online banks.",
       "alignmentValue": 8
     },
     {
       "key": "Beach Life",
-      "alignmentText": "Cold-water coasts limit typical beach lifestyle.",
+      "alignmentText": "Cold Pacific and Atlantic water keeps casual beach days rare for the kids, so warm-sand getaways mean summer trips or inland lakes.",
       "alignmentValue": 4
     },
     {
       "key": "Boardgaming & Tabletop",
-      "alignmentText": "Active hobby communities in major cities.",
-      "alignmentValue": 7
+      "alignmentText": "Toronto, Montreal, and Vancouver have thriving board-game cafes and conventions, giving Trey ready-made tabletop communities.",
+      "alignmentValue": 8
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Subsidies exist but availability can be limited.",
-      "alignmentValue": 6
+      "alignmentText": "Federal-provincial $10/day deals lower tuition, yet Sarah would still face waitlists and patchy infant care until the new spaces open.",
+      "alignmentValue": 7
     },
     {
       "key": "Child-Friendliness of Cities",
-      "alignmentText": "Urban centers offer playgrounds, parks, and family services.",
+      "alignmentText": "Most metros weave parks, libraries, and family programming into neighborhoods, though long winters mean planning for indoor play.",
       "alignmentValue": 7
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "Canada Child Benefit (CCB); provincial childcare subsidies; EI maternity/parental leave (up to 12–18 months combined); $10/day rollout.",
-      "alignmentValue": 8.0
+      "alignmentText": "Citizens tap the Canada Child Benefit, long parental leave, and expanding $10/day childcare, making it easier to balance Trey\u2019s startup goals with Sarah\u2019s work.",
+      "alignmentValue": 8
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Eligibility depends on residence/work status and province; many subsidies/leave accessible to work‑permit holders with SIN; documentation required.",
-      "alignmentValue": 7.0
+      "alignmentText": "Work-permit holders with SINs can access parental leave and subsidized care, but the family should plan extra time for paperwork and provincial eligibility checks when they arrive.",
+      "alignmentValue": 7
     },
     {
       "key": "Common Hobbies",
-      "alignmentText": "Outdoor sports, hockey, and winter activities are popular.",
+      "alignmentText": "Outdoor sports, hockey, and creative scenes abound, so the family can plug into year-round community even if winters lean snow-heavy.",
       "alignmentValue": 7
     },
     {
       "key": "Community Vibes",
-      "alignmentText": "Friendly yet reserved; community engagement varies.",
+      "alignmentText": "Canadians are polite and civic-minded; Trey and Sarah will need to lean into school and hobby groups to move past surface-level friendliness.",
       "alignmentValue": 7
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Strict but transparent rules reduce uncertainty.",
+      "alignmentText": "Rules are strict but transparent, meaning the family must stay on top of filings yet benefits from clear guidance and digital portals.",
       "alignmentValue": 7
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "High in urban centers relative to income.",
+      "alignmentText": "Toronto and Vancouver rents plus grocery inflation stretch a mid-six-figure tech income, pushing the family to consider secondary metros or suburban commutes.",
       "alignmentValue": 4
     },
     {
       "key": "Dual Citizenship Allowed",
-      "alignmentText": "Yes—Canada recognizes dual nationality.",
-      "alignmentValue": 9.0
+      "alignmentText": "Canada allows dual citizenship, letting Trey and Sarah retain U.S. passports while securing long-term Canadian rights for the kids.",
+      "alignmentValue": 9
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Stable G7 economy with steady growth and low unemployment.",
+      "alignmentText": "The economy is steady with low unemployment, yet commodity swings and high household debt encourage the family to keep a solid emergency fund.",
       "alignmentValue": 7
     },
     {
       "key": "Economic System",
-      "alignmentText": "Social market system with safety nets.",
+      "alignmentText": "A social-market mix funds healthcare and childcare while maintaining private enterprise, matching the family\u2019s preference for progressive capitalism.",
       "alignmentValue": 7
     },
     {
       "key": "Education",
-      "alignmentText": "Strong public education and respected universities.",
+      "alignmentText": "OECD scores stay strong and French immersion plus STEM magnet options give the kids rigorous paths without private school tuition.",
       "alignmentValue": 8
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Available but requires labor market assessments; moderate difficulty.",
+      "alignmentText": "Employers sponsor via LMIA or Global Talent Stream, but Trey would need standout credentials and patient timelines to secure a work permit.",
       "alignmentValue": 5
     },
     {
       "key": "Environment",
-      "alignmentText": "Vast wilderness and generally clean urban centers align with love of nature.",
+      "alignmentText": "National parks, strict water standards, and recycling culture let the family indulge their love of outdoors, aside from localized oil-sands impacts.",
       "alignmentValue": 8
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "Progressive tax leading to moderate-high rates.",
+      "alignmentText": "Stacked federal and provincial brackets push combined rates near 35-40% on tech incomes, so Trey\u2019s startup budget must include higher payroll taxes.",
       "alignmentValue": 5
     },
     {
       "key": "Fall Temperature Range (C/F)",
-      "alignmentText": "Comfortable shoulder season in many regions: 8–18 °C (46–64 °F); earlier cool in Prairies; storms/hurricanes can affect Atlantic.",
-      "alignmentValue": 7.0
+      "alignmentText": "September stays mild for family hikes, yet fast swings to frost in the Prairies mean the kids need layered wardrobes.",
+      "alignmentValue": 7
     },
     {
       "key": "Family Life",
-      "alignmentText": "Strong social supports and family-centric culture.",
+      "alignmentText": "Family-focused policies, parental leave, and community programs support Sarah\u2019s hunt for balance even if winter hibernation is real.",
       "alignmentValue": 8
     },
     {
       "key": "Family Members",
-      "alignmentText": "Spouses and children can obtain status and benefits.",
+      "alignmentText": "Spouses and dependent children can ride along on most residency streams, easing worries about keeping the household together.",
       "alignmentValue": 8
     },
     {
       "key": "Family Policy (Citizens)",
-      "alignmentText": "Strong mix: EI maternity/parental leave, CCB, provincial top‑ups; flexible work norms improving; varies by province/employer.",
-      "alignmentValue": 8.0
+      "alignmentText": "Citizens enjoy generous leave, universal healthcare, and indexed child benefits\u2014exactly the safety net Sarah asked for.",
+      "alignmentValue": 8
     },
     {
       "key": "Family Policy (Common Family)",
-      "alignmentText": "Parental leave and child benefits support families.",
+      "alignmentText": "Typical families rely on paid leave and subsidized childcare, so Trey and Sarah would see peers modeling the balance they want.",
       "alignmentValue": 8
     },
     {
       "key": "Family Policy (Visa Holders)",
-      "alignmentText": "Many benefits available to residents with contributions; details vary by province/status; employer policies matter.",
-      "alignmentValue": 7.0
+      "alignmentText": "Work-permit families qualify for many supports after meeting residency and contribution rules, so Trey and Sarah get a safety net once they clear province-specific requirements.",
+      "alignmentValue": 7
     },
     {
       "key": "Fashion Trends (Female)",
-      "alignmentText": "Practical chic; layers for seasons; athleisure/minimalist looks common in metros.",
-      "alignmentValue": 6.0
+      "alignmentText": "Urban centers lean toward practical minimalist layers\u2014great for Sarah\u2019s casual tech style, less exciting if she craves bold fashion.",
+      "alignmentValue": 6
     },
     {
       "key": "Fashion Trends (Male)",
-      "alignmentText": "Climate‑driven layering; smart‑casual/athleisure; quality outerwear/boots widely worn.",
-      "alignmentValue": 6.0
+      "alignmentText": "Men\u2019s fashion centers on technical outerwear and smart-casual looks, so Trey blends in with jeans, flannels, and weather-ready jackets.",
+      "alignmentValue": 6
     },
     {
       "key": "Femininity Norms",
-      "alignmentText": "Varied expectations; overall supportive of diverse expressions.",
+      "alignmentText": "Gender expectations are flexible; mothers balance careers and family without heavy social penalty, aligning with Sarah\u2019s goals.",
       "alignmentValue": 7
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Strong industry presence in Montreal and Vancouver.",
+      "alignmentText": "Montreal and Vancouver host AAA studios and mid-size shops, giving Trey a strong hiring market if his indie studio needs a safety net.",
       "alignmentValue": 8
     },
     {
       "key": "Gender Fluidity",
-      "alignmentText": "Recognition and growing acceptance of non-binary identities.",
-      "alignmentValue": 7
+      "alignmentText": "Legal recognition of non-binary markers and inclusive school policies make it easier to raise kids in the sex-positive environment the family values.",
+      "alignmentValue": 8
     },
     {
       "key": "Gender Rights",
-      "alignmentText": "Strong legal protections and parental leave policies.",
+      "alignmentText": "Equal pay laws, reproductive rights, and parental leave are well protected, giving the household confidence their progressive values will be upheld.",
       "alignmentValue": 9
     },
     {
       "key": "Gender Roles",
-      "alignmentText": "Largely egalitarian attitudes toward gender roles.",
+      "alignmentText": "Dual-income households are normal and dads take leave, matching Trey and Sarah\u2019s expectation of shared parenting.",
       "alignmentValue": 8
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "SIN, provincial health coverage (some with waiting periods), private insurance bridge; banking/lease docs; driver licence exchanges vary.",
-      "alignmentValue": 6.0
+      "alignmentText": "The family must navigate SIN applications, provincial health wait periods, and auto insurance rules before feeling fully settled.",
+      "alignmentValue": 6
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Rising wildfires and melting permafrost present moderate climate risks.",
+      "alignmentText": "Wildfires, thawing permafrost, and Atlantic storms are intensifying, so the family needs contingency plans despite strong emergency services.",
       "alignmentValue": 6
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal coverage with generally good outcomes.",
+      "alignmentText": "Universal coverage and good pediatric outcomes align with the family\u2019s priorities, though specialist waits mean planning routine care early.",
       "alignmentValue": 8
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Eligibility varies by province; private insurance may be needed.",
+      "alignmentText": "Temporary residents can join provincial plans after waiting periods, requiring private insurance to bridge coverage for the kids.",
       "alignmentValue": 6
     },
     {
       "key": "Higher Education Access (Citizens)",
-      "alignmentText": "Public universities/colleges with domestic tuition; provincial grants/loans; quality varies; co‑op programs common.",
-      "alignmentValue": 7.0
+      "alignmentText": "Domestic tuition plus RESP incentives keep university accessible for the boys, even if spots in top programs stay competitive.",
+      "alignmentValue": 7
     },
     {
       "key": "Higher Education Access (Visa Holders)",
-      "alignmentText": "International tuition higher; scholarships limited; work‑study/PGWP pathways help longer‑term access.",
-      "alignmentValue": 5.0
+      "alignmentText": "International fees remain steep and aid is limited, so the family would budget extra if the kids enroll before citizenship.",
+      "alignmentValue": 5
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Housing expensive in major cities; better elsewhere.",
+      "alignmentText": "Home prices and rents in major metros bite, pushing Trey and Sarah to weigh smaller cities or longer commutes for a family-sized rental.",
       "alignmentValue": 5
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "PAYE system with annual filing; fairly straightforward.",
+      "alignmentText": "CRA prefilled slips and online filing keep compliance manageable, yet the family will still hire cross-border tax help to reconcile U.S. obligations.",
       "alignmentValue": 6
     },
     {
       "key": "K-12 Education Access (Citizens)",
-      "alignmentText": "Free public schooling; quality varies by province/district; secular curricula with options for French immersion; zoning applies.",
-      "alignmentValue": 8.0
+      "alignmentText": "Free public schools with French immersion, STEM academies, and inclusive policies match the family\u2019s education priorities.",
+      "alignmentValue": 8
     },
     {
       "key": "K-12 Education Access (Visa Holders)",
-      "alignmentText": "Most work/resident visa dependents enroll as domestic; documentation/provincial rules apply; ELL supports common.",
-      "alignmentValue": 8.0
+      "alignmentText": "Dependent kids enroll as domestic students with ESL supports, letting the boys integrate quickly once paperwork clears.",
+      "alignmentValue": 8
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "English is an official language; French widespread in Quebec.",
+      "alignmentText": "English is official nationwide outside Quebec, and even Montreal tech circles function bilingually, easing Trey\u2019s work transitions.",
       "alignmentValue": 9
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Legal protections and strong urban acceptance.",
+      "alignmentText": "Legal protections and vibrant Pride scenes in major cities support the family\u2019s polyamory-positive values, with rural areas more conservative.",
       "alignmentValue": 8
     },
     {
       "key": "Marxism (Societal Attitudes)",
-      "alignmentText": "Limited mainstream interest outside academic circles.",
+      "alignmentText": "Left politics inform policy debates, yet mainstream parties stay centrist, so Trey\u2019s curiosity about socialist experiments is met mostly in academia.",
       "alignmentValue": 5
     },
     {
       "key": "Masculinity Norms",
-      "alignmentText": "Encourages caregiving and emotional openness.",
+      "alignmentText": "Canadian dads take leave and show-up in schools, giving Trey role models for engaged, emotionally open fatherhood.",
       "alignmentValue": 7
     },
     {
       "key": "Meetups & Communities",
-      "alignmentText": "Plentiful tech, gaming, and parenting meetups.",
+      "alignmentText": "Tech, gaming, and parenting meetups crowd Eventbrite in the big metros, helping the family build community quickly.",
       "alignmentValue": 8
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "Provincial rates provide modest earnings relative to cost of living.",
+      "alignmentText": "Provincial minimums hover around CAD $16, trailing metro living costs and signaling to the family that service-sector support workers may struggle without subsidies.",
       "alignmentValue": 6
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "Reliable infrastructure and fast internet nationwide.",
+      "alignmentText": "Gigabit fiber, reliable utilities, and modern transit projects keep cities functional, though rural broadband still lags Trey\u2019s latency needs.",
       "alignmentValue": 8
     },
     {
       "key": "Natural Beauty",
-      "alignmentText": "Mountains, forests, and lakes offer abundant scenic options.",
+      "alignmentText": "Mountains, boreal forests, and coastal parks give the family endless weekend adventures within a short flight or drive.",
       "alignmentValue": 9
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Low earthquake/hurricane risk; wildfire and extreme cold remain concerns.",
+      "alignmentText": "Wildfire evacuations, prairie blizzards, and occasional Atlantic hurricanes mean the family must keep go-bags despite low earthquake risk.",
       "alignmentValue": 6
     },
     {
       "key": "Nature Access",
-      "alignmentText": "Easy access to national parks and wilderness areas.",
+      "alignmentText": "National and provincial parks, urban ravine trails, and lake networks satisfy Trey\u2019s outdoor hobbies and the kids\u2019 need for green space.",
       "alignmentValue": 9
     },
     {
       "key": "Nightlife & Music",
-      "alignmentText": "Vibrant scenes in urban centers with diverse genres.",
+      "alignmentText": "Major metros host indie music, festivals, and late-night venues, giving Trey and Sarah occasional date nights while the kids enjoy all-ages events.",
       "alignmentValue": 7
     },
     {
       "key": "Nightlife Culture",
-      "alignmentText": "Vibrant in Toronto/Montreal/Vancouver; quieter in smaller cities; safety generally good; earlier closing in some provinces.",
-      "alignmentValue": 6.0
+      "alignmentText": "Toronto and Montreal stay lively, but earlier closing times and alcohol rules keep nightlife tamer than New York, fitting the parents\u2019 family-first rhythm.",
+      "alignmentValue": 6
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "Active communities like MIGS support developers.",
+      "alignmentText": "Groups like MIGS, DMG Toronto, and Vancouver\u2019s indie scene give Trey mentorship and co-founder options.",
       "alignmentValue": 8
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Ubisoft, EA, BioWare, and others operate locally.",
+      "alignmentText": "Studios such as Ubisoft, EA Motive, and Behaviour anchor a deep talent pool Trey can tap for collaborators or contract work.",
       "alignmentValue": 9
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Government grants and incubators foster startups.",
+      "alignmentText": "Federal funds, Quebec tax credits, and incubators like Execution Labs make it feasible for Trey to launch an indie studio with local partners.",
       "alignmentValue": 8
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "More relaxed in smaller cities; big-city pace manageable.",
+      "alignmentText": "Mid-sized cities like Ottawa and Halifax offer Sarah the calmer pace she wants, while Toronto\u2019s hustle stays manageable with remote work.",
       "alignmentValue": 7
     },
     {
       "key": "Parenting Expectations",
-      "alignmentText": "Moderate focus on extracurriculars with balanced autonomy.",
+      "alignmentText": "Parents juggle structured activities with free play; the family can choose hockey or coding clubs without judgment for charting a balanced path.",
       "alignmentValue": 6
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Clear path after residency and presence requirements.",
+      "alignmentText": "Three years of residency and language tests set a clear path to passports for the whole family.",
       "alignmentValue": 8
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Low corruption with strong transparency.",
+      "alignmentText": "Transparency International ranks Canada highly, reassuring the family that public funds and services rarely suffer from graft.",
       "alignmentValue": 8
     },
     {
       "key": "Political System",
-      "alignmentText": "Stable parliamentary democracy with rule of law.",
+      "alignmentText": "A parliamentary democracy with strong courts and charter rights aligns with the family\u2019s progressive expectations.",
       "alignmentValue": 8
     },
     {
       "key": "Polyamory",
-      "alignmentText": "Limited social acceptance, though legal risks are low.",
-      "alignmentValue": 4
+      "alignmentText": "Polyamory is legal but low-visibility; urban queer networks are welcoming, yet the family would still curate trusted circles.",
+      "alignmentValue": 5
     },
     {
       "key": "Pre-K / Early Childcare Landscape",
-      "alignmentText": "Rapid expansion via $10/day childcare agreements; mix of centres/home‑based; availability varies; urban waitlists remain.",
-      "alignmentValue": 7.0
+      "alignmentText": "The $10/day expansion is adding spots, but big-city centers keep waitlists, so the family should register early.",
+      "alignmentValue": 7
     },
     {
       "key": "Private Education",
-      "alignmentText": "Available in major cities (secular/religious/international); tuition significant; selective admissions at top schools.",
-      "alignmentValue": 5.0
+      "alignmentText": "Independent schools offer IB and alternative curricula, but tuition is steep, so the family views them as optional backups rather than a must.",
+      "alignmentValue": 5
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Generally progressive policies and social attitudes.",
+      "alignmentText": "Policies on healthcare, LGBTQ rights, and climate action align with Trey and Sarah\u2019s progressive values, even if provincial politics vary.",
       "alignmentValue": 8
     },
     {
       "key": "Propaganda Messaging",
-      "alignmentText": "Focus on national unity and multiculturalism.",
+      "alignmentText": "Government messaging leans on multicultural unity and national pride, but pluralistic media offer counterpoints the family appreciates.",
       "alignmentValue": 6
     },
     {
       "key": "Propaganda Prevalence",
-      "alignmentText": "Moderate; media is largely free but concentrated.",
+      "alignmentText": "Public broadcasters and private conglomerates dominate narratives, yet independent outlets stay accessible so the family can compare perspectives.",
       "alignmentValue": 6
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Robust in large cities, limited in rural areas.",
+      "alignmentText": "Subways and rapid buses in major cities are reliable, but suburbs and smaller metros push the family toward a car for flexibility.",
       "alignmentValue": 6
     },
     {
       "key": "Religion in Politics",
-      "alignmentText": "Low religious influence on governance.",
+      "alignmentText": "Faith groups rarely drive policy, supporting the secular governance the family wants for raising the boys.",
       "alignmentValue": 8
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Remote and hybrid work widely accepted post-pandemic.",
+      "alignmentText": "Hybrid norms persist post-pandemic, and coworking spaces plus time-zone overlap keep Trey and Sarah\u2019s remote work options open.",
       "alignmentValue": 8
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Permanent residency possible within a few years.",
+      "alignmentText": "Express Entry, provincial nominee programs, and study-to-work paths offer multi-year permits, giving the family flexibility if one route stalls.",
       "alignmentValue": 7
     },
     {
       "key": "Retirement (Citizens)",
-      "alignmentText": "CPP/QPP + OAS/GIS; adequacy depends on savings/housing; employer pensions/TFSA/RRSP pillars.",
-      "alignmentValue": 7.0
+      "alignmentText": "CPP/QPP plus OAS provide a stable base, but the family would still build RRSP and TFSA savings to maintain U.S.-level comfort.",
+      "alignmentValue": 7
     },
     {
       "key": "Retirement (Immigrants)",
-      "alignmentText": "Immigrants can participate in public pension after residency.",
+      "alignmentText": "Newcomers qualify for CPP after meeting residency years, so the household builds private savings knowing public pensions alone won\u2019t mirror U.S. income levels.",
       "alignmentValue": 6
     },
     {
       "key": "Retirement (Visa Holders)",
-      "alignmentText": "Eligibility and portability tied to contributions/status; totalization treaties help; private savings advisable.",
-      "alignmentValue": 5.0
+      "alignmentText": "Work permits grant access to CPP with contributions, but portability and benefits end if status lapses, prompting the family to maintain RRSPs and U.S. accounts.",
+      "alignmentValue": 5
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Moderate demand with pockets in startups.",
+      "alignmentText": "Ruby roles exist in startups and consultancies, yet Trey would rely on networking or remote U.S. clients for steady work.",
       "alignmentValue": 6
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Relatively low crime rates and safe streets.",
+      "alignmentText": "Violent crime rates are low and neighborhoods feel safe for the kids, though big cities still see property crime spikes.",
       "alignmentValue": 8
     },
     {
       "key": "Schooling Options",
-      "alignmentText": "High-quality public schools with French immersion and alternative programs.",
+      "alignmentText": "Public, French immersion, and alternative programs let the family tailor education without leaving secular schools.",
       "alignmentValue": 8
     },
     {
       "key": "Seasonal Beach Water Temp",
-      "alignmentText": "Comfortable swimming mostly in mid-summer southern regions.",
+      "alignmentText": "Even peak summer keeps ocean temps chilly, so the boys would mostly wade or wear wetsuits outside brief warm spells.",
       "alignmentValue": 4
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "Cold winters and warm summers; lacks mild climate preference.",
+      "alignmentText": "Lovely summers trade off with long winters and soggy shoulder seasons, challenging Sarah\u2019s desire for a mild climate.",
       "alignmentValue": 5
     },
     {
       "key": "Sex (Attitudes)",
-      "alignmentText": "Relatively open with comprehensive sex education.",
-      "alignmentValue": 7
+      "alignmentText": "Comprehensive sex education and queer-inclusive spaces make it easier to live the family\u2019s sex-positive values.",
+      "alignmentValue": 8
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Progressive on healthcare, education, and LGBTQ rights.",
+      "alignmentText": "Universal healthcare, child benefits, and progressive labor laws deliver the social contract Trey and Sarah want while raising the boys.",
       "alignmentValue": 8
     },
     {
       "key": "Spring Temperature Range (C/F)",
-      "alignmentText": "Regional: West Coast mild ~8–15 °C (46–59 °F); Prairies/Central cool; variable rain; snow melt/flood risk in some areas.",
-      "alignmentValue": 7.0
+      "alignmentText": "Spring oscillates between thaw and late snow, so the family keeps boots and rain gear ready for school runs.",
+      "alignmentValue": 6
     },
     {
       "key": "Stability",
-      "alignmentText": "High political and economic stability.",
+      "alignmentText": "Political and economic stability is high, keeping immigration policies and social services predictable for the family.",
       "alignmentValue": 8
     },
     {
       "key": "State Ideology",
-      "alignmentText": "Mixed economy combining capitalism with social welfare.",
+      "alignmentText": "Canada blends market economics with social welfare, aligning with Trey\u2019s preference for regulated capitalism.",
       "alignmentValue": 7
     },
     {
       "key": "State of Capitalism",
-      "alignmentText": "Regulated capitalism supporting SMEs.",
+      "alignmentText": "The system favors regulated markets with SME supports, so Trey can pursue entrepreneurship without extreme inequality concerns.",
       "alignmentValue": 7
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "Many regions warm/hot: 20–30 °C (68–86 °F); humid in Central/East; dry/hot spells West/Prairies; wildfire smoke episodic.",
-      "alignmentValue": 4.0
+      "alignmentText": "Most metros hit 30-33 \u00b0C with humidity and occasional wildfire smoke, so the family leans on AC and indoor play during peak weeks.",
+      "alignmentValue": 6
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Processing times moderate; fees manageable.",
+      "alignmentText": "Express Entry fees are reasonable, but biometrics and medicals add time, so the family should budget 12-18 months for PR.",
       "alignmentValue": 6
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Moderate to high public trust in institutions.",
+      "alignmentText": "Surveys show moderate-to-high trust in institutions, reinforcing the family\u2019s desire for dependable governance.",
       "alignmentValue": 7
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Occasional political scandals rather than systemic issues.",
+      "alignmentText": "Corruption surfaces as isolated patronage or procurement issues, which gives the family confidence they won\u2019t need insider favors to access services.",
       "alignmentValue": 7
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Competitive salaries in major tech hubs like Toronto and Vancouver.",
-      "alignmentValue": 8
+      "alignmentText": "Salaries in Toronto and Vancouver support a middle-class lifestyle, but lag Bay Area pay, nudging Trey to blend local work with remote contracts.",
+      "alignmentValue": 7
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Outdoors, sports, errands; most retail open weekends; winter activities (skating/ski) widespread; family focus common.",
-      "alignmentValue": 7.0
+      "alignmentText": "Weekends revolve around skating, hiking, and errands, with most retail open\u2014solid for a family balancing outdoors and community events.",
+      "alignmentValue": 7
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "Schools typically ~08:30–15:00; offices ~08:30–17:00; after‑school programs common to ~18:00; commute varies by metro.",
-      "alignmentValue": 7.0
+      "alignmentText": "Schools run roughly 8:30\u20133:00 and offices 8:30\u20135:00, so the family leans on after-school programs until parents log off remote shifts.",
+      "alignmentValue": 7
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Two weeks statutory leave plus public holidays.",
+      "alignmentText": "Statutory leave is two weeks plus holidays, requiring Trey to negotiate extra time for U.S. family visits.",
       "alignmentValue": 5
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Many tech roles offer three to four weeks annually.",
+      "alignmentText": "Tech employers often grant three to four weeks, which helps Sarah guard downtime but still trails European norms.",
       "alignmentValue": 6
     },
     {
       "key": "View of Neighboring Countries",
-      "alignmentText": "Generally positive toward the U.S. with pragmatic caution.",
+      "alignmentText": "Canadians view the U.S. as a vital partner with cautious critiques, so the family can discuss politics openly without hostility.",
       "alignmentValue": 6
     },
     {
       "key": "View of self",
-      "alignmentText": "Often see themselves as polite and inclusive.",
+      "alignmentText": "Canadians embrace an inclusive, polite national identity, matching the family\u2019s desire for collaborative communities.",
       "alignmentValue": 7
     },
     {
       "key": "View of Them by Neighboring Countries",
-      "alignmentText": "Viewed favorably for stability and friendliness.",
+      "alignmentText": "Neighboring countries generally see Canada as friendly and reliable, which helps Trey when pitching cross-border clients.",
       "alignmentValue": 7
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Multiple immigration streams including Express Entry.",
+      "alignmentText": "Express Entry, provincial nominations, and Start-up visas give the family multiple routes, though each demands meticulous documentation and proof of funds.",
       "alignmentValue": 7
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Generally welcoming with cultural similarities.",
+      "alignmentText": "Shared culture and existing American expats mean the family fits in quickly, though housing competition is stiff.",
       "alignmentValue": 7
     },
     {
       "key": "What Is Intriguing",
-      "alignmentText": "Multicultural society and access to outdoor adventure.",
+      "alignmentText": "A progressive society with strong outdoor culture lets the family mix civic engagement with wilderness adventures.",
       "alignmentValue": 8
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "Long/cold in much of country: often −20–0 °C (−4–32 °F); coastal BC milder 0–8 °C; snow/ice common outside coastal pockets.",
-      "alignmentValue": 3.0
+      "alignmentText": "Much of Canada spends months below freezing with heavy snow, so the family must invest in gear and accept long indoor stretches.",
+      "alignmentValue": 3
     },
     {
       "key": "Work Week Hours",
-      "alignmentText": "Standard 40-hour work week with overtime protections.",
+      "alignmentText": "Standard 40-hour expectations persist, with occasional crunch in tech; Trey and Sarah can guard evenings by negotiating boundaries.",
       "alignmentValue": 7
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Generally good boundaries, especially outside major cities.",
+      "alignmentText": "Canadian employers respect boundaries more than U.S. counterparts, letting the family schedule dinners and bedtime routines even when tech projects peak.",
       "alignmentValue": 7
     },
     {
       "key": "Workers' Rights",
-      "alignmentText": "Strong protections and union presence.",
+      "alignmentText": "Strong labor laws, paid leave, and union coverage support the family\u2019s need for stability and predictable schedules.",
       "alignmentValue": 8
     }
   ]


### PR DESCRIPTION
## Summary
- mark the Canada country report as version 2 and rewrite each alignment note to connect back to the family profile
- recalibrate major alignment values, including climate risk, childcare affordability, and software salary expectations, to match the rating guides
- highlight Canada’s game-dev ecosystem, immigration supports, and social policies in language tailored to Trey and Sarah

## Testing
- python - <<'PY'
import json
with open('reports/canada_report.json') as f:
    json.load(f)
print('ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_68e30f67478083218781788972e413a0