### PR TITLE
Update Switzerland report to version 2

### DIFF
--- a/reports/switzerland_report.json
+++ b/reports/switzerland_report.json
@@ -1,1 +1,541 @@
-{"iso":"CH","values":[{"key":"Environment","alignmentText":"Exceptional environmental standards, clean water, and extensive protected areas.","alignmentValue":9},{"key":"Global Warming Risk","alignmentText":"Low sea-level risk; alpine heat/drought and glacier melt impacts.","alignmentValue":7},{"key":"Seasonal Weather","alignmentText":"Temperate overall: mild summers, cool winters; low humidity in lowlands.","alignmentValue":6},{"key":"Air Quality","alignmentText":"Consistently good air quality outside occasional urban corridors.","alignmentValue":9},{"key":"Natural Disasters","alignmentText":"Generally low risk; localized floods/avalanches/landslides in alpine areas.","alignmentValue":7},{"key":"Spring Temperature Range (C/F)","alignmentText":"Lowlands ~8-18 C (46-64 F); frequent rain; lengthening daylight.","alignmentValue":6},{"key":"Summer Temperature Range (C/F)","alignmentText":"Lowlands ~20-28 C (68-82 F); low humidity; lakes offer relief.","alignmentValue":7},{"key":"Fall Temperature Range (C/F)","alignmentText":"Cooling to ~8-16 C (46-61 F); fog in some valleys; stable weather.","alignmentValue":6},{"key":"Winter Temperature Range (C/F)","alignmentText":"Lowlands ~-1-6 C (30-43 F); colder in alpine regions; periodic snow/ice.","alignmentValue":5},{"key":"Beach Life","alignmentText":"No sea beaches; lakes and river baths are delightful in summer.","alignmentValue":2},{"key":"Seasonal Beach Water Temp","alignmentText":"Lake swimming mainly late June-Aug; otherwise chilly.","alignmentValue":2},{"key":"Natural Beauty","alignmentText":"World-class Alps and lakes; unparalleled hiking and scenic rail.","alignmentValue":10},{"key":"Minimum Wage","alignmentText":"No federal minimum; several cantons set high floors (CHF/hr).","alignmentValue":5},{"key":"Typical Software Salaries","alignmentText":"Very high compensation, offset by high living costs.","alignmentValue":9},{"key":".NET Work Prospects","alignmentText":"Solid demand in finance, pharma, and enterprise (Zurich/Basel).","alignmentValue":7},{"key":"Ruby Work Prospects","alignmentText":"Moderate market; roles clustered in major cities.","alignmentValue":6},{"key":"Employer Visa Sponsorship","alignmentText":"Feasible but non-EU quotas and cantonal approvals add friction.","alignmentValue":5},{"key":"Economic Health","alignmentText":"Stable, diversified economy with low unemployment and strong CHF.","alignmentValue":9},{"key":"Remote-Friendly Culture","alignmentText":"Hybrid/remote acceptable in tech; many firms still prefer on-site.","alignmentValue":6},{"key":"Work-Life Balance","alignmentText":"Clear boundaries; generous leave culture vs. US norms.","alignmentValue":8},{"key":"Work Week Hours","alignmentText":"~40-42 typical; legal caps by sector; overtime regulated.","alignmentValue":7},{"key":"Vacation Days (Minimum)","alignmentText":"20 days statutory (more for youth); public holidays by canton.","alignmentValue":6},{"key":"Vacation Days (Typical)","alignmentText":"25-30 days common in tech/finance plus holidays.","alignmentValue":7},{"key":"Pace of Life","alignmentText":"Calm and orderly; slower rhythm outside Zurich/Geneva.","alignmentValue":7},{"key":"Typical Workday Schedule (Family of Four)","alignmentText":"Schools often have midday breaks; after-school care needed; offices ~08:30-17:30.","alignmentValue":6},{"key":"Typical Weekend Schedule (Family of Four)","alignmentText":"Outdoors, day trips, and sports; Sunday retail closures.","alignmentValue":7},{"key":"Family Life","alignmentText":"Exceptionally safe with abundant parks and family amenities.","alignmentValue":8},{"key":"Polyamory","alignmentText":"Limited social acceptance and no legal recognition; small communities.","alignmentValue":3},{"key":"Parenting Expectations","alignmentText":"Structured and independence-oriented; moderate extracurricular load.","alignmentValue":6},{"key":"Child-Friendliness of Cities","alignmentText":"Excellent playgrounds, clean public spaces, safe streets.","alignmentValue":8},{"key":"Schooling Options","alignmentText":"Strong public schools; language tracks; quality international schools are costly.","alignmentValue":8},{"key":"Pre-K / Early Childcare Landscape","alignmentText":"Kitas reliable but expensive; availability varies by city/canton.","alignmentValue":5},{"key":"Childcare Support (Citizens)","alignmentText":"Subsidies/tax relief depend on canton/municipality; leave modest.","alignmentValue":5},{"key":"Childcare Support (Visa Holders)","alignmentText":"Some subsidies accessible with residency/tax status; rules vary.","alignmentValue":4},{"key":"K-12 Education Access (Citizens)","alignmentText":"Free, high-quality public system; local catchments; secular options.","alignmentValue":9},{"key":"K-12 Education Access (Visa Holders)","alignmentText":"Resident children enroll in public schools; integration support available.","alignmentValue":8},{"key":"Private Education","alignmentText":"Available (incl. international/Montessori); admissions selective; fees high.","alignmentValue":6},{"key":"Family Policy (Citizens)","alignmentText":"Child allowances common; 14w maternity and 2w paternity leave.","alignmentValue":5},{"key":"Family Policy (Visa Holders)","alignmentText":"Eligibility mirrors residents paying contributions; canton rules apply.","alignmentValue":4},{"key":"Higher Education Access (Citizens)","alignmentText":"Top universities with relatively low tuition; language prerequisites.","alignmentValue":9},{"key":"Higher Education Access (Visa Holders)","alignmentText":"Non-EU students often pay modest tuition; scholarships limited.","alignmentValue":7},{"key":"Gender Roles","alignmentText":"Egalitarian trend with some traditional patterns persisting by region.","alignmentValue":6},{"key":"Gender Fluidity","alignmentText":"Legal recognition improving; social acceptance higher in cities.","alignmentValue":6},{"key":"Gender Rights","alignmentText":"Strong workplace equality laws and protections.","alignmentValue":8},{"key":"Femininity Norms","alignmentText":"Practical, understated style; safety and independence emphasized.","alignmentValue":6},{"key":"Masculinity Norms","alignmentText":"Reserved, pragmatic; caregiving roles increasingly normalized.","alignmentValue":6},{"key":"What Is Intriguing","alignmentText":"Alps, precision culture, and serene, reliable daily life.","alignmentValue":9},{"key":"Language & English Ubiquity","alignmentText":"English common in business; daily life benefits from German/French/Italian.","alignmentValue":6},{"key":"Progressivism","alignmentText":"Socially liberal overall; direct democracy yields mixed outcomes.","alignmentValue":7},{"key":"Marxism (Societal Attitudes)","alignmentText":"Limited; politics center on pragmatic market-social balance.","alignmentValue":4},{"key":"Atheism","alignmentText":"Secular society with plural religious presence.","alignmentValue":7},{"key":"Sex (Attitudes)","alignmentText":"Comprehensive sex-ed; public norms modest; cities more open.","alignmentValue":6},{"key":"LGBTQ+ Attitudes","alignmentText":"Same-sex marriage/legal protections; acceptance strong in urban areas.","alignmentValue":8},{"key":"Community Vibes","alignmentText":"Reserved at first; deep relationships form through schools/clubs.","alignmentValue":5},{"key":"View of self","alignmentText":"Neutral, precise, community-minded with high civic pride.","alignmentValue":8},{"key":"View of Neighboring Countries","alignmentText":"Cooperative with EU neighbors; tightly connected cross-border.","alignmentValue":7},{"key":"View of Them by Neighboring Countries","alignmentText":"Seen as wealthy, orderly, and occasionally insular.","alignmentValue":6},{"key":"Nightlife Culture","alignmentText":"Good in Zurich/Geneva/Lausanne; quieter elsewhere; early closures.","alignmentValue":6},{"key":"Fashion Trends (Male)","alignmentText":"Smart-casual, technical outerwear; understated quality.","alignmentValue":6},{"key":"Fashion Trends (Female)","alignmentText":"Practical chic; layered for weather; modest silhouettes.","alignmentValue":6},{"key":"Common Hobbies","alignmentText":"Hiking, skiing, cycling, lake swimming; youth sports popular.","alignmentValue":9},{"key":"Boardgaming & Tabletop","alignmentText":"Active clubs and shops; smaller scene than Germany.","alignmentValue":6},{"key":"Nightlife & Music","alignmentText":"Vibrant festivals (e.g., Montreux Jazz); lively city venues.","alignmentValue":6},{"key":"Meetups & Communities","alignmentText":"Strong meetup culture in big cities; English-speaking groups.","alignmentValue":7},{"key":"Nature Access","alignmentText":"Trailheads by train; car-free peaks; weekend trips are easy.","alignmentValue":10},{"key":"Political System","alignmentText":"Federal direct democracy; frequent referenda; strong local control.","alignmentValue":10},{"key":"Religion in Politics","alignmentText":"Limited church influence; secular policy norms.","alignmentValue":7},{"key":"Workers' Rights","alignmentText":"Solid protections and social insurance; less interventionist than Nordics.","alignmentValue":7},{"key":"State Ideology","alignmentText":"Liberal market economy with robust but lean safety nets.","alignmentValue":7},{"key":"Authoritarian Backsliding Risk","alignmentText":"Very low given institutions and civic participation.","alignmentValue":9},{"key":"State of Capitalism","alignmentText":"High-trust, high-productivity capitalism with strong SMEs.","alignmentValue":9},{"key":"Stability","alignmentText":"Exceptional economic and political stability.","alignmentValue":10},{"key":"Propaganda Prevalence","alignmentText":"Independent media landscape; low state narrative pressure.","alignmentValue":8},{"key":"Propaganda Messaging","alignmentText":"Public broadcasters emphasize neutrality/civic duty.","alignmentValue":6},{"key":"Social Policies","alignmentText":"Comprehensive insurance and benefits, though less expansive than Nordics.","alignmentValue":7},{"key":"Trust in Government","alignmentText":"High trust supported by transparency and local voice.","alignmentValue":8},{"key":"Perceived Corruption","alignmentText":"Among the lowest globally.","alignmentValue":9},{"key":"Type of Corruption","alignmentText":"Occasional corporate/compliance issues; petty corruption rare.","alignmentValue":8},{"key":"Housing Situation","alignmentText":"Very high rents and tight supply in major cities; low ownership.","alignmentValue":4},{"key":"Safety & Crime","alignmentText":"Extremely safe; violent crime rare; excellent emergency services.","alignmentValue":10},{"key":"Healthcare (Citizens)","alignmentText":"Mandatory private insurance with excellent quality; premiums high.","alignmentValue":8},{"key":"Healthcare (Visa Holders)","alignmentText":"Must obtain local insurance; access comparable; short waits.","alignmentValue":7},{"key":"Child Care Support","alignmentText":"Quality care but costly; subsidies depend on canton/municipality.","alignmentValue":5},{"key":"Family Policy (Common Family)","alignmentText":"Stable, safe, outdoors-oriented life; benefits adequate but lean.","alignmentValue":6},{"key":"Education","alignmentText":"High PISA outcomes; bilingual exposure possible; early tracking.","alignmentValue":9},{"key":"Public Transportation","alignmentText":"World-class rail/bus network; punctual and comprehensive.","alignmentValue":10},{"key":"Economic System","alignmentText":"Competitive market economy with social insurance pillars.","alignmentValue":8},{"key":"How Taxes Are Handled","alignmentText":"Withholding (Quellensteuer) for some B permits; filings vary by canton.","alignmentValue":6},{"key":"Expected Tax Rate (Our Family)","alignmentText":"Varies widely by canton/commune; mid-range overall for cities.","alignmentValue":6},{"key":"Banking & Payments","alignmentText":"Modern payments (TWINT); US persons face FATCA-related onboarding hurdles.","alignmentValue":6},{"key":"Cost of Living (Optional)","alignmentText":"Very high costs, especially housing, childcare, and dining.","alignmentValue":3},{"key":"Retirement (Citizens)","alignmentText":"Three-pillar system (AHV/AVS + occupational + private) ensures coverage.","alignmentValue":7},{"key":"Retirement (Visa Holders)","alignmentText":"Second-pillar portability/refunds possible on departure; treaty nuances.","alignmentValue":6},{"key":"Visa Paths","alignmentText":"Non-EU hiring under quotas; L/B permits; self-employment/startup routes narrow.","alignmentValue":4},{"key":"Welcoming of US Migrants","alignmentText":"Skilled Americans welcomed, but processes are selective and quota-bound.","alignmentValue":5},{"key":"Residency Types & Durations","alignmentText":"L (short-stay) and B (residence) renewable; C (permanent) after long residence.","alignmentValue":6},{"key":"Path to Citizenship","alignmentText":"Typically ~10 years residency with language/integration; communal/cantonal steps.","alignmentValue":5},{"key":"Family Members","alignmentText":"Family reunification available; spouse work rights depend on permit type.","alignmentValue":6},{"key":"Timelines & Costs","alignmentText":"Processing is orderly but not fast; fees and insurance costs add up.","alignmentValue":5},{"key":"Compliance & Risks","alignmentText":"Register with commune, maintain insurance, observe permit quotas/taxes.","alignmentValue":6},{"key":"Dual Citizenship Allowed","alignmentText":"Yes, dual nationality permitted for naturalized citizens.","alignmentValue":9},{"key":"General Considerations for Visa Holders","alignmentText":"US banking (FATCA), high deposits for rentals, and language needs.","alignmentValue":6},{"key":"Game Dev Work Prospects","alignmentText":"Small but present scene; roles limited compared to major hubs.","alignmentValue":5},{"key":"Notable Game Studios","alignmentText":"GIANTS Software (Zurich) and several indies/university labs.","alignmentValue":5},{"key":"Notable Game Development Communities","alignmentText":"SGDA network; city-level meetups and student groups.","alignmentValue":6},{"key":"Opportunities for Video Game Startup","alignmentText":"Support via Pro Helvetia SwissGames and Innosuisse programs.","alignmentValue":7},{"key":"Modernity & Infrastructure","alignmentText":"Gigabit fiber common; Azure regions in-country; trains/grid are first-rate.","alignmentValue":10}]}
+{
+  "version": 2,
+  "iso": "CH",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Exceptional environmental standards, clean water, and extensive protected areas.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Low sea-level risk; alpine heat/drought and glacier melt impacts.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Temperate overall: mild summers, cool winters; low humidity in lowlands.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Consistently good air quality outside occasional urban corridors.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Generally low risk; localized floods/avalanches/landslides in alpine areas.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Lowlands ~8-18 C (46-64 F); frequent rain; lengthening daylight.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Lowlands ~20-28 C (68-82 F); low humidity; lakes offer relief.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Cooling to ~8-16 C (46-61 F); fog in some valleys; stable weather.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Lowlands ~-1-6 C (30-43 F); colder in alpine regions; periodic snow/ice.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "No sea beaches; lakes and river baths are delightful in summer.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Lake swimming mainly late June-Aug; otherwise chilly.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "World-class Alps and lakes; unparalleled hiking and scenic rail.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "No federal minimum; several cantons set high floors (CHF/hr).",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Very high compensation, offset by high living costs.",
+      "alignmentValue": 9
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Solid demand in finance, pharma, and enterprise (Zurich/Basel).",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Moderate market; roles clustered in major cities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Feasible but non-EU quotas and cantonal approvals add friction.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Stable, diversified economy with low unemployment and strong CHF.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid/remote acceptable in tech; many firms still prefer on-site.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Clear boundaries; generous leave culture vs. US norms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "~40-42 typical; legal caps by sector; overtime regulated.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Statutory leave guarantees 20 paid days (25 for younger staff) plus canton holidays, so Sarah can reliably plan family breaks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Most tech employers grant 25–30 days plus holidays, letting Trey and Sarah schedule longer US visits or alpine getaways without pushback.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Calm and orderly; slower rhythm outside Zurich/Geneva.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools often have midday breaks; after-school care needed; offices ~08:30-17:30.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Outdoors, day trips, and sports; Sunday retail closures.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Exceptionally safe with abundant parks and family amenities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Polyamorous families stay discreet outside major cities; Zurich/Geneva scenes exist but legal frameworks stay strictly monogamous.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Structured and independence-oriented; moderate extracurricular load.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Excellent playgrounds, clean public spaces, safe streets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Strong public schools; language tracks; quality international schools are costly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Kitas reliable but expensive; availability varies by city/canton.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Municipal subsidies reduce Kita bills for some incomes, yet most parents still shoulder significant costs despite political promises.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Non-EU residents can access subsidies only after local tax registration, and canton quotas keep many visa families paying near full price.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Free, high-quality public system; local catchments; secular options.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children enroll in public schools; integration support available.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Available (incl. international/Montessori); admissions selective; fees high.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Child allowances and 14-week maternity leave help, yet benefits are lean compared with Nordic standards and paperwork varies by canton.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "B-permit families qualify once they pay into social insurance, but shorter leave and canton discretion limit predictable support.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Top universities with relatively low tuition; language prerequisites.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students often pay modest tuition; scholarships limited.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Egalitarian trend with some traditional patterns persisting by region.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition improving; social acceptance higher in cities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Strong workplace equality laws and protections.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Practical, understated style; safety and independence emphasized.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Reserved, pragmatic; caregiving roles increasingly normalized.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Alps, precision culture, and serene, reliable daily life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English common in business; daily life benefits from German/French/Italian.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Socially liberal overall; direct democracy yields mixed outcomes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Limited; politics center on pragmatic market-social balance.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular society with plural religious presence.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex-ed; public norms modest; cities more open.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Same-sex marriage/legal protections; acceptance strong in urban areas.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Reserved at first; deep relationships form through schools/clubs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Neutral, precise, community-minded with high civic pride.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Cooperative with EU neighbors; tightly connected cross-border.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Seen as wealthy, orderly, and occasionally insular.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Good in Zurich/Geneva/Lausanne; quieter elsewhere; early closures.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart-casual, technical outerwear; understated quality.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Practical chic; layered for weather; modest silhouettes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Hiking, skiing, cycling, lake swimming; youth sports popular.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Active clubs and shops; smaller scene than Germany.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Vibrant festivals (e.g., Montreux Jazz); lively city venues.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Strong meetup culture in big cities; English-speaking groups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Trailheads by train; car-free peaks; weekend trips are easy.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Federal direct democracy; frequent referenda; strong local control.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Limited church influence; secular policy norms.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Solid protections and social insurance; less interventionist than Nordics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Liberal market economy with robust but lean safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Very low given institutions and civic participation.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "High-trust, high-productivity capitalism with strong SMEs.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Exceptional economic and political stability.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Independent media landscape; low state narrative pressure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize neutrality/civic duty.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Comprehensive insurance and benefits, though less expansive than Nordics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "High trust supported by transparency and local voice.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Among the lowest globally.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Occasional corporate/compliance issues; petty corruption rare.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Very high rents and tight supply in major cities; low ownership.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Extremely safe; violent crime rare; excellent emergency services.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Mandatory private insurance with excellent quality; premiums high.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Must obtain local insurance; access comparable; short waits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Quality care exists but waits and high fees mean we stitch together Kitas, neighbor help, and remote days to cover gaps.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Stable, safe, outdoors-oriented life; benefits adequate but lean.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Education",
+      "alignmentText": "High PISA outcomes; bilingual exposure possible; early tracking.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "World-class rail/bus network; punctual and comprehensive.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Competitive market economy with social insurance pillars.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Withholding (Quellensteuer) for some B permits; filings vary by canton.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Varies widely by canton/commune; mid-range overall for cities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Modern payments (TWINT); US persons face FATCA-related onboarding hurdles.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Very high costs, especially housing, childcare, and dining.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Three-pillar system (AHV/AVS + occupational + private) ensures coverage.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Second-pillar portability/refunds possible on departure; treaty nuances.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Non-EU hiring under quotas; L/B permits; self-employment/startup routes narrow.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled Americans welcomed, but processes are selective and quota-bound.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "L (short-stay) and B (residence) renewable; C (permanent) after long residence.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Typically ~10 years residency with language/integration; communal/cantonal steps.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Family reunification available; spouse work rights depend on permit type.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing is orderly but not fast; fees and insurance costs add up.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Register with commune, maintain insurance, observe permit quotas/taxes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes, dual nationality permitted for naturalized citizens.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "US banking (FATCA), high deposits for rentals, and language needs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Small but present scene; roles limited compared to major hubs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "GIANTS Software (Zurich) and several indies/university labs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "SGDA network; city-level meetups and student groups.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Support via Pro Helvetia SwissGames and Innosuisse programs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber common; Azure regions in-country; trains/grid are first-rate.",
+      "alignmentValue": 10
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- mark the Switzerland report as version 2 while keeping the existing key structure intact
- recalibrated the vacation leave scores and justification so they reflect current statutory and typical allowances for tech workers
- refined the polyamory and childcare policy narratives to clarify expectations for both citizens and visa holders

## Testing
- jq empty reports/switzerland_report.json

------
https://chatgpt.com/codex/tasks/task_e_68e3168ae76c8321ae5c123fa5673fc8