### PR TITLE
Upgrade Taiwan, Thailand, and Vietnam reports to version 2

### DIFF
--- a/reports/taiwan_report.json
+++ b/reports/taiwan_report.json
@@ -1,539 +1,540 @@
 {
+  "version": 2,
   "iso": "TW",
   "values": [
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Microsoft stack appears in finance and government, though Java and web frameworks dominate.",
+      "alignmentText": "Microsoft stack appears in finance and government, though Java and web frameworks dominate. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 5
     },
     {
       "key": "Air Quality",
-      "alignmentText": "West coast cities see winter PM2.5 spikes, yet regulations are gradually improving air quality.",
+      "alignmentText": "West coast cities see winter PM2.5 spikes, yet regulations are gradually improving air quality. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 5
     },
     {
       "key": "Atheism",
-      "alignmentText": "High religious pluralism and a sizeable non-religious population foster tolerance for atheists.",
+      "alignmentText": "High religious pluralism and a sizeable non-religious population foster tolerance for atheists. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 7
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Vibrant democracy and active civil society keep autocratic drift low despite pressure from China.",
+      "alignmentText": "Vibrant democracy and active civil society keep autocratic drift low despite pressure from China. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 8
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "Modern banks, ubiquitous ATMs, and contactless systems like EasyCard make transactions easy.",
+      "alignmentText": "Modern banks, ubiquitous ATMs, and contactless systems like EasyCard make transactions easy. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 8
     },
     {
       "key": "Beach Life",
-      "alignmentText": "Accessible beaches line the east and south coasts, though they are more weekend escape than daily life.",
+      "alignmentText": "Accessible beaches line the east and south coasts, though they are more weekend escape than daily life. It shapes the family's weekend escapes when they need green space and fresh air.",
       "alignmentValue": 6
     },
     {
       "key": "Boardgaming & Tabletop",
-      "alignmentText": "Board game cafes and local publishers sustain an active tabletop scene in Taipei.",
+      "alignmentText": "Board game cafes and local publishers sustain an active tabletop scene in Taipei. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 7
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Subsidies and new public centers help but many families still rely on private care or relatives.",
+      "alignmentText": "Subsidies and new public centers help but many families still rely on private care or relatives. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 6
     },
     {
       "key": "Child-Friendliness of Cities",
-      "alignmentText": "Cities feature playgrounds, safe transit, and family-friendly night markets.",
+      "alignmentText": "Cities feature playgrounds, safe transit, and family-friendly night markets. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 7
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "Citizens receive monthly subsidies and expanding public preschool options.",
+      "alignmentText": "Citizens receive monthly subsidies and expanding public preschool options. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 7
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Foreign residents can access subsidies after registration but English services are limited.",
+      "alignmentText": "Foreign residents can access subsidies after registration but English services are limited. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 6
     },
     {
       "key": "Common Hobbies",
-      "alignmentText": "Hiking, night-market snacking, and gaming align well with the family's interests.",
+      "alignmentText": "Hiking, night-market snacking, and gaming align well with the family's interests. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 7
     },
     {
       "key": "Community Vibes",
-      "alignmentText": "Friendly locals and organized expat groups create welcoming communities despite language gaps.",
+      "alignmentText": "Friendly locals and organized expat groups create welcoming communities despite language gaps. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 7
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Visa renewals and business filings require Chinese paperwork, adding moderate bureaucratic friction.",
+      "alignmentText": "Visa renewals and business filings require Chinese paperwork, adding moderate bureaucratic friction. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 5
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Housing is pricey in Taipei, but food and transit remain affordable compared to U.S. cities.",
+      "alignmentText": "Housing is pricey in Taipei, but food and transit remain affordable compared to U.S. cities. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 6
     },
     {
       "key": "Dual Citizenship Allowed",
-      "alignmentText": "Naturalization typically demands renouncing prior citizenship with narrow exceptions.",
+      "alignmentText": "Naturalization typically demands renouncing prior citizenship with narrow exceptions. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 3
     },
     {
       "key": "Economic Health",
-      "alignmentText": "An export-driven tech economy maintains steady growth and low unemployment.",
+      "alignmentText": "An export-driven tech economy maintains steady growth and low unemployment. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 8
     },
     {
       "key": "Economic System",
-      "alignmentText": "Capitalist market complemented by strategic state guidance and strong SMEs.",
+      "alignmentText": "Capitalist market complemented by strategic state guidance and strong SMEs. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 7
     },
     {
       "key": "Education",
-      "alignmentText": "Public schools rank well internationally but emphasize rote learning and long hours.",
+      "alignmentText": "Public schools rank well internationally but emphasize rote learning and long hours. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 6
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Tech firms sponsor work permits, though openings often favor Mandarin speakers.",
+      "alignmentText": "Tech firms sponsor work permits, though openings often favor Mandarin speakers. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 6
     },
     {
       "key": "Environment",
-      "alignmentText": "Mountains and parks offer greenery, yet industrial zones reduce overall environmental quality.",
+      "alignmentText": "Mountains and parks offer greenery, yet industrial zones reduce overall environmental quality. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 6
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "Progressive income tax around 5–20% plus NHI premiums keeps overall burden moderate.",
+      "alignmentText": "Progressive income tax around 5–20% plus NHI premiums keeps overall burden moderate. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 5
     },
     {
       "key": "Fall Temperature Range (C/F)",
-      "alignmentText": "Autumn days sit near 22–28°C (72–82°F) as typhoon season winds down, making it comfortable.",
+      "alignmentText": "Autumn days sit near 22–28°C (72–82°F) as typhoon season winds down, making it comfortable. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 8
     },
     {
       "key": "Family Life",
-      "alignmentText": "Family is culturally central, though long work hours can limit shared time.",
+      "alignmentText": "Family is culturally central, though long work hours can limit shared time. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 6
     },
     {
       "key": "Family Members",
-      "alignmentText": "Spousal and dependent visas are commonly approved, enabling the whole family to stay together.",
+      "alignmentText": "Spousal and dependent visas are commonly approved, enabling the whole family to stay together. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 7
     },
     {
       "key": "Family Policy (Citizens)",
-      "alignmentText": "Parental leave up to six months and child allowances support citizen parents.",
+      "alignmentText": "Parental leave up to six months and child allowances support citizen parents. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 7
     },
     {
       "key": "Family Policy (Common Family)",
-      "alignmentText": "Standard households receive basic tax deductions and education subsidies.",
+      "alignmentText": "Standard households receive basic tax deductions and education subsidies. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 6
     },
     {
       "key": "Family Policy (Visa Holders)",
-      "alignmentText": "Foreign families access NHI and schools but miss some cash benefits.",
+      "alignmentText": "Foreign families access NHI and schools but miss some cash benefits. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "Fashion Trends (Female)",
-      "alignmentText": "Urban women blend East Asian streetwear with modest business attire.",
+      "alignmentText": "Urban women blend East Asian streetwear with modest business attire. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "Fashion Trends (Male)",
-      "alignmentText": "Men favor casual street fashion alongside smart office wear.",
+      "alignmentText": "Men favor casual street fashion alongside smart office wear. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "Femininity Norms",
-      "alignmentText": "Traditional expectations persist but younger generations show more gender flexibility.",
+      "alignmentText": "Traditional expectations persist but younger generations show more gender flexibility. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 5
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "A small yet growing sector hosts events like the Taipei Game Developers Forum.",
+      "alignmentText": "A small yet growing sector hosts events like the Taipei Game Developers Forum. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 6
     },
     {
       "key": "Gender Fluidity",
-      "alignmentText": "Legal gender change is possible, though understanding outside Taipei remains limited.",
+      "alignmentText": "Legal gender change is possible, though understanding outside Taipei remains limited. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 5
     },
     {
       "key": "Gender Rights",
-      "alignmentText": "Same-sex marriage and anti-discrimination laws put Taiwan ahead of most of Asia.",
+      "alignmentText": "Same-sex marriage and anti-discrimination laws put Taiwan ahead of most of Asia. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 8
     },
     {
       "key": "Gender Roles",
-      "alignmentText": "Work-centric culture still expects mothers to manage childcare, though attitudes slowly shift.",
+      "alignmentText": "Work-centric culture still expects mothers to manage childcare, though attitudes slowly shift. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 5
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "ARC applications are straightforward but rely on Mandarin documentation and local sponsors.",
+      "alignmentText": "ARC applications are straightforward but rely on Mandarin documentation and local sponsors. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 6
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Rising seas and stronger typhoons threaten coastal and low-lying areas.",
-      "alignmentValue": 5
+      "alignmentText": "Rising seas and stronger typhoons require routine floodproofing and evacuation planning for coastal neighborhoods. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
+      "alignmentValue": 4
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "National Health Insurance delivers broad coverage with low out-of-pocket costs.",
+      "alignmentText": "National Health Insurance delivers broad coverage with low out-of-pocket costs. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 9
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Foreigners join NHI after six months, accessing the same clinics at modest fees.",
+      "alignmentText": "Foreigners join NHI after six months, accessing the same clinics at modest fees. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 8
     },
     {
       "key": "Higher Education Access (Citizens)",
-      "alignmentText": "Universities are plentiful and affordable though highly competitive.",
+      "alignmentText": "Universities are plentiful and affordable though highly competitive. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 8
     },
     {
       "key": "Higher Education Access (Visa Holders)",
-      "alignmentText": "International programs exist, but most instruction remains in Mandarin.",
+      "alignmentText": "International programs exist, but most instruction remains in Mandarin. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 6
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Urban housing is compact and expensive, making family-sized units harder to afford.",
+      "alignmentText": "Urban housing is compact and expensive, making family-sized units harder to afford. The family will need to budget carefully to secure enough space for the boys.",
       "alignmentValue": 4
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "Annual filing can be done online but is largely in Mandarin, often requiring an agent.",
+      "alignmentText": "Annual filing can be done online but is largely in Mandarin, often requiring an agent. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 5
     },
     {
       "key": "K-12 Education Access (Citizens)",
-      "alignmentText": "High enrollment and quality public schools with strong STEM focus.",
+      "alignmentText": "High enrollment and quality public schools with strong STEM focus. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 8
     },
     {
       "key": "K-12 Education Access (Visa Holders)",
-      "alignmentText": "Foreign children may attend public schools, yet language support varies by district.",
+      "alignmentText": "Foreign children may attend public schools, yet language support varies by district. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 6
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Major cities host large Pride events and social acceptance is relatively high.",
+      "alignmentText": "Major cities host large Pride events and social acceptance is relatively high. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 8
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "Mandarin dominates and outside tourist areas English proficiency can be limited.",
+      "alignmentText": "Mandarin dominates and outside tourist areas English proficiency can be limited. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 5
     },
     {
       "key": "Marxism (Societal Attitudes)",
-      "alignmentText": "Public opinion favors liberal democracy, and Marxist ideas are rare.",
+      "alignmentText": "Public opinion favors liberal democracy, and Marxist ideas are rare. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 3
     },
     {
       "key": "Masculinity Norms",
-      "alignmentText": "Men face moderate expectations to be breadwinners, though metro fashion softens stereotypes.",
+      "alignmentText": "Men face moderate expectations to be breadwinners, though metro fashion softens stereotypes. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 5
     },
     {
       "key": "Meetups & Communities",
-      "alignmentText": "Tech, gaming, and language-exchange groups flourish in Taipei.",
+      "alignmentText": "Tech, gaming, and language-exchange groups flourish in Taipei. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 7
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "Monthly minimum wage near NT$27k (~USD900) signals baseline labor protections.",
+      "alignmentText": "Monthly minimum wage near NT$27k (~USD900) signals baseline labor protections. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 6
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "High-speed rail, 5G coverage, and smart-city projects indicate advanced infrastructure.",
+      "alignmentText": "High-speed rail, 5G coverage, and smart-city projects indicate advanced infrastructure. Solid infrastructure supports their remote work, gaming, and everyday logistics.",
       "alignmentValue": 8
     },
     {
       "key": "Natural Beauty",
-      "alignmentText": "From Taroko Gorge to Alishan forests, the island offers striking landscapes.",
+      "alignmentText": "From Taroko Gorge to Alishan forests, the island offers striking landscapes. It shapes the family's weekend escapes when they need green space and fresh air.",
       "alignmentValue": 8
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Regular earthquakes and typhoons pose significant risk.",
+      "alignmentText": "Regular earthquakes and typhoons pose significant risk. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 3
     },
     {
       "key": "Nature Access",
-      "alignmentText": "Trailheads are reachable by public transit, making weekend hikes easy.",
+      "alignmentText": "Trailheads are reachable by public transit, making weekend hikes easy. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 8
     },
     {
       "key": "Nightlife & Music",
-      "alignmentText": "Live houses, KTV, and festivals provide diverse evening entertainment.",
+      "alignmentText": "Live houses, KTV, and festivals provide diverse evening entertainment. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 7
     },
     {
       "key": "Nightlife Culture",
-      "alignmentText": "Night markets and late eateries create a social yet family-friendly nightlife.",
+      "alignmentText": "Night markets and late eateries create a social yet family-friendly nightlife. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "Groups like Taipei IGDA and local forums connect developers.",
+      "alignmentText": "Groups like Taipei IGDA and local forums connect developers. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 6
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Studios such as Rayark and Red Candle show local creativity.",
+      "alignmentText": "Studios such as Rayark and Red Candle show local creativity. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 6
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Innovation grants and the Taiwan Gold Card support entrepreneurial founders.",
+      "alignmentText": "Innovation grants and the Taiwan Gold Card support entrepreneurial founders. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 7
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Taipei moves fast, while smaller cities like Tainan offer a slower rhythm.",
+      "alignmentText": "Taipei moves fast, while smaller cities like Tainan offer a slower rhythm. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 5
     },
     {
       "key": "Parenting Expectations",
-      "alignmentText": "School-centric culture pressures parents toward after-school tutoring.",
+      "alignmentText": "School-centric culture pressures parents toward after-school tutoring. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 4
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Requires over five years' residence, language tests, and renouncing prior citizenship.",
+      "alignmentText": "Requires over five years' residence, language tests, and renouncing prior citizenship. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 4
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Transparency International ranks Taiwan relatively clean with strong anti-graft agencies.",
+      "alignmentText": "Transparency International ranks Taiwan relatively clean with strong anti-graft agencies. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 8
     },
     {
       "key": "Political System",
-      "alignmentText": "Multi-party democratic republic with regular competitive elections.",
+      "alignmentText": "Multi-party democratic republic with regular competitive elections. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 8
     },
     {
       "key": "Polyamory",
-      "alignmentText": "Polyamorous relationships lack legal recognition and remain largely taboo.",
+      "alignmentText": "Polyamorous relationships lack legal recognition and remain largely taboo. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 2
     },
     {
       "key": "Pre-K / Early Childcare Landscape",
-      "alignmentText": "Public preschools are expanding but urban waitlists are common.",
+      "alignmentText": "Public preschools are expanding but urban waitlists are common. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 6
     },
     {
       "key": "Private Education",
-      "alignmentText": "Private and international schools exist but command high tuition.",
+      "alignmentText": "Private and international schools exist but command high tuition. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Digital democracy initiatives and LGBTQ rights reflect a broadly progressive society.",
+      "alignmentText": "Digital democracy initiatives and LGBTQ rights reflect a broadly progressive society. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 7
     },
     {
       "key": "Propaganda Messaging",
-      "alignmentText": "Government messaging focuses on civic campaigns rather than ideology.",
-      "alignmentValue": 3
+      "alignmentText": "Official messaging emphasizes civic participation and pandemic readiness while occasionally leaning on national pride about sovereignty. They prioritize resilient democracies with transparent institutions for their kids' future.",
+      "alignmentValue": 8
     },
     {
       "key": "Propaganda Prevalence",
-      "alignmentText": "Free press and vibrant media limit state-controlled narratives.",
-      "alignmentValue": 2
+      "alignmentText": "Free press and vibrant media limit state-controlled narratives, though Chinese disinformation campaigns demand active media literacy. They prioritize resilient democracies with transparent institutions for their kids' future.",
+      "alignmentValue": 8
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Taipei MRT and intercity rail are clean, reliable, and extensive.",
+      "alignmentText": "Taipei MRT and intercity rail are clean, reliable, and extensive. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 9
     },
     {
       "key": "Religion in Politics",
-      "alignmentText": "Religion rarely influences policy, keeping governance largely secular.",
+      "alignmentText": "Religion rarely influences policy, keeping governance largely secular. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 7
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Co-working spaces support remote work, though many employers prefer office presence.",
+      "alignmentText": "Co-working spaces support remote work, though many employers prefer office presence. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 6
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Work visas, spousal ARCs, and three-year Gold Cards provide varied stay options.",
+      "alignmentText": "Work visas, spousal ARCs, and three-year Gold Cards provide varied stay options. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 7
     },
     {
       "key": "Retirement (Citizens)",
-      "alignmentText": "State pension offers modest payouts, supplemented by private savings.",
+      "alignmentText": "State pension offers modest payouts, supplemented by private savings. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 5
     },
     {
       "key": "Retirement (Visa Holders)",
-      "alignmentText": "Foreigners may retire but receive limited pension benefits unless contributing long-term.",
+      "alignmentText": "Foreigners may retire but receive limited pension benefits unless contributing long-term. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 4
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Ruby on Rails is used in some startups and fintech but isn't mainstream.",
+      "alignmentText": "Ruby on Rails is used in some startups and fintech but isn't mainstream. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 5
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Taiwan ranks among the world's safest countries with very low violent crime.",
+      "alignmentText": "Taiwan ranks among the world's safest countries with very low violent crime. That reassures Trey and Sarah about letting the kids explore transit and night markets.",
       "alignmentValue": 9
     },
     {
       "key": "Schooling Options",
-      "alignmentText": "Bilingual programs and international schools give alternatives to standard Mandarin instruction.",
+      "alignmentText": "Bilingual programs and international schools give alternatives to standard Mandarin instruction. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 7
     },
     {
       "key": "Seasonal Beach Water Temp",
-      "alignmentText": "Coastal waters range roughly 22°C in winter to 29°C in summer (72–84°F).",
+      "alignmentText": "Coastal waters range roughly 22°C in winter to 29°C in summer (72–84°F). It shapes the family's weekend escapes when they need green space and fresh air.",
       "alignmentValue": 7
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "Subtropical climate means hot, humid summers and mild winters with frequent rain.",
+      "alignmentText": "Subtropical climate means hot, humid summers and mild winters with frequent rain. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 5
     },
     {
       "key": "Sex (Attitudes)",
-      "alignmentText": "Public discussions of sexuality remain conservative despite some urban liberalization.",
+      "alignmentText": "Public discussions of sexuality remain conservative despite some urban liberalization. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 4
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Progressive on healthcare and LGBTQ rights but conservative on drugs and conscription.",
+      "alignmentText": "Progressive on healthcare and LGBTQ rights but conservative on drugs and conscription. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 6
     },
     {
       "key": "Spring Temperature Range (C/F)",
-      "alignmentText": "Spring sees 18–26°C (64–79°F) with blossoms and occasional rain.",
+      "alignmentText": "Spring sees 18–26°C (64–79°F) with blossoms and occasional rain. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 7
     },
     {
       "key": "Stability",
-      "alignmentText": "Domestic stability is high though cross-strait tensions persist.",
+      "alignmentText": "Domestic stability is high though cross-strait tensions persist. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 7
     },
     {
       "key": "State Ideology",
-      "alignmentText": "Emphasis on democratic values and a market economy rather than a single ideology.",
+      "alignmentText": "Emphasis on democratic values and a market economy rather than a single ideology. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 7
     },
     {
       "key": "State of Capitalism",
-      "alignmentText": "Entrepreneurial environment with strong private sector and venture support.",
+      "alignmentText": "Entrepreneurial environment with strong private sector and venture support. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 7
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "Summer highs reach about 33°C (91°F) with high humidity and typhoon threats.",
+      "alignmentText": "Summer highs reach about 33°C (91°F) with high humidity and typhoon threats. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 4
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Gold Card processing finishes in 1–2 months with moderate fees.",
+      "alignmentText": "Gold Card processing finishes in 1–2 months with moderate fees. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 6
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Public confidence rose after effective pandemic response and open data efforts.",
+      "alignmentText": "Public confidence rose after effective pandemic response and open data efforts. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 7
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Issues mainly involve petty bribery or influence peddling and are generally prosecuted.",
+      "alignmentText": "Issues mainly involve petty bribery or influence peddling and are generally prosecuted. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 7
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Mid-level developers earn around NT$1–1.5M yearly (USD33–50k).",
+      "alignmentText": "Mid-level developers earn around NT$1–1.5M yearly (USD33–50k). Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 5
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Families explore night markets, parks, and nearby hiking trails on weekends.",
+      "alignmentText": "Families explore night markets, parks, and nearby hiking trails on weekends. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 7
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "Standard office jobs run 9–6 with overtime culture that can eat into evenings.",
+      "alignmentText": "Standard office jobs run 9–6 with overtime culture that can eat into evenings. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 4
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Labor laws guarantee 7–15 paid days depending on tenure.",
+      "alignmentText": "Labor laws guarantee 7–15 paid days depending on tenure. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 5
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Most employees take around two weeks off annually, matching legal minimums.",
+      "alignmentText": "Most employees take around two weeks off annually, matching legal minimums. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 5
     },
     {
       "key": "View of Neighboring Countries",
-      "alignmentText": "Public sentiment is warm toward Japan but wary of China's intentions.",
+      "alignmentText": "Public sentiment is warm toward Japan but wary of China's intentions. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 5
     },
     {
       "key": "View of Them by Neighboring Countries",
-      "alignmentText": "Japan and the U.S. view Taiwan favorably, while China claims it as territory.",
+      "alignmentText": "Japan and the U.S. view Taiwan favorably, while China claims it as territory. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 4
     },
     {
       "key": "View of self",
-      "alignmentText": "Strong national identity centers on democracy and resilience.",
+      "alignmentText": "Strong national identity centers on democracy and resilience. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 8
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Work visas, family reunification, entrepreneur visas, and the flexible Gold Card offer multiple routes.",
+      "alignmentText": "Work visas, family reunification, entrepreneur visas, and the flexible Gold Card offer multiple routes. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 7
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Close ties with the U.S. and friendly locals make Americans generally well received.",
+      "alignmentText": "Close ties with the U.S. and friendly locals make Americans generally well received. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 7
     },
     {
       "key": "What Is Intriguing",
-      "alignmentText": "Blend of high-tech industry and vibrant traditional culture stands out.",
+      "alignmentText": "Blend of high-tech industry and vibrant traditional culture stands out. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 8
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "Winters hover around 13–18°C (55–65°F) in Taipei with cool rain.",
+      "alignmentText": "Winters hover around 13–18°C (55–65°F) in Taipei with cool rain. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 8
     },
     {
       "key": "Work Week Hours",
-      "alignmentText": "Legal cap is 40 hours, yet overtime is common in practice.",
+      "alignmentText": "Legal cap is 40 hours, yet overtime is common in practice. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 4
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Long hours and after-work obligations can strain family time.",
+      "alignmentText": "Long hours and after-work obligations can strain family time. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 4
     },
     {
       "key": "Workers' Rights",
-      "alignmentText": "Labor laws mandate overtime pay and leave, but enforcement varies in smaller firms.",
+      "alignmentText": "Labor laws mandate overtime pay and leave, but enforcement varies in smaller firms. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 5
     }
   ]

