### PR TITLE
Update New Zealand report to version 2

### DIFF
--- a/reports/new_zealand_report.json
+++ b/reports/new_zealand_report.json
@@ -1,544 +1,545 @@
 {
+  "version": 2,
   "iso": "NZ",
   "values": [
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Common in enterprise though market is limited.",
+      "alignmentText": "Auckland and Wellington keep a steady stream of government and enterprise .NET contracts, but the market is small enough that Trey would need to weave in remote clients between local engagements.",
       "alignmentValue": 6
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Generally excellent air quality.",
-      "alignmentValue": 9
-    },
-    {
-      "key": "Atheism",
-      "alignmentText": "Secular society with low religious adherence.",
+      "alignmentText": "Most urban areas average around 7 µg/m³ PM2.5 so the kids can play outside freely, yet winter wood-smoke inversions in Christchurch or Nelson mean we would keep a purifier handy for sensitive days.",
       "alignmentValue": 8
     },
     {
+      "key": "Atheism",
+      "alignmentText": "Nearly half the population reports no religion, letting Sarah and Trey raise the boys secularly with only occasional Christian defaults in school ceremonies to navigate.",
+      "alignmentValue": 9
+    },
+    {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Very low; robust institutions.",
+      "alignmentText": "Independent courts, MMP elections, and watchdog media keep democratic scores in the global top tier, aligning with the family’s demand for resilient institutions.",
       "alignmentValue": 9
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "Modern online banking and EFTPOS widely used.",
+      "alignmentText": "Contactless EFTPOS and instant bank-to-bank transfers make day-to-day spending effortless, though cross-border fees stay high enough that we would maintain a US fintech account for savings moves.",
       "alignmentValue": 8
     },
     {
       "key": "Beach Life",
-      "alignmentText": "Abundant beaches with good water quality.",
+      "alignmentText": "Coastal cities give the family easy beach access for weekend play, yet cooler Pacific water and strong UV push us toward wetsuits and vigilant sun care.",
       "alignmentValue": 8
     },
     {
       "key": "Boardgaming & Tabletop",
-      "alignmentText": "Growing hobby communities in cities.",
-      "alignmentValue": 6
+      "alignmentText": "Auckland’s board-game cafés and Wellington meetups give Trey outlets, but finding regular tables outside the main metros still takes proactive planning.",
+      "alignmentValue": 7
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Subsidies available but limited spaces in cities.",
+      "alignmentText": "Subsidies exist yet long waitlists in Auckland mean Sarah and Trey would juggle paid care with neighbor networks to cover full-time work.",
       "alignmentValue": 6
     },
     {
       "key": "Child-Friendliness of Cities",
-      "alignmentText": "Parks and playgrounds widely available.",
+      "alignmentText": "Compact neighborhoods, plentiful playgrounds, and low violent crime let the boys range independently while we monitor traffic in older suburbs.",
       "alignmentValue": 8
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "20 Hours ECE universal (3–5); Childcare Subsidy and Best Start payments based on income/age; paid parental leave up to 26 weeks.",
-      "alignmentValue": 8.0
+      "alignmentText": "20 Hours ECE and Best Start payments trim preschool costs for citizens, but infants still run NZ$350+ per week so families budget carefully until school age.",
+      "alignmentValue": 7
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "20 Hours ECE typically available regardless of citizenship; income‑based subsidies generally for residents/citizens; documentation needed.",
-      "alignmentValue": 6.0
+      "alignmentText": "Temporary visa households access the 20 Hours ECE program, yet most income-tested subsidies stay off-limits, leaving higher out-of-pocket care costs.",
+      "alignmentValue": 5
     },
     {
       "key": "Common Hobbies",
-      "alignmentText": "Hiking, rugby, and water sports.",
+      "alignmentText": "Weekend tramping clubs, bouldering gyms, and vibrant indie game scenes give both adults plenty of outlets, with rugby culture easy to join as casual fans.",
       "alignmentValue": 8
     },
     {
       "key": "Community Vibes",
-      "alignmentText": "Welcoming with strong local communities.",
+      "alignmentText": "Kiwi neighborliness and active parent-teacher groups make it simple to build a community net, even if newcomers need to show up consistently at first.",
       "alignmentValue": 8
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Must meet income and health requirements.",
+      "alignmentText": "Accredited Employer and Skilled Migrant visas spell out income and health hurdles, but shifting annual salary bands mean we must track policy updates to stay compliant.",
       "alignmentValue": 6
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "High in cities due to housing; moderate elsewhere.",
+      "alignmentText": "Groceries, power, and childcare in Auckland or Wellington run 20–30% above US averages, so the family would trade a smaller home or move to secondary cities to balance the budget.",
       "alignmentValue": 5
     },
     {
       "key": "Dual Citizenship Allowed",
-      "alignmentText": "Yes—dual nationality is allowed.",
-      "alignmentValue": 9.0
+      "alignmentText": "New Zealand allows dual nationality, letting the family keep US passports while naturalizing once residency requirements are met.",
+      "alignmentValue": 9
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Stable economy reliant on agriculture and services.",
-      "alignmentValue": 7
+      "alignmentText": "The economy is stable but sluggish after 2023’s technical recession, with high interest rates tempering hiring in tech and construction.",
+      "alignmentValue": 6
     },
     {
       "key": "Economic System",
-      "alignmentText": "Mixed economy with strong agriculture sector.",
+      "alignmentText": "A liberal market economy with strong agricultural exports coexists with targeted social programs, matching the family’s comfort with regulated capitalism.",
       "alignmentValue": 7
     },
     {
       "key": "Education",
-      "alignmentText": "High literacy and innovative curriculum.",
-      "alignmentValue": 8
+      "alignmentText": "Curriculum refreshes keep classrooms student-centered, yet falling PISA math scores mean we would supplement with home resources for the boys.",
+      "alignmentValue": 7
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Possible via skilled migrant program but subject to quotas.",
+      "alignmentText": "Employer sponsorship hinges on accredited companies and high salary thresholds, so Trey would target a short list of larger firms or remote-first roles.",
       "alignmentValue": 5
     },
     {
       "key": "Environment",
-      "alignmentText": "Pristine landscapes and low pollution levels.",
-      "alignmentValue": 9
+      "alignmentText": "Dramatic landscapes and low particulate pollution align with the family’s love of nature, even though dairying runoff and invasive species strain rivers and biodiversity.",
+      "alignmentValue": 8
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "Moderate income taxes and GST.",
+      "alignmentText": "Progressive brackets and 15% GST put the household near a 30–33% effective rate, comparable to Seattle but without US deductions.",
       "alignmentValue": 6
     },
     {
       "key": "Fall Temperature Range (C/F)",
-      "alignmentText": "Mild; North ~14–20 °C (57–68 °F), South cooler; more fronts/rain; daylight shortens.",
-      "alignmentValue": 8.0
+      "alignmentText": "Autumn days hover near 14–20 °C (57–68 °F) in the North Island, which suits Sarah’s mild-climate preference while the South Island brings cooler rain fronts.",
+      "alignmentValue": 8
     },
     {
       "key": "Family Life",
-      "alignmentText": "Safe, family-oriented society.",
+      "alignmentText": "Family-friendly work policies and safe neighborhoods support the boys’ routines, though relatives will be far away for backup care.",
       "alignmentValue": 8
     },
     {
       "key": "Family Members",
-      "alignmentText": "Partners and children can be included with work rights.",
+      "alignmentText": "Partner and dependent visas arrive with open work rights, keeping both adults employed once the main applicant qualifies.",
       "alignmentValue": 8
     },
     {
       "key": "Family Policy (Citizens)",
-      "alignmentText": "Paid parental leave up to 26 weeks; Working for Families tax credits; Best Start for newborns; flexible work rights.",
-      "alignmentValue": 8.0
+      "alignmentText": "Citizens receive 26 weeks of paid parental leave, Working for Families tax credits, and flexible work rights, covering much of the family’s desired safety net.",
+      "alignmentValue": 8
     },
     {
       "key": "Family Policy (Common Family)",
-      "alignmentText": "Supports nuclear and blended families.",
+      "alignmentText": "Policy defaults assume a two-parent household, yet flexible leave and shared-care arrangements support blended or nontraditional families reasonably well.",
       "alignmentValue": 7
     },
     {
       "key": "Family Policy (Visa Holders)",
-      "alignmentText": "Eligibility varies by visa/residence; many cash benefits require residence; core employment rights apply; ACC covers accidents.",
-      "alignmentValue": 6.0
+      "alignmentText": "Many cash benefits require residence or citizenship, so newcomers lean on employer policies and universal health coverage until status upgrades.",
+      "alignmentValue": 5
     },
     {
       "key": "Fashion Trends (Female)",
-      "alignmentText": "Casual/practical; knits/denim/dresses with layers; weatherproof outerwear; minimalist to sporty.",
-      "alignmentValue": 7.0
+      "alignmentText": "Women’s style centers on practical layers, rain shells, and casual dresses, so Sarah can blend in without overhauling her wardrobe.",
+      "alignmentValue": 7
     },
     {
       "key": "Fashion Trends (Male)",
-      "alignmentText": "Casual/outdoors‑oriented; weatherproof layers, sneakers/boots; smart‑casual in cities.",
-      "alignmentValue": 7.0
+      "alignmentText": "Men favor smart-casual layers and weatherproof gear, matching Trey’s existing mix of tech hoodies and outdoor wear.",
+      "alignmentValue": 7
     },
     {
       "key": "Femininity Norms",
-      "alignmentText": "Relaxed and varied expression.",
+      "alignmentText": "Gender expression is relaxed, with workplace norms supporting women in leadership and dads taking leave, which aligns with the family’s progressive stance.",
       "alignmentValue": 8
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Small but growing industry with Weta and indie studios.",
+      "alignmentText": "Studios like Wētā Workshop, Grinding Gear, and PikPok sustain a modest industry, so Trey could find opportunities but should expect limited senior openings.",
       "alignmentValue": 6
     },
     {
       "key": "Gender Fluidity",
-      "alignmentText": "Legal recognition and social support present.",
+      "alignmentText": "Legal recognition of gender diversity and community support in major cities give the boys exposure to inclusive norms from an early age.",
       "alignmentValue": 8
     },
     {
       "key": "Gender Rights",
-      "alignmentText": "Strong protections and parental leave policies.",
+      "alignmentText": "Equal pay audits, legal abortion access, and high female political representation deliver the protections the family expects.",
       "alignmentValue": 9
     },
     {
       "key": "Gender Roles",
-      "alignmentText": "Progressive with high female workforce participation.",
+      "alignmentText": "Dual-income households and normalized paternal leave help Trey and Sarah share caregiving without stigma.",
       "alignmentValue": 8
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "IRD number, bank account setup; public healthcare for residents, private cover for temps; tenancy/consumer protections; driver licence conversion.",
-      "alignmentValue": 7.0
+      "alignmentText": "New arrivals need IRD numbers, private insurance during the first two years, and proof of tenancy for schools, all manageable with upfront paperwork.",
+      "alignmentValue": 7
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Rising sea levels and storms threaten coastal areas.",
+      "alignmentText": "Sea-level rise threatens low-lying suburbs and stronger cyclones like Gabrielle show up every few years, so we would avoid coastal housing.",
       "alignmentValue": 6
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Public system with low cost and good quality.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Access after residency; interim private insurance.",
+      "alignmentText": "Public care is universal but specialist waitlists stretch months, meaning we’d keep private insurance for faster pediatric visits.",
       "alignmentValue": 7
     },
     {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Work visas of two years or more unlock public care, yet shorter stays require private coverage and upfront GP fees.",
+      "alignmentValue": 6
+    },
+    {
       "key": "Higher Education Access (Citizens)",
-      "alignmentText": "Domestic fees; student loans/allowances; some fee‑free policies (evolving); universities in Auckland/Wellington/Christchurch/Dunedin.",
-      "alignmentValue": 8.0
+      "alignmentText": "Universities in Auckland, Wellington, Christchurch, and Dunedin are accessible with student loans, though tuition and housing costs push families to plan early savings.",
+      "alignmentValue": 7
     },
     {
       "key": "Higher Education Access (Visa Holders)",
-      "alignmentText": "International tuition for most temporary visas; scholarships limited; pathways improve with residence/PR.",
-      "alignmentValue": 5.0
+      "alignmentText": "International tuition stays high until residency, so the boys would need scholarships or PR before tertiary study becomes affordable.",
+      "alignmentValue": 4
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "High prices in Auckland; more affordable elsewhere.",
-      "alignmentValue": 5
+      "alignmentText": "Tight rental markets, aging insulation, and frequent bidding wars in Auckland mean the family either pays premium rents or targets smaller regional cities.",
+      "alignmentValue": 4
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "PAYE system makes filings simple.",
+      "alignmentText": "PAYE withholding, prefilled returns, and the myIR portal keep compliance simple once we register for IRD numbers.",
       "alignmentValue": 8
     },
     {
       "key": "K-12 Education Access (Citizens)",
-      "alignmentText": "State and state‑integrated schools widely available; zoning applies; low or no tuition; secular options present alongside integrated religious schools.",
-      "alignmentValue": 8.0
+      "alignmentText": "State schools are free and zoned, but quality varies by decile so we’d choose housing carefully to land in strong catchments.",
+      "alignmentValue": 7
     },
     {
       "key": "K-12 Education Access (Visa Holders)",
-      "alignmentText": "Children of work/resident visa holders often treated as domestic students; others pay international fees; ESOL support available.",
-      "alignmentValue": 7.0
+      "alignmentText": "Children on work or resident visas attend public schools as domestic students, yet temporary visas under two years face international fees.",
+      "alignmentValue": 6
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "English is primary; Maori also official.",
+      "alignmentText": "English dominates everyday life while Te Reo Māori signage adds bilingual flair without impeding the family’s integration.",
       "alignmentValue": 9
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Inclusive laws and social acceptance.",
+      "alignmentText": "Marriage equality, adoption rights, and visible Pride events keep the social climate welcoming for a polyamory-positive household.",
       "alignmentValue": 9
     },
     {
       "key": "Marxism (Societal Attitudes)",
-      "alignmentText": "Market-oriented with strong social welfare.",
+      "alignmentText": "Politics lean centrist with active labor parties, yet pro-market consensus means overt socialist policies remain niche.",
       "alignmentValue": 6
     },
     {
       "key": "Masculinity Norms",
-      "alignmentText": "Encourages balance of work and family.",
+      "alignmentText": "Workplaces encourage men to take parental leave and share caregiving, aligning with Trey’s parenting style.",
       "alignmentValue": 8
     },
     {
       "key": "Meetups & Communities",
-      "alignmentText": "Active meetup groups across interests.",
+      "alignmentText": "Tech, parenting, and board-game meetups run regularly in big cities, but smaller towns rely on Facebook groups to self-organize.",
       "alignmentValue": 7
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "Relatively high national minimum wage.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Modernity & Infrastructure",
-      "alignmentText": "Reliable infrastructure though rural broadband lags.",
+      "alignmentText": "The NZ$23.15 minimum wage tracks living costs reasonably well yet still lags the Living Wage, so service workers often need dual incomes.",
       "alignmentValue": 7
     },
     {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fiber broadband and modern airports serve the metros, but aging water pipes and limited intercity rail create periodic disruptions.",
+      "alignmentValue": 6
+    },
+    {
       "key": "Natural Beauty",
-      "alignmentText": "Spectacular mountains, fjords, and forests.",
+      "alignmentText": "Glaciers, fjords, and geothermal parks put world-class scenery within a few hours of any city, matching the family’s love of the outdoors.",
       "alignmentValue": 10
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Earthquake risk in Wellington and Christchurch plus occasional cyclones.",
-      "alignmentValue": 5
+      "alignmentText": "Seismic faults, volcanic zones, and severe storms like Cyclone Gabrielle make emergency kits and earthquake insurance non-negotiable.",
+      "alignmentValue": 4
     },
     {
       "key": "Nature Access",
-      "alignmentText": "World-class access to nature within short drives.",
+      "alignmentText": "Regional parks, Great Walks, and surf breaks are close enough for regular family adventures without long drives.",
       "alignmentValue": 10
     },
     {
       "key": "Nightlife & Music",
-      "alignmentText": "Modest scenes centered in Auckland and Wellington.",
+      "alignmentText": "Auckland and Wellington host lively live-music circuits, yet smaller cities wind down early so date nights take planning.",
       "alignmentValue": 6
     },
     {
       "key": "Nightlife Culture",
-      "alignmentText": "Auckland/Wellington vibrant; smaller cities quieter; generally safe; earlier nights than large metros.",
-      "alignmentValue": 7.0
+      "alignmentText": "Metros stay open late with safe late-night transit, while regional towns quiet after midnight, which fits the family’s low-key habits.",
+      "alignmentValue": 7
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "Events like NZGDC foster collaboration.",
+      "alignmentText": "NZGDA meetups and the annual NZGDC give Trey access to peers, though events remain concentrated in Auckland and Wellington.",
       "alignmentValue": 7
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Grinding Gear Games and Rocketwerkz are notable studios.",
+      "alignmentText": "Studios such as Grinding Gear Games, RocketWerkz, and Balancing Monkey offer collaborative ecosystems even if headcounts stay modest.",
       "alignmentValue": 7
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Government grants support creative tech startups.",
-      "alignmentValue": 7
+      "alignmentText": "Creative grants, the CODE incubator, and film-tax incentives help, but venture funding is thin so Trey would still bootstrap an indie studio.",
+      "alignmentValue": 6
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Slow and relaxed outside Auckland.",
+      "alignmentText": "Outside of Auckland, commutes stay short and shops close earlier, giving Sarah the slower rhythm she wants for family time.",
       "alignmentValue": 8
     },
     {
       "key": "Parenting Expectations",
-      "alignmentText": "Emphasis on outdoor play and balanced activities.",
+      "alignmentText": "Schools emphasize outdoor play and resilience, dovetailing with the family’s preference for balanced academics and free time.",
       "alignmentValue": 7
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "After five years' residence and commitment to NZ.",
+      "alignmentText": "Citizenship follows five years of residence with strict physical-presence totals, so the family must stay rooted while navigating paperwork.",
       "alignmentValue": 7
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Among the world's least corrupt nations.",
+      "alignmentText": "Transparency International consistently ranks New Zealand among the least corrupt, satisfying the household’s demand for clean governance.",
       "alignmentValue": 9
     },
     {
       "key": "Political System",
-      "alignmentText": "Parliamentary democracy with proportional representation.",
+      "alignmentText": "Mixed-member proportional elections and coalition governance keep policy responsive and pluralistic, aligning with the family’s progressive politics.",
       "alignmentValue": 9
     },
     {
       "key": "Polyamory",
-      "alignmentText": "Small but relatively tolerant communities.",
-      "alignmentValue": 5
+      "alignmentText": "Poly groups meet openly in Auckland and Wellington, yet legal frameworks remain monogamy-centric so we would stay discreet with schools and landlords.",
+      "alignmentValue": 7
     },
     {
       "key": "Pre-K / Early Childcare Landscape",
-      "alignmentText": "20 Hours ECE for ages 3–5 at licensed services; mix of kindergartens/centres/home‑based; availability varies by suburb.",
-      "alignmentValue": 7.0
+      "alignmentText": "Licensed centers and kindergartens cover most suburbs, though popular Auckland neighborhoods still require joining waitlists during pregnancy.",
+      "alignmentValue": 7
     },
     {
       "key": "Private Education",
-      "alignmentText": "Independent and state‑integrated schools; fees for private and attendance dues for integrated; limited international schools.",
-      "alignmentValue": 6.0
+      "alignmentText": "Independent and integrated schools exist but carry NZ$15k–25k tuition, so private options become a selective backup rather than the norm.",
+      "alignmentValue": 6
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Highly progressive social policies.",
+      "alignmentText": "Policies on marriage equality, cannabis reform debates, and indigenous partnership echo the family’s progressive priorities.",
       "alignmentValue": 9
     },
     {
       "key": "Propaganda Messaging",
-      "alignmentText": "Public service messaging focuses on culture and identity.",
-      "alignmentValue": 6
+      "alignmentText": "Government messaging focuses on public health and national identity, generally transparent but occasionally paternalistic during crises.",
+      "alignmentValue": 7
     },
     {
       "key": "Propaganda Prevalence",
-      "alignmentText": "Independent media with low propaganda.",
+      "alignmentText": "Independent media and active fact-checkers keep spin low, so the family can rely on diverse news sources.",
       "alignmentValue": 8
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Limited outside main cities; improving networks.",
+      "alignmentText": "Auckland and Wellington have improving rail and bus networks, yet service gaps and weekend frequency drops mean the family would still keep a car.",
       "alignmentValue": 5
     },
     {
       "key": "Religion in Politics",
-      "alignmentText": "Secular governance with low religious influence.",
+      "alignmentText": "Secular governance dominates national debates, so faith rarely intrudes on policy affecting the family.",
       "alignmentValue": 9
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Remote work supported especially in tech.",
+      "alignmentText": "Post-pandemic norms allow hybrid work in tech hubs, though time zones with the US require Trey to schedule late calls.",
       "alignmentValue": 7
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Work visas can lead to residency after several years.",
-      "alignmentValue": 7
-    },
-    {
-      "key": "Retirement (Citizens)",
-      "alignmentText": "NZ Super from 65 subject to residency; KiwiSaver common; adequacy varies by housing costs and savings.",
-      "alignmentValue": 7.0
-    },
-    {
-      "key": "Retirement (Immigrants)",
-      "alignmentText": "KiwiSaver available; residency required for pension.",
+      "alignmentText": "Resident visas typically follow two to three years on work permits with income tests, so planning for renewals and savings is essential.",
       "alignmentValue": 6
     },
     {
-      "key": "Retirement (Visa Holders)",
-      "alignmentText": "Eligibility tied to residence class and years; KiwiSaver access via employment; portability depends on treaties/status.",
-      "alignmentValue": 5.0
+      "key": "Retirement (Citizens)",
+      "alignmentText": "NZ Super kicks in at 65 with modest payments, so homeowners fare best while renters need KiwiSaver contributions to stay comfortable.",
+      "alignmentValue": 7
     },
     {
-      "key": "Ruby Work Prospects",
-      "alignmentText": "Niche opportunities primarily in startups.",
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "New arrivals must live 10 of the years between 20 and 65 to access NZ Super, pushing the family to self-fund retirement if they relocate mid-career.",
       "alignmentValue": 5
     },
     {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Until permanent residence is secured, employer KiwiSaver contributions are limited and government pensions remain out of reach.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in a few startups and consultancies, so Sarah would likely rely on remote US work or retrain toward more in-demand stacks.",
+      "alignmentValue": 4
+    },
+    {
       "key": "Safety & Crime",
-      "alignmentText": "Low violent crime; petty theft in cities.",
+      "alignmentText": "Violent crime rates stay low and community policing is active, with petty theft around transit hubs the main issue to watch.",
       "alignmentValue": 8
     },
     {
       "key": "Schooling Options",
-      "alignmentText": "Quality public schools with limited international options.",
-      "alignmentValue": 7
-    },
-    {
-      "key": "Seasonal Beach Water Temp",
-      "alignmentText": "Swimmable in summer; cooler waters in the south.",
+      "alignmentText": "Public schools dominate and perform well, but international curricula and secular private options are limited outside Auckland.",
       "alignmentValue": 6
     },
     {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Summer sea temps reach 20–22 °C in the north yet stay chilly in the South Island, so longer swims need wetsuits for the kids.",
+      "alignmentValue": 5
+    },
+    {
       "key": "Seasonal Weather",
-      "alignmentText": "Mild maritime climate with wet winters and cool summers.",
+      "alignmentText": "The maritime climate keeps summers mild and winters damp, matching the family’s dislike of extremes while demanding rain gear year-round.",
       "alignmentValue": 7
     },
     {
       "key": "Sex (Attitudes)",
-      "alignmentText": "Open discussions and comprehensive sex education.",
+      "alignmentText": "Comprehensive sex education and open public discourse make it easy to raise sex-positive kids without stigma.",
       "alignmentValue": 8
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Progressive on LGBTQ and women's rights.",
+      "alignmentText": "Progress on LGBTQ+ rights, reproductive care, and indigenous partnership aligns with the family’s social priorities.",
       "alignmentValue": 9
     },
     {
       "key": "Spring Temperature Range (C/F)",
-      "alignmentText": "Temperate maritime; North Island ~12–18 °C (54–64 °F), South cooler; frequent showers; increasing sunshine/UV.",
-      "alignmentValue": 8.0
+      "alignmentText": "Spring ranges from 12–18 °C (54–64 °F) in the North Island with frequent showers, while the South runs cooler but brightens quickly.",
+      "alignmentValue": 8
     },
     {
       "key": "Stability",
-      "alignmentText": "Politically stable with low corruption.",
+      "alignmentText": "Political turnover is orderly, and public debt remains moderate, giving the family confidence in long-term plans.",
       "alignmentValue": 9
     },
     {
       "key": "State Ideology",
-      "alignmentText": "Social democracy with free-market elements.",
+      "alignmentText": "Governments swing between center-left and center-right coalitions, blending social investment with market reforms.",
       "alignmentValue": 7
     },
     {
       "key": "State of Capitalism",
-      "alignmentText": "Open market with regulation.",
+      "alignmentText": "Open markets with consumer protections let entrepreneurs thrive while keeping monopolies in check.",
       "alignmentValue": 7
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "North Island ~20–26 °C (68–79 °F), South ~18–24 °C (64–75 °F); humidity moderate; strong UV; sea breezes.",
-      "alignmentValue": 8.0
+      "alignmentText": "Summer highs sit near 20–26 °C (68–79 °F) with strong UV, keeping things comfortable if we manage midday sun.",
+      "alignmentValue": 8
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Processing times moderate with reasonable fees.",
-      "alignmentValue": 6
+      "alignmentText": "Visa processing routinely stretches beyond six months and application fees top NZ$4,000 for a family, so we’d budget both time and money for the move.",
+      "alignmentValue": 5
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Relatively high public trust.",
+      "alignmentText": "Surveys show sustained trust in Parliament and public health agencies, which supports the family’s desire for transparent governance.",
       "alignmentValue": 8
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Minor, occasional local issues.",
+      "alignmentText": "Corruption cases tend to be minor local procurement issues, not systemic bribery, matching the family’s low tolerance for graft.",
       "alignmentValue": 9
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Smaller market with moderate salaries.",
-      "alignmentValue": 6
+      "alignmentText": "Senior dev salaries cluster around NZ$120k–140k, covering basics but requiring side projects or remote gigs to match US earnings.",
+      "alignmentValue": 5
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Outdoors focus (beaches, hikes), markets/sport; shops open both days with shorter Sun hours; family activities common.",
-      "alignmentValue": 8.0
+      "alignmentText": "Weekends revolve around beach trips, tramping clubs, and Saturday markets, giving the boys plenty of outdoor time while Sundays stay quieter.",
+      "alignmentValue": 8
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "Primary ~09:00–15:00; secondary ~08:45–15:15; offices ~08:30–17:00; after‑school care common to ~18:00.",
-      "alignmentValue": 8.0
+      "alignmentText": "Primary schools run roughly 9 a.m.–3 p.m. and offices 8:30 a.m.–5 p.m., so after-school programs to 6 p.m. bridge both adults’ workdays.",
+      "alignmentValue": 8
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Four weeks annual leave.",
+      "alignmentText": "Four weeks of statutory leave plus public holidays provide reliable downtime as long as we book early around Christmas closures.",
       "alignmentValue": 7
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Some employers offer additional days.",
+      "alignmentText": "Most tech employers stick close to the 20-day floor with occasional company shutdowns, so extra rest days require tenure or negotiation.",
       "alignmentValue": 7
     },
     {
       "key": "View of Neighboring Countries",
-      "alignmentText": "Generally positive toward Australia and Pacific neighbors.",
+      "alignmentText": "Kiwis joke about Australia yet maintain cooperative ties across the Tasman, fostering friendly regional sentiment.",
       "alignmentValue": 7
     },
     {
       "key": "View of self",
-      "alignmentText": "See themselves as friendly and independent.",
+      "alignmentText": "National identity emphasizes fairness, outdoor life, and independence—values that resonate with the family.",
       "alignmentValue": 8
     },
     {
       "key": "View of Them by Neighboring Countries",
-      "alignmentText": "Viewed as peaceful and green.",
+      "alignmentText": "Australia and Pacific neighbors generally view New Zealand as stable and eco-conscious, reinforcing a positive regional reputation.",
       "alignmentValue": 8
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Skilled migrant and entrepreneur visas available.",
-      "alignmentValue": 6
+      "alignmentText": "Skilled Migrant and Entrepreneur visas exist but run on points, salary thresholds, and capped quotas, so the family must present strong credentials.",
+      "alignmentValue": 5
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Generally positive but small quotas.",
-      "alignmentValue": 7
+      "alignmentText": "Americans integrate easily culturally, yet annual residence caps and strict biosecurity mean entry still feels selective.",
+      "alignmentValue": 6
     },
     {
       "key": "What Is Intriguing",
-      "alignmentText": "Outdoor lifestyle and friendly culture.",
+      "alignmentText": "The mix of thriving indie tech, Māori culture, and wild landscapes checks every box the family lists for an adventurous move.",
       "alignmentValue": 9
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "North Island ~8–14 °C (46–57 °F) damp cool; South Island ~5–10 °C (41–50 °F) with alpine snow; frosts inland.",
-      "alignmentValue": 7.0
+      "alignmentText": "Winters hover around 8–14 °C (46–57 °F) in the north and drop to 5–10 °C (41–50 °F) in the south with damp chill, so insulation upgrades matter.",
+      "alignmentValue": 7
     },
     {
       "key": "Work Week Hours",
-      "alignmentText": "Standard 40-hour week.",
+      "alignmentText": "A standard 40-hour week is the norm, with overtime less common but still appearing in peak product cycles.",
       "alignmentValue": 7
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Laid-back culture values time off.",
+      "alignmentText": "Teams expect employees to log off by early evening, supporting Sarah’s need for predictable family dinners.",
       "alignmentValue": 8
     },
     {
       "key": "Workers' Rights",
-      "alignmentText": "Strong protections and unions.",
+      "alignmentText": "Collective bargaining coverage and strong safety laws protect employees, even though union membership is voluntary.",
       "alignmentValue": 8
     }
   ]


### PR DESCRIPTION
## Summary
- recalibrated New Zealand alignment scores around climate resilience, childcare access, and housing to better match the family profile and rating guides
- refreshed every alignment narrative to connect local context with Trey and Sarah’s priorities
- tagged the report as version 2 so the refresh is traceable

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e30ff1190483219398ae0e136c7fb3