### PR TITLE
Refresh Austria climate and social metrics for version 2

### DIFF
--- a/reports/austria_report.json
+++ b/reports/austria_report.json
@@ -1,30 +1,31 @@
 {
+  "version": 2,
   "iso": "AT",
   "values": [
     {
       "key": "Environment",
-      "alignmentText": "Austria pairs strict EU environmental rules with abundant alpine forests, lakes, and city green belts, giving an outdoorsy family clean air and walkable parks right in Vienna or Graz.",
-      "alignmentValue": 8
+      "alignmentText": "Strict EU protections keep over half the country forested and rivers swimmable, so the family gets clean urban parks and quick alpine escapes without worrying about pollution.",
+      "alignmentValue": 9
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Alpine glaciers are shrinking and heatwaves have increased since 2018, yet Vienna sits inland with robust flood defenses, keeping near-term climate risk moderate compared with coastal countries.",
-      "alignmentValue": 6
-    },
-    {
-      "key": "Seasonal Weather",
-      "alignmentText": "Central European seasons mean mild springs and falls, warm (occasionally hot) summers, and winters that are cool and gray rather than brutally cold—still a step gentler than Kansas City swings.",
-      "alignmentValue": 6
-    },
-    {
-      "key": "Air Quality",
-      "alignmentText": "Most cities meet EU PM2.5 targets; inversions in alpine valleys bring winter wood-smoke spikes, but Vienna’s monitoring and low-emission zones keep routine exposure low for kids.",
+      "alignmentText": "Heatwaves and glacier melt are intensifying, yet Vienna's inland setting, funded flood works, and national adaptation plans keep climate shocks manageable for the coming decades.",
       "alignmentValue": 7
     },
     {
+      "key": "Seasonal Weather",
+      "alignmentText": "Springs and autumns stay mild, summers warm without Midwestern humidity, and winters are cold but gentler than Kansas City swings, so routines mostly call for good seasonal gear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Vienna and Graz average about 12 µg/m³ PM2.5 with low-emission zones, and even winter inversion days clear quickly, letting the kids play outside with minimal filtration worries.",
+      "alignmentValue": 8
+    },
+    {
       "key": "Natural Disasters",
-      "alignmentText": "Major quakes and hurricanes are absent; the main hazards are alpine avalanches and Danube flooding, both managed with warning systems and infrastructure the family can plan around.",
-      "alignmentValue": 6
+      "alignmentText": "Flood defenses on the Danube and alpine avalanche controls make major disasters rare; preparedness mainly means heeding seasonal alerts rather than bracing for life-altering storms.",
+      "alignmentValue": 8
     },
     {
       "key": "Spring Temperature Range (C/F)",
@@ -33,18 +34,18 @@
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "June–August sees 15–27°C (59–81°F) highs with occasional 32°C (90°F) heatwaves; lakes and shaded streets offer relief but humid spikes are possible.",
-      "alignmentValue": 6
+      "alignmentText": "June–August highs around 27–29°C (81–84°F) with cool nights let the family rely on fans, with only a few humid spikes sending everyone to the lakes.",
+      "alignmentValue": 8
     },
     {
       "key": "Fall Temperature Range (C/F)",
-      "alignmentText": "September–November typically runs 8–18°C (46–64°F) with crisp mornings, colorful vineyards, and some fog in valleys—good sweater weather.",
-      "alignmentValue": 7
+      "alignmentText": "Autumn sits near 10–18°C (50–64°F); occasional foggy mornings require layers, but most weekends stay perfect for vineyard hikes and park time.",
+      "alignmentValue": 8
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "December–February averages −2 to 5°C (28–41°F); snow shows up but rarely piles above knee height in cities, though skies stay gray.",
-      "alignmentValue": 6
+      "alignmentText": "Vienna winters hover from −1 to 5°C (30–41°F) with reliable snow clearing, so proper coats and boots suffice without brutal deep freezes.",
+      "alignmentValue": 8
     },
     {
       "key": "Beach Life",
@@ -63,8 +64,8 @@
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "No statutory minimum wage exists, yet collective agreements set most tech salaries well above living wage levels, giving some security with a bureaucratic learning curve.",
-      "alignmentValue": 5
+      "alignmentText": "Austria lacks a single legal floor, yet sector collective agreements set tech wages well above living-cost benchmarks, giving newcomers dependable entry pay once they navigate union paperwork.",
+      "alignmentValue": 7
     },
     {
       "key": "Typical Software Salaries",
@@ -103,13 +104,13 @@
     },
     {
       "key": "Work Week Hours",
-      "alignmentText": "Standard contracts run 38.5 hours with overtime premium; crunch culture is rare outside peak project pushes.",
-      "alignmentValue": 7
+      "alignmentText": "Collective agreements hold most contracts to 38–39 hours with tracked overtime, letting Sarah safeguard family evenings even during crunches.",
+      "alignmentValue": 8
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Employees receive at least 25 paid days plus about 13 public holidays, giving ample downtime for family travel.",
-      "alignmentValue": 9
+      "alignmentText": "Five statutory weeks (25 days) of paid leave become six after long service, so Trey and Sarah can plan U.S. visits knowing the time is protected.",
+      "alignmentValue": 8
     },
     {
       "key": "Vacation Days (Typical)",
@@ -238,8 +239,8 @@
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "Urban Austrians speak solid English, yet bureaucracy, schools, and social integration expect German—making language study a must.",
-      "alignmentValue": 6
+      "alignmentText": "City life runs smoothly in English for work and daily errands, but government offices and lasting community ties still push the family toward steady German study.",
+      "alignmentValue": 7
     },
     {
       "key": "Progressivism",
@@ -258,13 +259,13 @@
     },
     {
       "key": "Sex (Attitudes)",
-      "alignmentText": "Sex education is comprehensive, but public attitudes remain more reserved than in Scandinavia, so open non-monogamy may stay discreet.",
-      "alignmentValue": 5
+      "alignmentText": "Urban Austria is comfortable discussing consent and comprehensive sex ed, yet Catholic roots keep frank conversations patchy outside the big cities.",
+      "alignmentValue": 7
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Same-sex marriage and anti-discrimination laws are in place, with Vienna Pride drawing large crowds, yet rural regions can feel cautious.",
-      "alignmentValue": 6
+      "alignmentText": "Equal marriage and anti-discrimination laws are in place, and Vienna's queer scene is vibrant, though rural regions remain more cautious about openly poly or LGBTQ+ families.",
+      "alignmentValue": 7
     },
     {
       "key": "Community Vibes",
@@ -363,13 +364,13 @@
     },
     {
       "key": "Propaganda Prevalence",
-      "alignmentText": "A public broadcaster and diverse press keep narratives plural, though tabloids like Kronen Zeitung can sensationalize politics.",
-      "alignmentValue": 7
+      "alignmentText": "Independent outlets and the ORF watchdog culture challenge spin quickly, so nationalistic narratives surface mainly during campaign seasons.",
+      "alignmentValue": 8
     },
     {
       "key": "Propaganda Messaging",
-      "alignmentText": "Government messaging emphasizes social cohesion and neutrality; immigration rhetoric can swing hard during elections, so media literacy remains useful.",
-      "alignmentValue": 6
+      "alignmentText": "Government communication usually stresses social partnership and pragmatic fixes, with patriotic framing appearing but rarely turning into hostile us-versus-them rhetoric.",
+      "alignmentValue": 8
     },
     {
       "key": "Social Policies",


### PR DESCRIPTION
## Summary
- mark the Austria country report as version 2 and recalibrate environmental, climate-risk, and seasonal weather scores per the guides
- update labor protections, leave allowances, and language expectations so alignment values reflect collective agreements and daily integration needs
- refresh social tolerance and media environment notes to document LGBTQ+ acceptance and limited propaganda spin

## Testing
- jq empty reports/austria_report.json

------
https://chatgpt.com/codex/tasks/task_e_68e30fe9d18c8321a3c00521cc321595