--- a/reports/thailand_report.json
+++ b/reports/thailand_report.json
@@ -1,539 +1,540 @@
 {
+  "version": 2,
   "iso": "TH",
   "values": [
     {
       "key": "Environment",
-      "alignmentText": "Tropical forests, coral reefs, and national parks offer rich biodiversity amid urban sprawl.",
+      "alignmentText": "Tropical forests, coral reefs, and national parks offer rich biodiversity amid urban sprawl. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 7
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Low-lying coasts and hotter seasons make climate change a serious threat despite adaptation efforts.",
+      "alignmentText": "Low-lying coasts and hotter seasons make climate change a serious threat despite adaptation efforts. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 4
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "Hot, humid tropics with a rainy monsoon and short cool season, far from our mild preference.",
+      "alignmentText": "Hot, humid tropics with a rainy monsoon and short cool season, far from our mild preference. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 3
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Bangkok often suffers from PM2.5 pollution though smaller towns fare better.",
+      "alignmentText": "Bangkok often suffers from PM2.5 pollution though smaller towns fare better. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 4
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Seasonal flooding and occasional typhoons pose recurring hazards.",
+      "alignmentText": "Seasonal flooding and occasional typhoons pose recurring hazards. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 4
     },
     {
       "key": "Spring Temperature Range (C/F)",
-      "alignmentText": "26–34°C (79–93°F) hot and dry before the monsoon.",
+      "alignmentText": "26–34°C (79–93°F) hot and dry before the monsoon. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 3
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "25–32°C (77–90°F) with heavy rain and high humidity.",
+      "alignmentText": "25–32°C (77–90°F) with heavy rain and high humidity. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 3
     },
     {
       "key": "Fall Temperature Range (C/F)",
-      "alignmentText": "24–31°C (75–88°F) still humid but rains taper.",
+      "alignmentText": "24–31°C (75–88°F) still humid but rains taper. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 4
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "22–32°C (72–90°F) drier and slightly cooler.",
+      "alignmentText": "22–32°C (72–90°F) drier and slightly cooler. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 6
     },
     {
       "key": "Beach Life",
-      "alignmentText": "Islands like Phuket and Samui offer warm beaches and resort infrastructure.",
+      "alignmentText": "Islands like Phuket and Samui offer warm beaches and resort infrastructure. It shapes the family's weekend escapes when they need green space and fresh air.",
       "alignmentValue": 8
     },
     {
       "key": "Seasonal Beach Water Temp",
-      "alignmentText": "Seas stay around 27–30°C (81–86°F) year-round.",
+      "alignmentText": "Seas stay around 27–30°C (81–86°F) year-round. It shapes the family's weekend escapes when they need green space and fresh air.",
       "alignmentValue": 8
     },
     {
       "key": "Natural Beauty",
-      "alignmentText": "Karst mountains, jungles, and temples provide striking scenery.",
+      "alignmentText": "Karst mountains, jungles, and temples provide striking scenery. It shapes the family's weekend escapes when they need green space and fresh air.",
       "alignmentValue": 8
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "Daily minimum varies by province around 363 THB (~$10) offering a low baseline.",
+      "alignmentText": "Daily minimum varies by province around 363 THB (~$10) offering a low baseline. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 3
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Bangkok developers earn roughly $20k–$40k USD, stretching further with low costs.",
+      "alignmentText": "Bangkok developers earn roughly $20k–$40k USD, stretching further with low costs. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 5
     },
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Multinational firms and outsourcing shops use .NET but the ecosystem is modest.",
+      "alignmentText": "Multinational firms and outsourcing shops use .NET but the ecosystem is modest. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 4
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Ruby jobs are scarce, mainly in startups.",
+      "alignmentText": "Ruby jobs are scarce, mainly in startups. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 3
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Non-B work visas require employer sponsorship and proof of capital.",
+      "alignmentText": "Non-B work visas require employer sponsorship and proof of capital. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 4
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Tourism and manufacturing keep GDP growing though inequality persists.",
+      "alignmentText": "Tourism and manufacturing keep GDP growing though inequality persists. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 6
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Co-working hubs and nomad visas support remote work, especially in Bangkok and Chiang Mai.",
+      "alignmentText": "Co-working hubs and nomad visas support remote work, especially in Bangkok and Chiang Mai. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 7
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Thai offices can run long hours yet overall culture values leisure and festivals.",
+      "alignmentText": "Thai offices can run long hours yet overall culture values leisure and festivals. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 6
     },
     {
       "key": "Work Week Hours",
-      "alignmentText": "Labor law caps at 48 but many firms keep near 40.",
+      "alignmentText": "Labor law caps at 48 but many firms keep near 40. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 5
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Only 6 paid days after a year, among the region’s lowest.",
+      "alignmentText": "Only 6 paid days after a year, among the region’s lowest. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 3
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Multinationals offer 10–15 days and taking them is usually accepted.",
+      "alignmentText": "Multinationals offer 10–15 days and taking them is usually accepted. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 5
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Relaxed vibe outside Bangkok suits a slower lifestyle.",
+      "alignmentText": "Relaxed vibe outside Bangkok suits a slower lifestyle. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 7
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "School and work often start around 8 a.m., with evening markets or family dinners.",
+      "alignmentText": "School and work often start around 8 a.m., with evening markets or family dinners. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 6
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Weekends feature temple visits, outdoor markets, or beach trips.",
+      "alignmentText": "Weekends feature temple visits, outdoor markets, or beach trips. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 7
     },
     {
       "key": "Family Life",
-      "alignmentText": "Extended families are common and children are welcomed in public spaces.",
+      "alignmentText": "Extended families are common and children are welcomed in public spaces. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 7
     },
     {
       "key": "Polyamory",
-      "alignmentText": "No legal recognition and social norms favor monogamy.",
+      "alignmentText": "No legal recognition and social norms favor monogamy. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 2
     },
     {
       "key": "Parenting Expectations",
-      "alignmentText": "Society expects respectful, well-behaved kids; communal caretaking is normal.",
+      "alignmentText": "Society expects respectful, well-behaved kids; communal caretaking is normal. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 6
     },
     {
       "key": "Child-Friendliness of Cities",
-      "alignmentText": "Urban parks and malls cater to families though sidewalks can be rough.",
+      "alignmentText": "Urban parks and malls cater to families though sidewalks can be rough. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "Schooling Options",
-      "alignmentText": "Public schools are basic; international schools provide quality at high cost.",
+      "alignmentText": "Public schools are basic; international schools provide quality at high cost. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 4
     },
     {
       "key": "Pre-K / Early Childcare Landscape",
-      "alignmentText": "Private nurseries and preschool programs are available but quality varies.",
+      "alignmentText": "Private nurseries and preschool programs are available but quality varies. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "Government subsidies are limited, leaving families to self-fund.",
+      "alignmentText": "Government subsidies are limited, leaving families to self-fund. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 4
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Foreign families receive no subsidies but can access private centers.",
+      "alignmentText": "Foreign families receive no subsidies but can access private centers. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 3
     },
     {
       "key": "K-12 Education Access (Citizens)",
-      "alignmentText": "Universal basic education through grade 9 with mixed outcomes.",
+      "alignmentText": "Universal basic education through grade 9 with mixed outcomes. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "K-12 Education Access (Visa Holders)",
-      "alignmentText": "Public schools accept foreign kids but language barriers and quality pose issues.",
+      "alignmentText": "Public schools accept foreign kids but language barriers and quality pose issues. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 4
     },
     {
       "key": "Private Education",
-      "alignmentText": "International schools deliver high standards yet tuition is steep.",
+      "alignmentText": "International schools deliver high standards yet tuition is steep. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 4
     },
     {
       "key": "Family Policy (Citizens)",
-      "alignmentText": "Small child allowances and maternity leave exist but benefits are modest.",
+      "alignmentText": "Small child allowances and maternity leave exist but benefits are modest. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 4
     },
     {
       "key": "Family Policy (Visa Holders)",
-      "alignmentText": "Most benefits exclude foreigners aside from private insurance options.",
+      "alignmentText": "Most benefits exclude foreigners aside from private insurance options. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 3
     },
     {
       "key": "Higher Education Access (Citizens)",
-      "alignmentText": "Public universities are affordable and improving.",
+      "alignmentText": "Public universities are affordable and improving. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 6
     },
     {
       "key": "Higher Education Access (Visa Holders)",
-      "alignmentText": "Foreign students pay higher tuition but admissions are possible.",
+      "alignmentText": "Foreign students pay higher tuition but admissions are possible. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "Gender Roles",
-      "alignmentText": "Traditional roles persist though urban areas show more equality.",
+      "alignmentText": "Traditional roles persist though urban areas show more equality. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 5
     },
     {
       "key": "Gender Fluidity",
-      "alignmentText": "Thai culture shows visible gender variance, especially kathoey communities.",
+      "alignmentText": "Thai culture shows visible gender variance, especially kathoey communities. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 6
     },
     {
       "key": "Gender Rights",
-      "alignmentText": "Legal protections against discrimination remain limited.",
+      "alignmentText": "Legal protections against discrimination remain limited. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 4
     },
     {
       "key": "Femininity Norms",
-      "alignmentText": "Femininity is associated with modesty and soft-spoken behavior.",
+      "alignmentText": "Femininity is associated with modesty and soft-spoken behavior. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 5
     },
     {
       "key": "Masculinity Norms",
-      "alignmentText": "Men face expectations to provide and maintain a calm demeanor.",
+      "alignmentText": "Men face expectations to provide and maintain a calm demeanor. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 5
     },
     {
       "key": "What Is Intriguing",
-      "alignmentText": "Blend of Buddhist culture, street food, and digital nomad scene draws interest.",
+      "alignmentText": "Blend of Buddhist culture, street food, and digital nomad scene draws interest. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 7
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "Tourist zones use English but proficiency drops outside cities.",
+      "alignmentText": "Tourist zones use English but proficiency drops outside cities. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 4
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Social views are moderate with some reforms but conservative institutions.",
+      "alignmentText": "Social views are moderate with some reforms but conservative institutions. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 5
     },
     {
       "key": "Marxism (Societal Attitudes)",
-      "alignmentText": "Marxism holds little sway beyond academic circles.",
+      "alignmentText": "Marxism holds little sway beyond academic circles. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 3
     },
     {
       "key": "Atheism",
-      "alignmentText": "Buddhist majority allows private disbelief but few identify openly.",
+      "alignmentText": "Buddhist majority allows private disbelief but few identify openly. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 5
     },
     {
       "key": "Sex (Attitudes)",
-      "alignmentText": "Sex work is widespread yet public conversation remains modest.",
+      "alignmentText": "Sex work is widespread yet public conversation remains modest. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 4
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Public tolerance in urban areas contrasts with lack of legal rights.",
+      "alignmentText": "Public tolerance in urban areas contrasts with lack of legal rights. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 5
     },
     {
       "key": "Community Vibes",
-      "alignmentText": "Friendly smiles and neighborhood markets foster community.",
+      "alignmentText": "Friendly smiles and neighborhood markets foster community. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 7
     },
     {
       "key": "View of self",
-      "alignmentText": "Pride in hospitality and cultural heritage.",
+      "alignmentText": "Pride in hospitality and cultural heritage. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 7
     },
     {
       "key": "View of Neighboring Countries",
-      "alignmentText": "Generally cordial toward ASEAN neighbors but wary of Myanmar’s instability.",
+      "alignmentText": "Generally cordial toward ASEAN neighbors but wary of Myanmar’s instability. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "View of Them by Neighboring Countries",
-      "alignmentText": "Seen as a tourist magnet and pragmatic partner.",
+      "alignmentText": "Seen as a tourist magnet and pragmatic partner. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "Nightlife Culture",
-      "alignmentText": "Vibrant scenes from Bangkok clubs to beach parties.",
+      "alignmentText": "Vibrant scenes from Bangkok clubs to beach parties. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 8
     },
     {
       "key": "Fashion Trends (Male)",
-      "alignmentText": "Casual lightweight clothing suits the heat; business wear mostly in offices.",
+      "alignmentText": "Casual lightweight clothing suits the heat; business wear mostly in offices. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "Fashion Trends (Female)",
-      "alignmentText": "Blend of modest outfits and trendy street fashion.",
+      "alignmentText": "Blend of modest outfits and trendy street fashion. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "Common Hobbies",
-      "alignmentText": "Cooking classes, Muay Thai, and temple festivals are popular.",
+      "alignmentText": "Cooking classes, Muay Thai, and temple festivals are popular. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 7
     },
     {
       "key": "Boardgaming & Tabletop",
-      "alignmentText": "Growing café scene in Bangkok and Chiang Mai.",
+      "alignmentText": "Growing café scene in Bangkok and Chiang Mai. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 6
     },
     {
       "key": "Nightlife & Music",
-      "alignmentText": "Live music bars and EDM festivals abound.",
+      "alignmentText": "Live music bars and EDM festivals abound. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 8
     },
     {
       "key": "Meetups & Communities",
-      "alignmentText": "Expat and tech meetups flourish in urban hubs.",
+      "alignmentText": "Expat and tech meetups flourish in urban hubs. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 7
     },
     {
       "key": "Nature Access",
-      "alignmentText": "Easy access to jungles, mountains, and marine parks.",
+      "alignmentText": "Easy access to jungles, mountains, and marine parks. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 8
     },
     {
       "key": "Political System",
-      "alignmentText": "Constitutional monarchy with frequent military influence.",
+      "alignmentText": "Constitutional monarchy with frequent military influence. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 3
     },
     {
       "key": "Religion in Politics",
-      "alignmentText": "Buddhism informs culture yet the state is officially secular.",
+      "alignmentText": "Buddhism informs culture yet the state is officially secular. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 5
     },
     {
       "key": "Workers' Rights",
-      "alignmentText": "Labor unions exist but power is limited and enforcement inconsistent.",
+      "alignmentText": "Labor unions exist but power is limited and enforcement inconsistent. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 4
     },
     {
       "key": "State Ideology",
-      "alignmentText": "Nationalism and royalism dominate official narratives.",
+      "alignmentText": "Nationalism and royalism dominate official narratives. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 3
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Military coups and party bans keep democracy fragile.",
+      "alignmentText": "Military coups and party bans keep democracy fragile. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 3
     },
     {
       "key": "State of Capitalism",
-      "alignmentText": "Market-driven economy with a significant informal sector.",
+      "alignmentText": "Market-driven economy with a significant informal sector. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 6
     },
     {
       "key": "Stability",
-      "alignmentText": "Political protests recur but daily life remains mostly stable.",
+      "alignmentText": "Political protests recur but daily life remains mostly stable. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 5
     },
     {
       "key": "Propaganda Prevalence",
-      "alignmentText": "Government controls messaging around monarchy and security.",
+      "alignmentText": "Government controls messaging around the monarchy and security, and lèse-majesté laws deter dissenting coverage. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 4
     },
     {
       "key": "Propaganda Messaging",
-      "alignmentText": "Emphasis on royal loyalty and national unity.",
+      "alignmentText": "Official narratives celebrate royal virtue and national unity while downplaying political fractures. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 3
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Basic welfare programs exist but coverage is patchy.",
+      "alignmentText": "Basic welfare programs exist but coverage is patchy. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 4
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Many residents distrust politicians due to corruption scandals.",
+      "alignmentText": "Many residents distrust politicians due to corruption scandals. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 3
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Bribery and patronage are commonly perceived.",
+      "alignmentText": "Bribery and patronage are commonly perceived. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 3
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Petty bribery in bureaucracy alongside high-level kickbacks.",
+      "alignmentText": "Petty bribery in bureaucracy alongside high-level kickbacks. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 3
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Affordable rentals available but quality varies; expats cluster in condos.",
+      "alignmentText": "Affordable rentals are available in condos, but larger family homes can require longer searches or higher deposits. The family will need to budget and scout neighborhoods that balance space with transit access.",
       "alignmentValue": 6
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Violent crime is low but petty theft and scams affect tourists.",
+      "alignmentText": "Violent crime is low but petty theft and scams affect tourists. Trey and Sarah would keep close watch on the kids in crowded transit and market areas.",
       "alignmentValue": 6
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal Coverage Scheme provides basic care with long waits.",
+      "alignmentText": "Universal Coverage Scheme provides basic care with long waits. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 7
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Expats rely on private hospitals offering high-quality care at moderate prices.",
+      "alignmentText": "Expats rely on private hospitals offering high-quality care at moderate prices. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 7
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Limited public subsidies mean families often rely on relatives.",
+      "alignmentText": "Limited public subsidies mean families often rely on relatives. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 4
     },
     {
       "key": "Family Policy (Common Family)",
-      "alignmentText": "Policies support nuclear families modestly with maternity leave and education subsidies.",
+      "alignmentText": "Policies support nuclear families modestly with maternity leave and education subsidies. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 4
     },
     {
       "key": "Education",
-      "alignmentText": "Public education quality varies; strong private and international options exist.",
+      "alignmentText": "Public education quality varies; strong private and international options exist. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 4
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Bangkok's BTS/MRT and regional buses provide coverage but rural areas rely on cars.",
+      "alignmentText": "Bangkok's BTS/MRT and regional buses provide coverage but rural areas rely on cars. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 5
     },
     {
       "key": "Economic System",
-      "alignmentText": "Mixed economy with strong tourism and manufacturing sectors.",
+      "alignmentText": "Mixed economy with strong tourism and manufacturing sectors. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 6
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "Progressive income tax filed annually; VAT collected at point of sale.",
+      "alignmentText": "Progressive income tax filed annually; VAT collected at point of sale. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 6
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "With moderate incomes, effective income tax likely around 15%.",
+      "alignmentText": "With moderate incomes, effective income tax likely around 15%. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 6
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "Modern banking apps and QR payments are widely adopted.",
+      "alignmentText": "Modern banking apps and QR payments are widely adopted. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 8
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Low costs for food and housing stretch budgets.",
+      "alignmentText": "Low costs for food and housing stretch budgets. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 8
     },
     {
       "key": "Retirement (Citizens)",
-      "alignmentText": "State pension exists but payouts are small.",
+      "alignmentText": "State pension exists but payouts are small. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 4
     },
     {
       "key": "Retirement (Visa Holders)",
-      "alignmentText": "Long-stay retirement visas and affordable healthcare make retirement feasible.",
-      "alignmentValue": 7
+      "alignmentText": "Long-stay retirement visas exist but require proof of sizable savings and offer no access to state pensions. It guides household budgeting and Trey's entrepreneurship planning.",
+      "alignmentValue": 4
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Tourist, Non-B, marriage, and Elite visas offer varied routes but paperwork is heavy.",
+      "alignmentText": "Tourist, Non-B, marriage, and Elite visas offer varied routes but paperwork is heavy. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 5
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Friendly to Westerners though long-term residency requires patience.",
+      "alignmentText": "Friendly to Westerners though long-term residency requires patience. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 5
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "One-year extensions or elite packages; permanent residency after years.",
+      "alignmentText": "One-year extensions or elite packages; permanent residency after years. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 4
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Naturalization demands years of residence, language, and quotas.",
+      "alignmentText": "Naturalization demands years of residence, language, and quotas. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 3
     },
     {
       "key": "Family Members",
-      "alignmentText": "Spouses and kids can be included on dependent visas.",
+      "alignmentText": "Spouses and kids can be included on dependent visas. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 6
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Processing takes months; elite visa fees reach tens of thousands USD.",
+      "alignmentText": "Processing takes months; elite visa fees reach tens of thousands USD. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 4
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Strict reporting and overstay fines require diligence.",
+      "alignmentText": "Strict reporting and overstay fines require diligence. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 4
     },
     {
       "key": "Dual Citizenship Allowed",
-      "alignmentText": "Thai-born can hold dual; naturalized citizens are expected to renounce.",
+      "alignmentText": "Thai-born can hold dual; naturalized citizens are expected to renounce. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 4
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Regular 90-day reports and address checks can be bureaucratic.",
+      "alignmentText": "Regular 90-day reports and address checks can be bureaucratic. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 4
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Growing indie scene and outsourcing companies but limited AAA presence.",
+      "alignmentText": "Growing indie scene and outsourcing companies but limited AAA presence. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 5
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Studios like Sanuk Games and Urnique produce regional titles.",
+      "alignmentText": "Studios like Sanuk Games and Urnique produce regional titles. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 5
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "Events in Bangkok and Chiang Mai foster small dev communities.",
+      "alignmentText": "Events in Bangkok and Chiang Mai foster small dev communities. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 6
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Low living costs and emerging talent make a feasible launchpad.",
+      "alignmentText": "Low living costs and emerging talent make a feasible launchpad. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 6
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "High-speed internet and modern malls coexist with patchy rural infrastructure.",
+      "alignmentText": "High-speed internet and modern malls coexist with patchy rural infrastructure. Solid infrastructure supports their remote work, gaming, and everyday logistics.",
       "alignmentValue": 6
     }
   ]

--- a/reports/vietnam_report.json
+++ b/reports/vietnam_report.json
@@ -1,539 +1,540 @@
 {
+  "version": 2,
   "iso": "VN",
   "values": [
     {
       "key": "Environment",
-      "alignmentText": "Lush mountains, river deltas, and long coastlines offer varied ecosystems, though rapid urbanization and deforestation strain habitats.",
+      "alignmentText": "Lush mountains, river deltas, and long coastlines offer varied ecosystems, though rapid urbanization and deforestation strain habitats. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 5
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "The Mekong and Red River deltas face severe sea-level rise and saltwater intrusion risks despite national adaptation plans.",
+      "alignmentText": "The Mekong and Red River deltas face severe sea-level rise and saltwater intrusion risks despite national adaptation plans. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 3
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "Tropical monsoon patterns bring hot, humid summers and a drier, cooler season in the north, far more humid than our mild ideal.",
+      "alignmentText": "Tropical monsoon patterns bring hot, humid summers and a drier, cooler season in the north, far more humid than our mild ideal. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 3
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Hanoi and Ho Chi Minh City frequently exceed WHO PM2.5 limits due to traffic and burning, with only seasonal relief.",
+      "alignmentText": "Hanoi and Ho Chi Minh City frequently exceed WHO PM2.5 limits due to traffic and burning, with only seasonal relief. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 3
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Typhoons, flooding, and occasional landslides are recurring hazards, especially along the central coast.",
+      "alignmentText": "Typhoons, flooding, and occasional landslides are recurring hazards, especially along the central coast. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 3
     },
     {
       "key": "Spring Temperature Range (C/F)",
-      "alignmentText": "Northern cities run ~20\u201328\u00b0C (68\u201382\u00b0F) with rising humidity; southern hubs stay near 26\u201334\u00b0C (79\u201393\u00b0F).",
+      "alignmentText": "Northern cities run ~20–28°C (68–82°F) with rising humidity; southern hubs stay near 26–34°C (79–93°F). That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 4
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "Expect 27\u201335\u00b0C (81\u201395\u00b0F) plus high humidity and heavy monsoon rains, challenging for heat-sensitive family members.",
+      "alignmentText": "Expect 27–35°C (81–95°F) plus high humidity and heavy monsoon rains, challenging for heat-sensitive family members. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 3
     },
     {
       "key": "Fall Temperature Range (C/F)",
-      "alignmentText": "Autumn in the north sits ~22\u201330\u00b0C (72\u201386\u00b0F) but central regions see typhoon rains; the south remains steamy.",
+      "alignmentText": "Autumn in the north sits ~22–30°C (72–86°F) but central regions see typhoon rains; the south remains steamy. That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 4
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "North Vietnam cools to 15\u201322\u00b0C (59\u201372\u00b0F) with damp chill; southern cities hover near 23\u201331\u00b0C (73\u201388\u00b0F).",
+      "alignmentText": "North Vietnam cools to 15–22°C (59–72°F) with damp chill; southern cities hover near 23–31°C (73–88°F). That helps the family plan around their mild-weather preference and safe outdoor time for the boys.",
       "alignmentValue": 5
     },
     {
       "key": "Beach Life",
-      "alignmentText": "Da Nang, Nha Trang, and Phu Quoc provide warm beaches, though water cleanliness varies with season and development.",
+      "alignmentText": "Da Nang, Nha Trang, and Phu Quoc provide warm beaches, though water cleanliness varies with season and development. It shapes the family's weekend escapes when they need green space and fresh air.",
       "alignmentValue": 6
     },
     {
       "key": "Seasonal Beach Water Temp",
-      "alignmentText": "Coastal waters stay about 25\u201329\u00b0C (77\u201384\u00b0F) year-round, comfortable for swimming.",
+      "alignmentText": "Coastal waters stay about 25–29°C (77–84°F) year-round, comfortable for swimming. It shapes the family's weekend escapes when they need green space and fresh air.",
       "alignmentValue": 7
     },
     {
       "key": "Natural Beauty",
-      "alignmentText": "Karst bays, terraced highlands, and national parks like Phong Nha offer dramatic scenery and outdoor excursions.",
+      "alignmentText": "Karst bays, terraced highlands, and national parks like Phong Nha offer dramatic scenery and outdoor excursions. It shapes the family's weekend escapes when they need green space and fresh air.",
       "alignmentValue": 7
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "Regional monthly minimum wages range 3.25\u20134.68M VND (~$130\u2013190 USD), low for international families.",
+      "alignmentText": "Regional monthly minimum wages range 3.25–4.68M VND (~$130–190 USD), low for international families. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 3
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Mid-level developers in Ho Chi Minh City earn roughly $18k\u201335k USD yearly, boosted by low living costs but modest globally.",
+      "alignmentText": "Mid-level developers in Ho Chi Minh City earn roughly $18k–35k USD yearly, boosted by low living costs but modest globally. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 5
     },
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Firms such as FPT Software and NashTech run sizable .NET teams, yet competition for higher-paying roles is stiff.",
+      "alignmentText": "Firms such as FPT Software and NashTech run sizable .NET teams, yet competition for higher-paying roles is stiff. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 6
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Ruby roles are niche, concentrated in a few startups and outsourcing houses, limiting opportunities for Sarah.",
+      "alignmentText": "Ruby roles are niche, concentrated in a few startups and outsourcing houses, limiting opportunities for Sarah. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 3
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Work permits require employer sponsorship, degree proof, and criminal checks; reputable firms manage the paperwork but expect lead time.",
+      "alignmentText": "Work permits require employer sponsorship, degree proof, and criminal checks; reputable firms manage the paperwork but expect lead time. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 5
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Vietnam posts ~5\u20136% GDP growth with expanding manufacturing and services, though inflation spikes occasionally.",
+      "alignmentText": "Vietnam posts ~5–6% GDP growth with expanding manufacturing and services, though inflation spikes occasionally. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 6
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Ho Chi Minh City and Da Nang host coworking hubs and reliable fiber, but time zones complicate US collaboration.",
+      "alignmentText": "Ho Chi Minh City and Da Nang host coworking hubs and reliable fiber, but time zones complicate US collaboration. Trey and Sarah factor this into balancing remote work with any local tech roles.",
       "alignmentValue": 6
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Export-oriented companies often expect overtime, though some tech firms embrace flexible schedules.",
+      "alignmentText": "Export-oriented companies often expect overtime, though some tech firms embrace flexible schedules. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 4
     },
     {
       "key": "Work Week Hours",
-      "alignmentText": "Labor law caps at 48 hours; many offices run 44\u201348, with overtime during peak projects.",
+      "alignmentText": "Labor law caps at 48 hours; many offices run 44–48, with overtime during peak projects. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 4
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Employees receive 12 paid days plus public holidays, modest compared with Europe.",
+      "alignmentText": "Employees receive 12 paid days plus public holidays, modest compared with Europe. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 5
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "International employers may offer 15\u201318 days, but local firms rarely exceed the statutory minimum.",
+      "alignmentText": "International employers may offer 15–18 days, but local firms rarely exceed the statutory minimum. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 5
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Ho Chi Minh City is fast-paced, while Da Nang and Hue offer a calmer lifestyle that could suit Sarah\u2019s slower preference.",
+      "alignmentText": "Ho Chi Minh City is fast-paced, while Da Nang and Hue offer a calmer lifestyle that could suit Sarah’s slower preference. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 6
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "Offices commonly run 8:00\u201317:30 with a long lunch; schools start near 7:30 and finish mid-afternoon, requiring after-school plans.",
+      "alignmentText": "Offices commonly run 8:00–17:30 with a long lunch; schools start near 7:30 and finish mid-afternoon, requiring after-school plans. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 4
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Weekends revolve around morning markets, caf\u00e9 meetups, and family outings before hot afternoons drive people indoors.",
+      "alignmentText": "Weekends revolve around morning markets, café meetups, and family outings before hot afternoons drive people indoors. This directly affects Sarah's need for a calmer rhythm and shared family evenings.",
       "alignmentValue": 6
     },
     {
       "key": "Family Life",
-      "alignmentText": "Family-centric culture values children, yet public spaces can be crowded and sidewalks uneven for strollers.",
+      "alignmentText": "Family-centric culture values children, yet public spaces can be crowded and sidewalks uneven for strollers. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "Polyamory",
-      "alignmentText": "Non-monogamous relationships lack legal recognition and remain socially taboo; discretion would be essential.",
+      "alignmentText": "Non-monogamous relationships lack legal recognition and remain socially taboo; discretion would be essential. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 1
     },
     {
       "key": "Parenting Expectations",
-      "alignmentText": "Schools and relatives emphasize academic achievement and respect for elders, creating pressure for kids to conform.",
+      "alignmentText": "Schools and relatives emphasize academic achievement and respect for elders, creating pressure for kids to conform. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 4
     },
     {
       "key": "Child-Friendliness of Cities",
-      "alignmentText": "Urban parks and indoor play spaces exist but are limited; traffic and air quality require vigilance with young children.",
+      "alignmentText": "Urban parks and indoor play spaces exist but are limited; traffic and air quality require vigilance with young children. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 4
     },
     {
       "key": "Schooling Options",
-      "alignmentText": "Public schools are Vietnamese-language and test-heavy; international schools in major cities offer English curricula at high tuition.",
+      "alignmentText": "Public schools are Vietnamese-language and test-heavy; international schools in major cities offer English curricula at high tuition. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "Pre-K / Early Childcare Landscape",
-      "alignmentText": "Private preschools and bilingual Montessori options operate in cities, yet quality varies and waitlists can be long.",
+      "alignmentText": "Private preschools and bilingual Montessori options operate in cities, yet quality varies and waitlists can be long. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "State subsidies are modest; extended family often fills gaps, leaving formal childcare uneven.",
+      "alignmentText": "State subsidies are modest; extended family often fills gaps, leaving formal childcare uneven. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 4
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Foreign families rely on pricey international preschools or nannies, with little government assistance.",
+      "alignmentText": "Foreign families rely on pricey international preschools or nannies, with little government assistance. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 3
     },
     {
       "key": "K-12 Education Access (Citizens)",
-      "alignmentText": "Citizens access free-to-low-cost public schools, though rural quality gaps remain.",
+      "alignmentText": "Citizens access free-to-low-cost public schools, though rural quality gaps remain. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 6
     },
     {
       "key": "K-12 Education Access (Visa Holders)",
-      "alignmentText": "Foreign children may enroll in public schools but face language and bureaucratic barriers; most choose private options.",
+      "alignmentText": "Foreign children may enroll in public schools but face language and bureaucratic barriers; most choose private options. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 4
     },
     {
       "key": "Private Education",
-      "alignmentText": "International Baccalaureate and British schools deliver high-quality programs at $15k\u201330k USD per child annually.",
+      "alignmentText": "International Baccalaureate and British schools deliver high-quality programs at $15k–30k USD per child annually. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "Family Policy (Citizens)",
-      "alignmentText": "Maternity leave lasts 6 months at partial pay and child allowances are small, offering moderate support.",
+      "alignmentText": "Maternity leave lasts 6 months at partial pay and child allowances are small, offering moderate support. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "Family Policy (Visa Holders)",
-      "alignmentText": "Foreign workers generally follow employer policies with limited statutory benefits beyond basic leave.",
+      "alignmentText": "Foreign workers generally follow employer policies with limited statutory benefits beyond basic leave. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 4
     },
     {
       "key": "Higher Education Access (Citizens)",
-      "alignmentText": "Public universities are affordable and expanding, especially in engineering and IT.",
+      "alignmentText": "Public universities are affordable and expanding, especially in engineering and IT. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 6
     },
     {
       "key": "Higher Education Access (Visa Holders)",
-      "alignmentText": "International programs accept foreign students, though language readiness and paperwork add friction.",
+      "alignmentText": "International programs accept foreign students, though language readiness and paperwork add friction. Those conditions determine how easily Anduin and Alasdair can thrive day to day.",
       "alignmentValue": 5
     },
     {
       "key": "Gender Roles",
-      "alignmentText": "Traditional gender expectations persist, yet urban professionals increasingly support dual-career households.",
+      "alignmentText": "Traditional gender expectations persist, yet urban professionals increasingly support dual-career households. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 5
     },
     {
       "key": "Gender Fluidity",
-      "alignmentText": "Legal recognition for trans and nonbinary identities is minimal, though youth culture is slowly more accepting.",
+      "alignmentText": "Legal recognition for trans and nonbinary identities is minimal, though youth culture is slowly more accepting. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 3
     },
     {
       "key": "Gender Rights",
-      "alignmentText": "Gender equality laws exist, but wage gaps and limited political representation remain challenges.",
+      "alignmentText": "Gender equality laws exist, but wage gaps and limited political representation remain challenges. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 4
     },
     {
       "key": "Femininity Norms",
-      "alignmentText": "Women face pressure toward modest dress and family caregiving, especially outside major metros.",
+      "alignmentText": "Women face pressure toward modest dress and family caregiving, especially outside major metros. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 4
     },
     {
       "key": "Masculinity Norms",
-      "alignmentText": "Men are expected to be primary earners and defer to elders, with growing acceptance of softer roles in cities.",
+      "alignmentText": "Men are expected to be primary earners and defer to elders, with growing acceptance of softer roles in cities. Their progressive, polyamory-positive values make this climate especially important.",
       "alignmentValue": 4
     },
     {
       "key": "What Is Intriguing",
-      "alignmentText": "Dynamic street food scenes, French-colonial architecture, and UNESCO sites create constant exploration opportunities.",
+      "alignmentText": "Dynamic street food scenes, French-colonial architecture, and UNESCO sites create constant exploration opportunities. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 7
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "Vietnamese is dominant; English proficiency is improving in tech hubs but drops sharply outside cities.",
+      "alignmentText": "Vietnamese is dominant; English proficiency is improving in tech hubs but drops sharply outside cities. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 4
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Social policy is cautious and the one-party state limits activism, offering limited progressive reforms.",
+      "alignmentText": "Social policy is cautious and the one-party state limits activism, offering limited progressive reforms. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 3
     },
     {
       "key": "Marxism (Societal Attitudes)",
-      "alignmentText": "Official ideology remains socialist, though daily life blends market pragmatism with party messaging.",
+      "alignmentText": "Official ideology remains socialist, though daily life blends market pragmatism with party messaging. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 5
     },
     {
       "key": "Atheism",
-      "alignmentText": "State is officially atheist, yet folk Buddhism and ancestor worship are widely practiced.",
+      "alignmentText": "State is officially atheist, yet folk Buddhism and ancestor worship are widely practiced. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 5
     },
     {
       "key": "Sex (Attitudes)",
-      "alignmentText": "Public discussion of sexuality is conservative; sex education is limited and discretion is expected.",
+      "alignmentText": "Public discussion of sexuality is conservative; sex education is limited and discretion is expected. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 3
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Same-sex marriage is neither recognized nor outlawed; urban Pride events exist but stigma persists.",
+      "alignmentText": "Same-sex marriage is neither recognized nor outlawed; urban Pride events exist but stigma persists. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 4
     },
     {
       "key": "Community Vibes",
-      "alignmentText": "Tight-knit neighborhoods, night markets, and expat groups foster connection if you engage locally.",
+      "alignmentText": "Tight-knit neighborhoods, night markets, and expat groups foster connection if you engage locally. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "View of self",
-      "alignmentText": "Vietnamese pride centers on resilience, entrepreneurial hustle, and hospitality toward guests.",
+      "alignmentText": "Vietnamese pride centers on resilience, entrepreneurial hustle, and hospitality toward guests. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "View of Neighboring Countries",
-      "alignmentText": "Relations with ASEAN neighbors are pragmatic, while maritime disputes with China create wariness.",
+      "alignmentText": "Relations with ASEAN neighbors are pragmatic, while maritime disputes with China create wariness. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 5
     },
     {
       "key": "View of Them by Neighboring Countries",
-      "alignmentText": "Vietnam is seen as a fast-growing manufacturing hub and reliable regional partner, though rivalry with China lingers.",
+      "alignmentText": "Vietnam is seen as a fast-growing manufacturing hub and reliable regional partner, though rivalry with China lingers. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "Nightlife Culture",
-      "alignmentText": "Major cities offer lively rooftop bars, craft beer spots, and late-night street food.",
+      "alignmentText": "Major cities offer lively rooftop bars, craft beer spots, and late-night street food. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 7
     },
     {
       "key": "Fashion Trends (Male)",
-      "alignmentText": "Young men mix casual streetwear with office formalwear; tailored shirts and sneakers dominate.",
+      "alignmentText": "Young men mix casual streetwear with office formalwear; tailored shirts and sneakers dominate. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "Fashion Trends (Female)",
-      "alignmentText": "Women blend ao dai heritage with modern Korean-influenced styles, balancing modesty and flair.",
+      "alignmentText": "Women blend ao dai heritage with modern Korean-influenced styles, balancing modesty and flair. It signals how comfortably their progressive, gaming-friendly lifestyle would mesh locally.",
       "alignmentValue": 6
     },
     {
       "key": "Common Hobbies",
-      "alignmentText": "Soccer, badminton, karaoke, and motorbike road trips are popular pastimes.",
+      "alignmentText": "Soccer, badminton, karaoke, and motorbike road trips are popular pastimes. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 6
     },
     {
       "key": "Boardgaming & Tabletop",
-      "alignmentText": "Board game caf\u00e9s in Hanoi and Ho Chi Minh City host small but growing communities.",
+      "alignmentText": "Board game cafés in Hanoi and Ho Chi Minh City host small but growing communities. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 5
     },
     {
       "key": "Nightlife & Music",
-      "alignmentText": "Live music venues range from jazz clubs to indie gigs, though noise curfews can end nights early.",
+      "alignmentText": "Live music venues range from jazz clubs to indie gigs, though noise curfews can end nights early. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 6
     },
     {
       "key": "Meetups & Communities",
-      "alignmentText": "Tech meetups, language exchanges, and parenting groups meet regularly in expat districts.",
+      "alignmentText": "Tech meetups, language exchanges, and parenting groups meet regularly in expat districts. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 6
     },
     {
       "key": "Nature Access",
-      "alignmentText": "Weekend trips reach national parks, highland retreats like Da Lat, and scenic coastal drives.",
+      "alignmentText": "Weekend trips reach national parks, highland retreats like Da Lat, and scenic coastal drives. Shared hobbies and inclusive scenes help Trey keep gaming and Sarah build community.",
       "alignmentValue": 6
     },
     {
       "key": "Political System",
-      "alignmentText": "One-party socialist republic led by the Communist Party with centralized decision-making.",
+      "alignmentText": "One-party socialist republic led by the Communist Party with centralized decision-making. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 2
     },
     {
       "key": "Religion in Politics",
-      "alignmentText": "The state is officially secular and restricts religious influence on governance.",
+      "alignmentText": "The state is officially secular and restricts religious influence on governance. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 6
     },
     {
       "key": "Workers' Rights",
-      "alignmentText": "Unions are state-run and strikes require approval, limiting independent labor advocacy.",
+      "alignmentText": "Unions are state-run and strikes require approval, limiting independent labor advocacy. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 3
     },
     {
       "key": "State Ideology",
-      "alignmentText": "The party promotes a socialist-oriented market economy and collective prosperity narrative.",
+      "alignmentText": "The party promotes a socialist-oriented market economy and collective prosperity narrative. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 4
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Media censorship, anti-dissent laws, and recent arrests of activists indicate high authoritarian risk.",
+      "alignmentText": "Media censorship, anti-dissent laws, and recent arrests of activists indicate high authoritarian risk. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 2
     },
     {
       "key": "State of Capitalism",
-      "alignmentText": "A hybrid economy welcomes foreign investment while strategic sectors stay under state guidance.",
+      "alignmentText": "A hybrid economy welcomes foreign investment while strategic sectors stay under state guidance. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 6
     },
     {
       "key": "Stability",
-      "alignmentText": "Political stability is strong with predictable leadership transitions and low civil unrest.",
+      "alignmentText": "Political stability is strong with predictable leadership transitions and low civil unrest. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 7
     },
     {
       "key": "Propaganda Prevalence",
-      "alignmentText": "State media and billboards deliver unified messaging on development and patriotism.",
+      "alignmentText": "State media and billboards deliver unified messaging on development and patriotism. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 3
     },
     {
       "key": "Propaganda Messaging",
-      "alignmentText": "Narratives emphasize economic growth, party loyalty, and national sovereignty.",
+      "alignmentText": "Narratives emphasize economic growth, party loyalty, and national sovereignty. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 4
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Programs target poverty reduction and rural development but civil liberties remain constrained.",
+      "alignmentText": "Programs target poverty reduction and rural development but civil liberties remain constrained. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 4
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Surveys show moderate trust in central authorities, though locals often question lower-level corruption.",
+      "alignmentText": "Surveys show moderate trust in central authorities, though locals often question lower-level corruption. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 5
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Transparency International scores Vietnam mid-low due to petty bribery and opaque procurement.",
+      "alignmentText": "Transparency International scores Vietnam mid-low due to petty bribery and opaque procurement. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 3
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Facilitation payments for permits and state-linked business favoritism are the most cited issues.",
+      "alignmentText": "Facilitation payments for permits and state-linked business favoritism are the most cited issues. They prioritize resilient democracies with transparent institutions for their kids' future.",
       "alignmentValue": 3
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Rapid condo development offers modern units, yet expat rents in top districts are rising quickly.",
+      "alignmentText": "Rapid condo development offers modern units, yet expat rents in top districts are rising quickly. The family must weigh proximity to schools and air quality against budget flexibility.",
       "alignmentValue": 5
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Violent crime is rare, but petty theft and motorbike accidents are common urban risks.",
+      "alignmentText": "Violent crime is rare, but petty theft and motorbike accidents are common urban risks. Trey and Sarah would plan extra street-safety routines for the boys.",
       "alignmentValue": 6
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal health insurance covers basic care, yet overcrowded public hospitals limit quality.",
+      "alignmentText": "Universal health insurance covers basic care, yet overcrowded public hospitals limit quality. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 5
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Private hospitals deliver high-quality care with English-speaking staff at moderate costs compared with the US.",
+      "alignmentText": "Private hospitals deliver high-quality care with English-speaking staff at moderate costs compared with the US. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 6
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Working parents rely on grandparents or private caregivers; formal state programs remain limited.",
+      "alignmentText": "Working parents rely on grandparents or private caregivers; formal state programs remain limited. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 4
     },
     {
       "key": "Family Policy (Common Family)",
-      "alignmentText": "Families receive modest cash allowances and tuition reductions, but benefits rarely cover actual costs.",
+      "alignmentText": "Families receive modest cash allowances and tuition reductions, but benefits rarely cover actual costs. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 4
     },
     {
       "key": "Education",
-      "alignmentText": "STEM achievement is strong, yet rote learning and class sizes may clash with progressive pedagogy preferences.",
+      "alignmentText": "STEM achievement is strong, yet rote learning and class sizes may clash with progressive pedagogy preferences. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 5
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Urban buses are widespread; Ho Chi Minh City\u2019s first metro line opens soon but mass transit remains limited.",
+      "alignmentText": "Urban buses are widespread; Ho Chi Minh City’s first metro line opens soon but mass transit remains limited. Reliable public services are critical for the children's schooling, healthcare, and mobility.",
       "alignmentValue": 4
     },
     {
       "key": "Economic System",
-      "alignmentText": "Socialist-oriented market economy balancing state-owned giants with vibrant private SMEs.",
+      "alignmentText": "Socialist-oriented market economy balancing state-owned giants with vibrant private SMEs. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 6
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "Personal income tax is progressive (5\u201335%) with monthly payroll withholding and annual reconciliation.",
+      "alignmentText": "Personal income tax is progressive (5–35%) with monthly payroll withholding and annual reconciliation. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 5
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "At moderate expat salaries, effective income tax would likely land near 10\u201315% plus social insurance contributions.",
+      "alignmentText": "At moderate expat salaries, effective income tax would likely land near 10–15% plus social insurance contributions. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 6
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "Digital wallets like MoMo and widespread QR payments coexist with a still-cash-heavy culture.",
+      "alignmentText": "Digital wallets like MoMo and widespread QR payments coexist with a still-cash-heavy culture. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 6
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Housing, food, and services remain far below US costs, enabling significant savings if schooling is managed.",
+      "alignmentText": "Housing, food, and services remain far below US costs, enabling significant savings if schooling is managed. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 8
     },
     {
       "key": "Retirement (Citizens)",
-      "alignmentText": "State pensions are modest and depend on long contribution histories, prompting reliance on family support.",
+      "alignmentText": "State pensions are modest and depend on long contribution histories, prompting reliance on family support. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 4
     },
     {
       "key": "Retirement (Visa Holders)",
-      "alignmentText": "No dedicated retirement visa; long-stay options require investment or marriage, limiting ease for foreigners.",
+      "alignmentText": "No dedicated retirement visa; long-stay options require investment or marriage, limiting ease for foreigners. It guides household budgeting and Trey's entrepreneurship planning.",
       "alignmentValue": 3
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Options include work permits with temporary residence cards, investor visas, and marriage visas, each with layered paperwork.",
+      "alignmentText": "Options include work permits with temporary residence cards, investor visas, and marriage visas, each with layered paperwork. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 4
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Locals are generally friendly to Americans, but immigration bureaucracy and language barriers temper the welcome.",
+      "alignmentText": "Locals are generally friendly to Americans, but immigration bureaucracy and language barriers temper the welcome. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 5
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Temporary residence cards typically last 1\u20133 years and require ongoing employer or investment sponsorship.",
+      "alignmentText": "Temporary residence cards typically last 1–3 years and require ongoing employer or investment sponsorship. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 4
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Naturalization demands 5+ years\u2019 residence, language fluency, and usually renouncing prior citizenship.",
+      "alignmentText": "Naturalization demands 5+ years’ residence, language fluency, and usually renouncing prior citizenship. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 2
     },
     {
       "key": "Family Members",
-      "alignmentText": "Spouses and children can obtain dependent residence tied to the principal visa holder.",
+      "alignmentText": "Spouses and children can obtain dependent residence tied to the principal visa holder. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 5
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Work permit and TRC processing often take 2\u20133 months with fees in the hundreds of USD plus translation costs.",
+      "alignmentText": "Work permit and TRC processing often take 2–3 months with fees in the hundreds of USD plus translation costs. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 4
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Quarterly reporting, local police registrations, and sudden rule changes require ongoing diligence.",
+      "alignmentText": "Quarterly reporting, local police registrations, and sudden rule changes require ongoing diligence. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 3
     },
     {
       "key": "Dual Citizenship Allowed",
-      "alignmentText": "Vietnam allows limited dual citizenship, but naturalizing foreigners are commonly asked to renounce prior passports.",
+      "alignmentText": "Vietnam allows limited dual citizenship, but naturalizing foreigners are commonly asked to renounce prior passports. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 3
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Keeping notarized translations, health checks, and employer paperwork current is essential to avoid fines.",
+      "alignmentText": "Keeping notarized translations, health checks, and employer paperwork current is essential to avoid fines. Visa stability is essential so the household can settle without disruption.",
       "alignmentValue": 4
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Studios like VNG, Sparx*, and Glass Egg (Virtuos) employ large art and engineering teams serving global clients.",
+      "alignmentText": "Studios like VNG, Sparx*, and Glass Egg (Virtuos) employ large art and engineering teams serving global clients. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 6
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Key players include VNG Games, Sparx* (Virtuos), Gameloft Vietnam, and indie shop Emobi.",
+      "alignmentText": "Key players include VNG Games, Sparx* (Virtuos), Gameloft Vietnam, and indie shop Emobi. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 6
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "GameDev Vietnam, Global Game Jam chapters, and Saigon\u2019s Indie Game Developers group host regular meetups.",
+      "alignmentText": "GameDev Vietnam, Global Game Jam chapters, and Saigon’s Indie Game Developers group host regular meetups. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 6
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Low burn rates and abundant art talent help early-stage studios, though funding networks remain nascent.",
+      "alignmentText": "Low burn rates and abundant art talent help early-stage studios, though funding networks remain nascent. Trey's hope to launch a game studio depends on ecosystems like this.",
       "alignmentValue": 6
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "Fiber internet and new metro projects signal modern growth, yet power outages and uneven sidewalks persist.",
+      "alignmentText": "Fiber internet and new metro projects signal modern growth, yet power outages and uneven sidewalks persist. Solid infrastructure supports their remote work, gaming, and everyday logistics.",
       "alignmentValue": 5
     }
   ]


### PR DESCRIPTION
## Summary
- mark the Taiwan report as version 2, weave the family’s priorities into every alignment note, and recalibrate items like climate risk, propaganda exposure, housing, and safety
- refresh the Thailand report with family-focused context, updated propaganda descriptions, and corrected retirement access scoring
- update the Vietnam report to version 2 with family-centred guidance on environment, housing, safety, and key service considerations

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e315f268d4832191fd27952e63264f