### PR TITLE
Upgrade Greenland, Italy, Laos, Russia, and South Korea reports to v2

### DIFF
--- a/reports/greenland_report.json
+++ b/reports/greenland_report.json
@@ -1,104 +1,105 @@
 {
+  "version": 2,
   "iso": "GL",
   "values": [
     {
       "key": "Environment",
-      "alignmentText": "Vast unspoiled wilderness with minimal pollution, appealing for outdoor family adventures.",
+      "alignmentText": "Glaciers, fjords, and low pollution create spectacular nature escapes, even if gear and careful planning are needed for the kids.",
       "alignmentValue": 8
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Rapid Arctic warming threatens ecosystems and traditional lifestyles.",
-      "alignmentValue": 3
+      "alignmentText": "Arctic warming is racing ahead of global averages, threatening permafrost, fisheries, and coastal settlements the family would rely on.",
+      "alignmentValue": 2
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "Long, dark winters and short, cool summers pose challenges for a family preferring mild climates.",
-      "alignmentValue": 3
+      "alignmentText": "Polar night stretches for months and short summers stay chilly, far from the mild year-round climate we want.",
+      "alignmentValue": 1
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Crisp Arctic air with low industrial emissions offers excellent breathing conditions.",
+      "alignmentText": "With minimal industry and ocean winds, air stays crisp except for occasional wood-stove smoke in winter.",
       "alignmentValue": 9
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Limited earthquake or storm activity but risk of ice-related hazards.",
-      "alignmentValue": 6
+      "alignmentText": "Major quakes or storms are rare, yet warming-driven landslides and coastal erosion add nontrivial safety planning.",
+      "alignmentValue": 4
     },
     {
       "key": "Spring Temperature Range (C/F)",
-      "alignmentText": "Around -5°C to 5°C (23-41°F) with lingering snow and increasing daylight.",
-      "alignmentValue": 2
+      "alignmentText": "Spring hovers below freezing until May, so playground time still needs snow gear.",
+      "alignmentValue": 1
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "Typically 5-15°C (41-59°F); cool even in peak season, aligning poorly with warmth preference.",
-      "alignmentValue": 3
-    },
-    {
-      "key": "Fall Temperature Range (C/F)",
-      "alignmentText": "Cool 0-5°C (32-41°F) with rapidly shortening days and early snowfall.",
+      "alignmentText": "Summer highs around 10–12°C (50–54°F) stay brisk for outdoor play despite the long daylight.",
       "alignmentValue": 2
     },
     {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn rapidly slides back to freezing with early snowfall and storms shortening daylight.",
+      "alignmentValue": 1
+    },
+    {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "-20°C (-4°F) or colder with polar night, far from desired mild winters.",
+      "alignmentText": "Winter brings -20°C (-4°F) cold snaps and weeks without sun, a poor fit for Sarah’s low-stress climate goals.",
       "alignmentValue": 1
     },
     {
       "key": "Beach Life",
-      "alignmentText": "Beaches are rugged and icy, not suitable for typical family beach outings.",
+      "alignmentText": "Shorelines are icy and rugged, so there’s no family-friendly beach culture.",
       "alignmentValue": 1
     },
     {
       "key": "Seasonal Beach Water Temp",
-      "alignmentText": "Sea rarely exceeds 5°C (41°F), making swimming impractical.",
+      "alignmentText": "Sea temperatures rarely top 5°C (41°F), making swimming unsafe without drysuits.",
       "alignmentValue": 1
     },
     {
       "key": "Natural Beauty",
-      "alignmentText": "Dramatic glaciers and fjords provide extraordinary scenery for nature-focused trips.",
+      "alignmentText": "Towering icebergs, northern lights, and fjords provide awe-inspiring backdrops for family adventures.",
       "alignmentValue": 9
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "No statutory minimum wage; wages negotiated through unions and often high to offset costs.",
-      "alignmentValue": 4
-    },
-    {
-      "key": "Typical Software Salaries",
-      "alignmentText": "Few local tech roles; salaries trail major markets, though remote pay could match international levels.",
+      "alignmentText": "There’s no statutory minimum; union contracts pay well on paper but disappear quickly under Greenland’s extreme living costs.",
       "alignmentValue": 3
     },
     {
-      "key": ".NET Work Prospects",
-      "alignmentText": "Limited local demand; remote work essential for .NET opportunities.",
+      "key": "Typical Software Salaries",
+      "alignmentText": "Local tech hiring is sparse, so sustaining US-level income would depend on remote contracts.",
       "alignmentValue": 2
     },
     {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Government IT teams are tiny, leaving .NET specialists reliant on remote-first roles.",
+      "alignmentValue": 1
+    },
+    {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Sparse ecosystem with almost no Ruby-focused employers; remote contracting required.",
+      "alignmentText": "No meaningful Ruby market exists, so any work would have to stay with international clients.",
       "alignmentValue": 1
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Few companies and limited need for foreign hires make sponsorship uncommon.",
+      "alignmentText": "Few employers recruit abroad, and sponsorship still routes through Denmark’s quotas.",
       "alignmentValue": 2
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Small economy reliant on fishing and Danish subsidies with narrow diversification.",
-      "alignmentValue": 3
-    },
-    {
-      "key": "Remote-Friendly Culture",
-      "alignmentText": "Internet connections improving but latency and bandwidth can hamper remote work.",
+      "alignmentText": "GDP hinges on fisheries and Danish block grants, leaving little resilience for entrepreneurs.",
       "alignmentValue": 4
     },
     {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Internet has improved but long-haul links stay latency-heavy, so Trey would need backup connectivity.",
+      "alignmentValue": 3
+    },
+    {
       "key": "Work-Life Balance",
-      "alignmentText": "Nordic norms support reasonable hours and family time.",
+      "alignmentText": "Nordic norms keep overtime rare and leave time for family, even in small public-sector offices.",
       "alignmentValue": 7
     },
     {
@@ -108,27 +109,27 @@
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Roughly five weeks of leave following Danish labor standards.",
+      "alignmentText": "Five weeks of statutory leave mirror Denmark, giving space for long trips back to the States.",
       "alignmentValue": 8
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Public sector often exceeds minimums, enabling extended family trips.",
-      "alignmentValue": 8
+      "alignmentText": "Most teams take the full allowance, though small staffs sometimes stagger time off to keep services running.",
+      "alignmentValue": 7
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Slow-paced communities may suit the family’s desire for less hectic living.",
-      "alignmentValue": 7
+      "alignmentText": "Short commutes and tight-knit towns offer the slower daily rhythm Sarah craves.",
+      "alignmentValue": 8
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "Schools and offices often run 8:00-16:00, aligning with family routines.",
-      "alignmentValue": 7
+      "alignmentText": "Schools run roughly 8–14h and offices finish by 16h, but limited after-school care means parents juggle shifts.",
+      "alignmentValue": 6
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Weekends focus on outdoor activities and local events but options are limited.",
+      "alignmentText": "Weekends revolve around outdoor excursions and community events, yet weather can cancel plans last-minute.",
       "alignmentValue": 6
     },
     {
@@ -238,13 +239,13 @@
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "Greenlandic and Danish dominate; English spoken in tourism and youth circles.",
-      "alignmentValue": 4
+      "alignmentText": "Greenlandic and Danish dominate daily life; English helps with youth and tourism but isn’t reliable for bureaucracy.",
+      "alignmentValue": 3
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Political leanings favor social welfare though social views can be conservative.",
-      "alignmentValue": 5
+      "alignmentText": "Politics lean social-democratic, though some social issues track more traditional Inuit and Danish norms.",
+      "alignmentValue": 6
     },
     {
       "key": "Marxism (Societal Attitudes)",
@@ -263,8 +264,8 @@
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Legal protections exist yet small communities offer limited visibility and support.",
-      "alignmentValue": 4
+      "alignmentText": "Legal protections follow Denmark, but tiny communities mean limited queer visibility and peer support.",
+      "alignmentValue": 5
     },
     {
       "key": "Community Vibes",
@@ -328,8 +329,8 @@
     },
     {
       "key": "Political System",
-      "alignmentText": "Parliamentary democracy under the Kingdom of Denmark with local self-rule.",
-      "alignmentValue": 6
+      "alignmentText": "A home-rule parliament under Denmark keeps democratic institutions transparent and accountable.",
+      "alignmentValue": 8
     },
     {
       "key": "Religion in Politics",
@@ -348,8 +349,8 @@
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Danish oversight and democratic institutions keep risks low.",
-      "alignmentValue": 7
+      "alignmentText": "Strong links to Danish rule-of-law and an active press make backsliding unlikely despite the small media market.",
+      "alignmentValue": 8
     },
     {
       "key": "State of Capitalism",
@@ -373,22 +374,22 @@
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Comprehensive welfare state supports healthcare and education.",
+      "alignmentText": "Universal healthcare, subsidized childcare, and education support mirror Nordic welfare priorities.",
       "alignmentValue": 8
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Moderate trust, though some skepticism exists about efficiency.",
+      "alignmentText": "Residents trust core services but question how efficiently Nuuk manages remote settlements.",
       "alignmentValue": 6
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Overall low but small communities sometimes report favoritism.",
+      "alignmentText": "Transparency is generally good, though small-town hiring can feel insider-based.",
       "alignmentValue": 6
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Petty nepotism more common than large-scale scandals.",
+      "alignmentText": "Issues mostly involve patronage or family ties rather than large-scale graft.",
       "alignmentValue": 5
     },
     {
@@ -398,23 +399,23 @@
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Low violent crime but social issues like alcohol abuse remain concerns.",
-      "alignmentValue": 5
+      "alignmentText": "Violent crime is rare, yet alcohol-related domestic incidents mean we’d need robust community support networks.",
+      "alignmentValue": 4
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal coverage with local clinics; serious cases referred to Denmark.",
-      "alignmentValue": 7
-    },
-    {
-      "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Foreign residents can access care but may face language and referral hurdles.",
+      "alignmentText": "Primary care is universal, but serious cases require medevac to Denmark, adding travel stress.",
       "alignmentValue": 6
     },
     {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Resident permits grant access, though Danish referrals and language gaps add friction.",
+      "alignmentValue": 5
+    },
+    {
       "key": "Child Care Support",
-      "alignmentText": "Limited provider availability despite subsidies.",
-      "alignmentValue": 4
+      "alignmentText": "Municipal daycares exist but waitlists and staffing shortages are common in Nuuk.",
+      "alignmentValue": 3
     },
     {
       "key": "Family Policy (Common Family)",
@@ -423,17 +424,17 @@
     },
     {
       "key": "Education",
-      "alignmentText": "Basic education is accessible yet lacks advanced programs.",
-      "alignmentValue": 5
+      "alignmentText": "Outcomes trail Danish averages, so the boys would likely need supplemental tutoring or boarding options later on.",
+      "alignmentValue": 4
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Local bus networks exist in towns, but intercity travel relies on air or boat.",
-      "alignmentValue": 3
+      "alignmentText": "Town buses cover short hops, yet there are no intercity roads—travel between communities needs flights or ferries.",
+      "alignmentValue": 2
     },
     {
       "key": "Economic System",
-      "alignmentText": "Market activity constrained by geography; heavy reliance on fishing.",
+      "alignmentText": "A mixed economy balances public control with small private firms, but scale is limited.",
       "alignmentValue": 5
     },
     {
@@ -453,7 +454,7 @@
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Imported goods make day-to-day expenses among the highest worldwide.",
+      "alignmentText": "Almost everything is imported, so groceries and gear cost well above Danish levels.",
       "alignmentValue": 3
     },
     {
@@ -468,38 +469,38 @@
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Danish-controlled visa system offers work and family permits but quotas are tight.",
-      "alignmentValue": 4
+      "alignmentText": "Residence permits flow through Danish immigration, with tight quotas and case-by-case approvals.",
+      "alignmentValue": 3
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Small population is generally polite yet cautious toward newcomers.",
-      "alignmentValue": 5
+      "alignmentText": "Locals are friendly yet protective of community resources, so integration takes time.",
+      "alignmentValue": 4
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Temporary and permanent residency follow Danish rules with renewal requirements.",
-      "alignmentValue": 5
+      "alignmentText": "Temporary permits require renewal and proof of employment; permanent residency demands long stays and language.",
+      "alignmentValue": 4
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Naturalization through Denmark requires long residence and language proficiency.",
+      "alignmentText": "Naturalization follows Denmark’s 9+ year timeline plus Danish-language exams.",
       "alignmentValue": 4
     },
     {
       "key": "Family Members",
-      "alignmentText": "Spouses and children can usually obtain dependent permits with access to services.",
-      "alignmentValue": 6
-    },
-    {
-      "key": "Timelines & Costs",
-      "alignmentText": "Processing can take many months and incurs Danish application fees.",
+      "alignmentText": "Dependents qualify for permits, but housing and school placement must be secured in advance.",
       "alignmentValue": 5
     },
     {
+      "key": "Timelines & Costs",
+      "alignmentText": "Applications can stretch past six months and require travel to Danish consulates.",
+      "alignmentValue": 4
+    },
+    {
       "key": "Compliance & Risks",
-      "alignmentText": "Overstays or failure to maintain employment jeopardize status.",
-      "alignmentValue": 6
+      "alignmentText": "Losing the sponsoring job or failing Danish paperwork can quickly end the stay.",
+      "alignmentValue": 5
     },
     {
       "key": "Dual Citizenship Allowed",
@@ -508,32 +509,32 @@
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Remote healthcare and schooling access require careful planning.",
+      "alignmentText": "Remote logistics, medevac travel, and language barriers mean the family would need contingency plans.",
       "alignmentValue": 4
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "No established industry; remote freelancing is the primary option.",
+      "alignmentText": "No local studios exist, so Trey would have to build everything remotely.",
       "alignmentValue": 1
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "No notable local studios present.",
+      "alignmentText": "There are no established Greenlandic studios to network with.",
       "alignmentValue": 1
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "Lacks organized dev meetups; online communities fill the gap.",
+      "alignmentText": "Occasional school workshops happen, but most collaboration would remain online.",
       "alignmentValue": 2
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Sparse market and high costs limit viability; Danish grants may help.",
-      "alignmentValue": 3
+      "alignmentText": "Funding is scarce beyond small cultural grants, and the local market is tiny.",
+      "alignmentValue": 2
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "Basic services in towns but limited road networks and high reliance on imports.",
+      "alignmentText": "Nuuk has reliable power and broadband, yet settlements rely on diesel and limited transport links.",
       "alignmentValue": 4
     }
   ]

--- a/reports/italy_report.json
+++ b/reports/italy_report.json
@@ -1,30 +1,31 @@
 {
+  "version": 2,
   "iso": "IT",
   "values": [
     {
       "key": "Environment",
-      "alignmentText": "Varied landscapes from alpine valleys to Mediterranean coasts give options for mild microclimates, though industrial northern plains feel less pristine.",
-      "alignmentValue": 6
+      "alignmentText": "Regional parks and Mediterranean coasts offer quick escapes, though the Po Valley’s smog keeps it shy of a top score.",
+      "alignmentValue": 7
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Mediterranean heatwaves, Alpine glacier melt, and rising Adriatic flood risk require adaptation planning for a climate-sensitive family.",
-      "alignmentValue": 4
+      "alignmentText": "Hotter summers, drought-prone agriculture, and Venice lagoon flooding require active adaptation for a climate-cautious family.",
+      "alignmentValue": 3
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "Central Italy delivers spring and fall shoulder seasons but summers can swing hot and humid, especially in the Po Valley.",
-      "alignmentValue": 6
+      "alignmentText": "Spring and fall are pleasant, but humid 35°C (95°F) summer spikes and damp northern winters demand careful city selection.",
+      "alignmentValue": 5
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Cities like Milan and Turin see PM2.5 spikes in winter inversions, so cleaner air would mean targeting coastal or hill towns.",
-      "alignmentValue": 4
+      "alignmentText": "Alpine breezes help smaller towns, yet Milan and Turin frequently breach EU particulate limits.",
+      "alignmentValue": 5
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Earthquakes along the Apennines plus occasional flooding and volcanic risk near Naples demand location-specific mitigation.",
-      "alignmentValue": 3
+      "alignmentText": "Earthquakes, floods, and volcanic zones mean we’d need to vet housing and insurance closely.",
+      "alignmentValue": 4
     },
     {
       "key": "Spring Temperature Range (C/F)",
@@ -33,7 +34,7 @@
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "Many regions hit 20–32°C (68–90°F) and humidity builds in July–August, making shade and siesta culture important.",
+      "alignmentText": "Coastal cities hold around 28–32°C (82–90°F), but inland heatwaves can feel oppressive for Sarah.",
       "alignmentValue": 5
     },
     {
@@ -43,8 +44,8 @@
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "Coastal cities hover 3–12°C (37–54°F) with damp chill, while the north can drop below freezing and see snow.",
-      "alignmentValue": 6
+      "alignmentText": "Winters in central Italy hover 4–10°C (39–50°F) with damp chill rather than deep freezes.",
+      "alignmentValue": 5
     },
     {
       "key": "Beach Life",
@@ -63,72 +64,72 @@
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "No national minimum wage; sectoral contracts set pay and can lag behind living costs, challenging for newcomers.",
+      "alignmentText": "No national minimum wage exists; sectoral contracts often lag the cost of family life in major metros.",
       "alignmentValue": 4
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Mid-level devs often earn €35–45k in Milan/Rome—lower than Northern Europe, so remote USD income would stretch further.",
+      "alignmentText": "Senior developers earn roughly €40–55k, so Trey would likely lean on remote US clients.",
       "alignmentValue": 4
     },
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Banking, telecom, and public-sector vendors rely on .NET, but roles concentrate in Milan/Rome and expect Italian fluency.",
+      "alignmentText": "Finance and consulting hubs in Milan and Rome hire .NET talent, but roles skew on-site.",
       "alignmentValue": 5
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Ruby scenes exist in fintech and agencies yet remain niche; many teams pivot to JavaScript or Java stacks.",
+      "alignmentText": "Ruby shops cluster in Turin and remote consultancies, yet openings remain sporadic.",
       "alignmentValue": 4
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Quota-driven work permits and paperwork-heavy employers make sponsorship inconsistent unless joining multinationals.",
-      "alignmentValue": 3
+      "alignmentText": "Larger firms sponsor EU Blue Cards, but paperwork and quotas make timelines unpredictable.",
+      "alignmentValue": 5
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Italy’s GDP growth is modest with high debt, yet unemployment is trending down and inflation stabilized within EU norms.",
+      "alignmentText": "Growth is modest with high public debt, though Northern industry still offers stability.",
       "alignmentValue": 5
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Post-pandemic hybrid policies exist in tech hubs, but many firms still expect office presence and Italian working hours.",
+      "alignmentText": "Hybrid work is more accepted post-pandemic, yet many employers expect regular office days.",
       "alignmentValue": 5
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Long lunches, protected vacation time, and strong labor rules reinforce boundaries Sarah would appreciate.",
+      "alignmentText": "Even demanding teams respect evening family time, and extended lunch breaks ease daily pacing.",
       "alignmentValue": 7
     },
     {
       "key": "Work Week Hours",
-      "alignmentText": "Contracts mandate ~40 hours, but some offices expect extra availability despite union protections.",
+      "alignmentText": "The legal 40-hour week is standard, with occasional overtime during product pushes.",
       "alignmentValue": 6
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Statutory leave is at least four weeks plus ~11 public holidays, giving ample family recharge time.",
+      "alignmentText": "Employees receive at least four weeks plus 10–12 public holidays, supporting long US visits.",
       "alignmentValue": 8
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Most staff take extended August breaks and bridge holidays, though startups may temper that flexibility.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Pace of Life",
-      "alignmentText": "Outside Milan, daily rhythms favor slower meals and evening passeggiata, matching their desire for a calmer vibe.",
+      "alignmentText": "Many tech companies close in August, but newer startups sometimes trade leave for fast growth.",
       "alignmentValue": 7
     },
     {
+      "key": "Pace of Life",
+      "alignmentText": "Urban cores feel busy, yet medium cities like Bologna deliver a calmer rhythm.",
+      "alignmentValue": 6
+    },
+    {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "Schools often end by early afternoon, so parents juggle midday pickups unless after-school programs are secured.",
+      "alignmentText": "School runs 8:30–16:00 with a midday meal; parents navigate lunch breaks and occasional after-school gaps.",
       "alignmentValue": 6
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Weekends revolve around markets, parks, and Sunday closures, encouraging family time but requiring planning for errands.",
+      "alignmentText": "Weekends revolve around markets, park strolls, and day trips by train when weather cooperates.",
       "alignmentValue": 7
     },
     {
@@ -238,12 +239,12 @@
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "English proficiency is moderate in tourist centers but scarce with officials, making Italian study essential.",
-      "alignmentValue": 3
+      "alignmentText": "Tourism corridors speak English, but local bureaucracy expects Italian proficiency.",
+      "alignmentValue": 4
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Urban voters back progressive coalitions, yet national politics swings centrist-to-conservative with Catholic influence.",
+      "alignmentText": "Cities vote center-left, yet national politics swing conservative on migration and family policy.",
       "alignmentValue": 5
     },
     {
@@ -263,7 +264,7 @@
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Civil unions are legal and Pride events thrive in Milan/Rome, yet legal gaps on adoption and surrogacy remain.",
+      "alignmentText": "Civil unions exist and big cities host Pride events, but adoption rights and rural acceptance lag.",
       "alignmentValue": 5
     },
     {
@@ -328,8 +329,8 @@
     },
     {
       "key": "Political System",
-      "alignmentText": "Parliamentary democracy with proportional representation encourages pluralism but creates complex coalitions.",
-      "alignmentValue": 6
+      "alignmentText": "Parliamentary institutions are democratic though governments change frequently.",
+      "alignmentValue": 7
     },
     {
       "key": "Religion in Politics",
@@ -348,7 +349,7 @@
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Populist rhetoric surfaces, but institutions, EU oversight, and active civil society keep checks in place.",
+      "alignmentText": "Independent courts and media persist, yet far-right coalitions test civil society vigilance.",
       "alignmentValue": 6
     },
     {
@@ -373,47 +374,47 @@
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Welfare reforms target families and low-income workers, though benefits lag behind Northern Europe.",
+      "alignmentText": "Universal healthcare and family allowances exist, but childcare and housing aid vary by region.",
       "alignmentValue": 6
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Surveys show low institutional trust, reflecting frustration with bureaucracy and political churn.",
+      "alignmentText": "Citizens often view institutions as inefficient, fueling reliance on personal networks.",
       "alignmentValue": 4
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Transparency International scores highlight persistent corruption risks, especially in procurement.",
-      "alignmentValue": 3
+      "alignmentText": "Transparency International ranks Italy mid-pack, with concerns about procurement and patronage.",
+      "alignmentValue": 4
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Clientelism and organized crime-linked patronage shape certain regions, demanding diligence from newcomers.",
-      "alignmentValue": 3
+      "alignmentText": "Influence peddling and regional favoritism dominate rather than overt bribery.",
+      "alignmentValue": 4
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Homeownership is high but rentals in Florence/Milan are tight; smaller towns offer better value.",
+      "alignmentText": "Buying is pricey in Milan and Rome, but rentals in secondary cities remain attainable.",
       "alignmentValue": 5
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Violent crime is low; petty theft in tourist zones is the main concern to manage.",
-      "alignmentValue": 7
+      "alignmentText": "Violent crime stays low, while petty theft requires vigilance in tourist hubs.",
+      "alignmentValue": 6
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "The Servizio Sanitario Nazionale delivers universal care with strong preventive services and modest co-pays.",
-      "alignmentValue": 8
-    },
-    {
-      "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Non-EU residents can enroll once holding a permesso, but the registration process requires patience.",
+      "alignmentText": "The Servizio Sanitario Nazionale provides comprehensive care with respected specialists in major cities.",
       "alignmentValue": 7
     },
     {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Residents can enroll in the national system, yet enrollment paperwork and waitlists take time.",
+      "alignmentValue": 6
+    },
+    {
       "key": "Child Care Support",
-      "alignmentText": "Means-tested vouchers and expanding nursery slots exist, yet availability varies widely by municipality.",
+      "alignmentText": "Municipal nurseries offer subsidies, but slots are limited and schedules can be half-day.",
       "alignmentValue": 5
     },
     {
@@ -423,37 +424,37 @@
     },
     {
       "key": "Education",
-      "alignmentText": "Academic rigor is strong but teaching methods skew traditional, so project-based learners may need extracurriculars.",
+      "alignmentText": "Public schools provide solid academics, though families often supplement English and STEM enrichment.",
       "alignmentValue": 6
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "High-speed rail and metro networks in Rome/Milan make car-free living feasible, though southern service is patchier.",
-      "alignmentValue": 7
+      "alignmentText": "High-speed rail links major cities, yet local buses and metros suffer from occasional strikes.",
+      "alignmentValue": 6
     },
     {
       "key": "Economic System",
-      "alignmentText": "EU single-market access and diversified SMEs create stability despite bureaucracy.",
+      "alignmentText": "A regulated market economy balances strong manufacturing with state oversight and bureaucracy.",
       "alignmentValue": 6
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "High payroll taxes and complex filings require a commercialista, adding overhead for freelancers.",
-      "alignmentValue": 4
+      "alignmentText": "Italy offers online filing, but deductions and regional surtaxes make professional help wise.",
+      "alignmentValue": 5
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "Combined income taxes and social contributions can approach 35–40% for middle-class households.",
-      "alignmentValue": 4
+      "alignmentText": "Combined income near €120k faces 35–43% brackets plus municipal surcharges.",
+      "alignmentValue": 5
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "SEPA instant transfers, widespread contactless payments, and modern fintech apps support daily life.",
-      "alignmentValue": 7
+      "alignmentText": "Digital banking is improving, though some landlords still prefer traditional bank transfers.",
+      "alignmentValue": 6
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Housing and groceries cost less than coastal US cities, but Milan tech hubs feel pricier than Iberia.",
+      "alignmentText": "Groceries and childcare run cheaper than US coasts, but Milan housing narrows the gap.",
       "alignmentValue": 6
     },
     {
@@ -468,38 +469,38 @@
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Elective residency suits retirees, while startup and digital nomad visas demand high income proofs and patience.",
+      "alignmentText": "Elective residence visas require high passive income, while the new digital nomad visa demands employer documentation.",
       "alignmentValue": 4
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Locals are friendly to Americans, yet limited English and bureaucratic offices can feel unwelcoming initially.",
+      "alignmentText": "Large expat enclaves exist, yet integration still hinges on speaking Italian and respecting local rhythm.",
       "alignmentValue": 5
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Permessi di soggiorno start at 1–2 years with renewals before a 5-year long-term permit.",
+      "alignmentText": "Most permits renew annually at first, with long-term EU residence available after five years.",
       "alignmentValue": 5
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Naturalization requires 10 years’ legal residency plus language certification and can take years to process.",
+      "alignmentText": "Naturalization requires 10 years of residence and language certification.",
       "alignmentValue": 4
     },
     {
       "key": "Family Members",
-      "alignmentText": "Family reunification is allowed and dependents can share residency status once documentation is approved.",
+      "alignmentText": "Dependents can join once the main applicant meets income and housing requirements.",
       "alignmentValue": 6
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Permesso renewals can take months, with revenue stamps, translations, and postal kits adding recurring costs.",
+      "alignmentText": "Permesso di soggiorno processing can stretch 3–6 months with multiple in-person appointments.",
       "alignmentValue": 4
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Strict address registration, annual income proofs, and regional rule variations create tripwires for overstays.",
-      "alignmentValue": 4
+      "alignmentText": "Falling below income thresholds or missing annual renewals risks lapses in status.",
+      "alignmentValue": 5
     },
     {
       "key": "Dual Citizenship Allowed",
@@ -508,33 +509,33 @@
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Expect in-person appointments, Italian-only portals, and the need for local helpers to navigate paperwork.",
-      "alignmentValue": 4
+      "alignmentText": "Translations, health insurance proof, and periodic in-person check-ins are routine requirements.",
+      "alignmentValue": 5
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Industry is growing with studios in Milan and Rome, but total headcount remains limited compared to UK/France.",
+      "alignmentText": "Studios like Milestone and Ubisoft Milan offer roles, but the ecosystem is smaller than Northern Europe.",
       "alignmentValue": 5
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Milestone, Ubisoft Milan, 505 Games, and Nacon Italy offer recognizable AAA or AA opportunities.",
-      "alignmentValue": 6
+      "alignmentText": "Key players include Milestone, 34BigThings, and Storm in a Teacup clustered around Milan and Turin.",
+      "alignmentValue": 5
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "Events like Milan Games Week, First Playable in Florence, and indie meetups provide networking albeit infrequently.",
+      "alignmentText": "Meetups such as Codemotion and Italian Game Developer Summit provide networking and mentorship.",
       "alignmentValue": 6
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "EU Creative Europe grants and local incubators exist, yet bureaucracy and small domestic market require export focus.",
-      "alignmentValue": 5
+      "alignmentText": "Public grants exist but bureaucracy, limited venture capital, and high payroll taxes slow new studios.",
+      "alignmentValue": 4
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "Fiber broadband covers major cities and high-speed rail links north-south, while some southern infrastructure still lags.",
-      "alignmentValue": 6
+      "alignmentText": "Fiber broadband reaches most cities, high-speed trains connect regions, and utilities are reliable outside occasional strikes.",
+      "alignmentValue": 7
     }
   ]
 }

--- a/reports/laos_report.json
+++ b/reports/laos_report.json
@@ -1,30 +1,31 @@
 {
+  "version": 2,
   "iso": "LA",
   "values": [
     {
       "key": "Environment",
-      "alignmentText": "Mountain forests along the Mekong still feel wild, though hydropower projects and logging mean protected areas take extra travel to enjoy.",
-      "alignmentValue": 5
+      "alignmentText": "Forest reserves and the Mekong remain stunning, but slash-and-burn agriculture erodes access to pristine nature.",
+      "alignmentValue": 4
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Laos ranks among Southeast Asia’s most climate-vulnerable countries, facing stronger Mekong floods, erratic droughts, and landslides with limited adaptive infrastructure.",
-      "alignmentValue": 3
+      "alignmentText": "Hotter monsoons, Mekong dam impacts, and drought stress keep climate risk uncomfortably high.",
+      "alignmentValue": 2
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "A tropical monsoon pattern brings a long hot, humid wet season and a short dry spell, far from the mild weather the family prefers.",
-      "alignmentValue": 3
+      "alignmentText": "Six sticky monsoon months with 35°C+ highs clash with the family’s mild-weather preference.",
+      "alignmentValue": 2
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Slash-and-burn agriculture and smoky dry-season haze regularly push PM2.5 above WHO guidance in Vientiane and northern valleys.",
+      "alignmentText": "Crop burning and regional haze push PM2.5 above WHO limits each dry season.",
       "alignmentValue": 3
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Seasonal Mekong flooding, drought, and occasional earthquakes or dam issues are recurring risks with limited emergency capacity.",
-      "alignmentValue": 4
+      "alignmentText": "Floods and landslides frequently disrupt rural provinces, and urban drainage is limited.",
+      "alignmentValue": 3
     },
     {
       "key": "Spring Temperature Range (C/F)",
@@ -33,8 +34,8 @@
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "June–August stay near 24–32 °C (75–90 °F) but feel hotter thanks to heavy monsoon humidity and cloudbursts.",
-      "alignmentValue": 3
+      "alignmentText": "April and May often sit at 33–37°C (91–99°F) with high humidity, requiring constant cooling.",
+      "alignmentValue": 2
     },
     {
       "key": "Fall Temperature Range (C/F)",
@@ -43,8 +44,8 @@
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "December–February drop to 17–28 °C (63–82 °F) with drier air—still warm but the most comfortable window.",
-      "alignmentValue": 5
+      "alignmentText": "Dry-season highs around 25–28°C (77–82°F) feel pleasant, though nights stay warm.",
+      "alignmentValue": 6
     },
     {
       "key": "Beach Life",
@@ -63,43 +64,43 @@
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "The national minimum wage is about 1.3 million kip (~US$70) per month, signaling a very low baseline for local pay.",
+      "alignmentText": "Monthly minimum wages near $150 USD cannot cover international school fees or housing upgrades.",
       "alignmentValue": 2
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Software roles in Vientiane often pay US$6k–12k annually—well below Western compensation and rarely remote-ready.",
+      "alignmentText": "Local developers often earn under $15k USD, so sustaining US income requires remote contracts.",
       "alignmentValue": 2
     },
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Only a handful of banks, telecoms, or regional outsourcing firms hire .NET developers, so opportunities are scarce.",
+      "alignmentText": "Government digitization projects hire a handful of .NET devs, but the market is tiny.",
       "alignmentValue": 2
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Ruby shops are nearly nonexistent; most Lao tech work leans on PHP or Java, meaning little fit for Sarah’s stack.",
+      "alignmentText": "Ruby is virtually absent from the local tech stack outside of a few regional startups.",
       "alignmentValue": 1
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "NGOs, hydropower firms, and hotels sometimes sponsor skilled foreigners, but bureaucracy makes approvals uncommon.",
+      "alignmentText": "Most companies rely on short business visas; long-term sponsorship is rare and bureaucratic.",
       "alignmentValue": 2
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Laos remains a lower-middle-income economy driven by hydropower and mining; growth near 4–5% masks high debt and inflation shocks.",
+      "alignmentText": "GDP growth is fast but from a low base, with heavy reliance on hydropower concessions.",
       "alignmentValue": 4
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Coworking hubs in Vientiane and Luang Prabang exist, yet broadband reliability and time-zone collaboration remain inconsistent.",
+      "alignmentText": "Fiber exists in Vientiane, yet outages and power fluctuations mean Trey needs backup plans.",
       "alignmentValue": 3
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Workplaces outside hospitality tend to observe formal hours and a slower pace, though limited labor protections add stress.",
-      "alignmentValue": 5
+      "alignmentText": "Workdays tend to finish by early evening, and family gatherings are culturally important.",
+      "alignmentValue": 6
     },
     {
       "key": "Work Week Hours",
@@ -108,28 +109,28 @@
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Employees earn at least 15 paid leave days plus public holidays after a year of service, but enforcement varies.",
-      "alignmentValue": 5
+      "alignmentText": "Labor law grants 15 days, but smaller firms may only honor the legal floor.",
+      "alignmentValue": 4
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Most private employers stick close to the legal floor, offering little extra time off beyond national festivals.",
+      "alignmentText": "Companies rarely go beyond the minimum, so extended US trips require negotiation.",
       "alignmentValue": 4
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Outside a few tourist hubs, daily life is slow and communal, aligning with Sarah’s desire to ease the family’s pace.",
-      "alignmentValue": 6
+      "alignmentText": "Daily rhythms feel laid back compared to US metros, matching Sarah’s slower pace goal.",
+      "alignmentValue": 7
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "Schools start around 7:30 a.m.; offices run 8 a.m.–5 p.m. with a midday lunch break, requiring afternoon childcare planning.",
+      "alignmentText": "Schools often run half-day shifts, requiring parents to juggle midday pickups or hire help.",
       "alignmentValue": 5
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Weekends revolve around markets, temple visits, and river outings; many services close early, so structured kids’ activities are limited.",
-      "alignmentValue": 5
+      "alignmentText": "Weekends highlight river markets and temple visits, though heat can limit outdoor time.",
+      "alignmentValue": 6
     },
     {
       "key": "Family Life",
@@ -238,12 +239,12 @@
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "Lao is dominant; outside tourism corridors, sustained daily life requires learning Lao or Thai.",
+      "alignmentText": "Lao is essential; English is limited outside tourism and NGO circles.",
       "alignmentValue": 2
     },
     {
       "key": "Progressivism",
-      "alignmentText": "The one-party state maintains conservative speech controls and resists the kind of social liberalism the family values.",
+      "alignmentText": "The single-party state maintains conservative social norms with little space for dissent.",
       "alignmentValue": 2
     },
     {
@@ -263,7 +264,7 @@
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Urban nightlife is somewhat tolerant, yet there are no anti-discrimination protections or legal recognition.",
+      "alignmentText": "There’s social tolerance in Vientiane nightlife, but no legal protections or recognition.",
       "alignmentValue": 2
     },
     {
@@ -328,7 +329,7 @@
     },
     {
       "key": "Political System",
-      "alignmentText": "Laos is a one-party socialist republic with tight control over media and civil society.",
+      "alignmentText": "The Lao People’s Revolutionary Party monopolizes power with no competitive elections.",
       "alignmentValue": 2
     },
     {
@@ -348,8 +349,8 @@
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Civil liberties are already curtailed, and recent arrests of activists show no sign of liberalization.",
-      "alignmentValue": 1
+      "alignmentText": "Civil society is tightly controlled, and criticism of the state can trigger surveillance.",
+      "alignmentValue": 2
     },
     {
       "key": "State of Capitalism",
@@ -373,48 +374,48 @@
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Welfare coverage is thin, with pilot health insurance and poverty reduction schemes reaching only parts of the population.",
+      "alignmentText": "Basic healthcare and schooling exist but funding gaps limit quality and access.",
       "alignmentValue": 3
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Official surveys report high trust, but limited civic space means skepticism is voiced quietly.",
-      "alignmentValue": 4
+      "alignmentText": "Citizens rely on state media; grievances are often managed quietly rather than publicly.",
+      "alignmentValue": 3
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Business surveys cite pervasive bribery in customs, land, and police interactions.",
-      "alignmentValue": 2
+      "alignmentText": "Petty bribery and favoritism remain common in permitting and policing.",
+      "alignmentValue": 3
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Rent-seeking around infrastructure concessions and petty facilitation payments are both common.",
-      "alignmentValue": 2
+      "alignmentText": "Officials expect facilitation payments for licensing, and state-owned firms dominate deals.",
+      "alignmentValue": 3
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Housing is inexpensive, yet quality varies and expats often renovate older homes for reliable utilities.",
-      "alignmentValue": 4
+      "alignmentText": "Expats can find affordable detached homes, but quality varies and insulation is minimal.",
+      "alignmentValue": 5
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Violent crime rates are low; petty theft is the main concern in tourist corridors.",
-      "alignmentValue": 7
+      "alignmentText": "Violent crime is rare, yet petty theft and road safety issues require vigilance.",
+      "alignmentValue": 5
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Primary clinics exist nationwide, but limited specialists and equipment push serious cases abroad.",
+      "alignmentText": "Provincial hospitals lack specialists; serious cases often go to Thailand.",
       "alignmentValue": 3
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Foreigners rely on private clinics for basics and fly to Bangkok for advanced care, adding time and cost.",
+      "alignmentText": "Expats typically rely on private clinics for basics and evacuate to Bangkok for major care.",
       "alignmentValue": 2
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Babysitters are typically informal hires; few licensed daycare centers meet Western expectations.",
-      "alignmentValue": 3
+      "alignmentText": "Formal daycare options are scarce; most families lean on relatives or hired nannies.",
+      "alignmentValue": 2
     },
     {
       "key": "Family Policy (Common Family)",
@@ -423,37 +424,37 @@
     },
     {
       "key": "Education",
-      "alignmentText": "Education reforms aim to improve literacy, yet outcomes trail neighbors and English-medium options are rare.",
+      "alignmentText": "Public schools lag in English and STEM, pushing expats toward costly international programs.",
       "alignmentValue": 3
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Outside a new China-Laos railway, public transit is limited to songthaews and tuk-tuks without schedules.",
+      "alignmentText": "Aside from Vientiane buses and the China–Laos railway, transit is informal tuk-tuks or private vans.",
       "alignmentValue": 2
     },
     {
       "key": "Economic System",
-      "alignmentText": "The economy mixes socialist planning with growing private enterprise, anchored by hydropower exports.",
-      "alignmentValue": 3
+      "alignmentText": "A state-led economy coexists with growing private enterprise, but regulation can be opaque.",
+      "alignmentValue": 4
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "Personal income tax uses a progressive schedule up to 24%; filings are manual but relatively straightforward with employer assistance.",
+      "alignmentText": "Tax filing is manual, and foreign earners often hire local accountants to navigate incentives.",
       "alignmentValue": 4
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "Foreign professionals typically face marginal rates between 10–20%, plus social security if locally contracted.",
-      "alignmentValue": 4
+      "alignmentText": "Personal income tax tops out near 24%, though treaty gaps may complicate remote income.",
+      "alignmentValue": 3
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "Cash remains dominant; ATMs can be unreliable, though QR payments via LaoPay and Thai wallets are expanding.",
+      "alignmentText": "Cash dominates; ATMs work in cities but online payments remain limited.",
       "alignmentValue": 3
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Housing, food, and domestic help are affordable, enabling a low monthly burn if content with local standards.",
+      "alignmentText": "Local food and services are inexpensive, though imported goods carry a premium.",
       "alignmentValue": 7
     },
     {
@@ -468,37 +469,37 @@
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Tourist visas on arrival are easy, yet long-term options revolve around business, NGO, or spouse sponsorship with strict reporting.",
-      "alignmentValue": 3
+      "alignmentText": "Most foreigners rotate business visas; permanent residency is difficult without deep investment.",
+      "alignmentValue": 2
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Americans are generally treated warmly, but few support networks exist and bureaucracy can feel opaque.",
-      "alignmentValue": 3
+      "alignmentText": "Laotians are friendly, yet the state monitors NGOs and media, limiting outspoken activism.",
+      "alignmentValue": 4
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Most residence permits are one-year renewable and tied to an employer or investment project.",
-      "alignmentValue": 3
+      "alignmentText": "Long-term residence requires annual renewals tied to employment or investment.",
+      "alignmentValue": 2
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Naturalization demands a decade of residency, Lao language fluency, and is rarely approved.",
+      "alignmentText": "Naturalization is rare and demands a decade of residence plus government approval.",
       "alignmentValue": 1
     },
     {
       "key": "Family Members",
-      "alignmentText": "Dependent visas are possible but require repeated police clearances, housing checks, and school letters.",
+      "alignmentText": "Dependents may accompany work permits, but schooling and healthcare arrangements fall on the family.",
       "alignmentValue": 3
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Processing often takes several months with unofficial fees for paperwork and renewals.",
-      "alignmentValue": 2
+      "alignmentText": "Paperwork often needs multiple in-person visits and translation fees.",
+      "alignmentValue": 3
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Work permits and address reporting are strictly enforced; falling out of status risks fines or deportation.",
+      "alignmentText": "Visa overstays draw fines, and political speech restrictions apply to foreigners.",
       "alignmentValue": 3
     },
     {
@@ -508,32 +509,32 @@
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Expect quarterly reporting at immigration, travel permits for some provinces, and reliance on local fixers for paperwork.",
+      "alignmentText": "We’d need evacuation insurance, language support, and contingency plans for power and schooling.",
       "alignmentValue": 3
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "The domestic game industry is nascent, with only a few small mobile teams and little middleware expertise.",
+      "alignmentText": "There is virtually no local game industry, so Trey would operate entirely remotely.",
       "alignmentValue": 1
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Beyond micro studios in Vientiane and regional outsourcing shops, there are no prominent Lao game companies.",
+      "alignmentText": "No internationally recognized studios are based in Laos.",
       "alignmentValue": 1
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "Developer meetups happen sporadically through Facebook groups, lacking structured mentorship or events.",
-      "alignmentValue": 1
+      "alignmentText": "Small co-working spaces host occasional tech meetups, but consistent game-dev groups are rare.",
+      "alignmentValue": 2
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Ultra-low operating costs help, but limited talent pipelines, funding, and consumer spend hinder a studio launch.",
+      "alignmentText": "Startup grants are minimal and digital payment penetration is low for monetization.",
       "alignmentValue": 2
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "Roads, power, and internet are improving but still uneven outside cities, and frequent outages demand backups.",
+      "alignmentText": "Vientiane has improving fiber and 4G, yet power grids and roads outside the capital remain fragile.",
       "alignmentValue": 3
     }
   ]

--- a/reports/russia_report.json
+++ b/reports/russia_report.json
@@ -1,30 +1,31 @@
 {
+  "version": 2,
   "iso": "RU",
   "values": [
     {
       "key": "Environment",
-      "alignmentText": "Vast landscapes mix pristine taiga with polluted industrial zones, making access to clean nature uneven for families.",
+      "alignmentText": "Wild taiga and lake districts are beautiful, yet pollution around industrial hubs limits easy weekend escapes.",
       "alignmentValue": 4
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Rapid Arctic warming and permafrost thaw pose long-term ecological and infrastructure challenges.",
+      "alignmentText": "Permafrost melt, Siberian wildfires, and volatile harvests signal rising climate risk.",
       "alignmentValue": 3
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "Continental extremes bring hot summers and very cold winters, far from the mild climate preference.",
+      "alignmentText": "Winters plunge well below freezing and summers swing hot, far from the family’s mild-climate goal.",
       "alignmentValue": 2
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Major cities suffer from vehicle and coal pollution while remote areas remain fairly clean.",
-      "alignmentValue": 3
+      "alignmentText": "Major cities regularly exceed PM limits due to coal heat and traffic, though coastal and northern towns fare better.",
+      "alignmentValue": 4
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Generally low risk, though some regions face floods, wildfires, or Far East earthquakes.",
-      "alignmentValue": 5
+      "alignmentText": "Flooding, wildfires, and thawing permafrost threaten infrastructure in multiple regions.",
+      "alignmentValue": 4
     },
     {
       "key": "Spring Temperature Range (C/F)",
@@ -33,7 +34,7 @@
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "Typically 15–30°C (59–86°F); occasional heat waves and humidity in cities.",
+      "alignmentText": "Moscow and Saint Petersburg average 20–26°C (68–79°F) but heatwaves now top 32°C (90°F).",
       "alignmentValue": 4
     },
     {
@@ -43,8 +44,8 @@
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "Commonly -15 to -5°C (5–23°F) with heavy snow and icy streets.",
-      "alignmentValue": 1
+      "alignmentText": "Extended stretches below -10°C (14°F) demand heavy gear and limit outdoor family time.",
+      "alignmentValue": 2
     },
     {
       "key": "Beach Life",
@@ -63,43 +64,43 @@
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "Approximately ₽16k/month (~$170), offering little support for a family of four.",
+      "alignmentText": "Regional minimums often sit under 20,000 RUB (~$220), insufficient for a four-person household.",
       "alignmentValue": 2
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Salaries in Moscow average $20–40k USD, well below Western levels.",
-      "alignmentValue": 3
+      "alignmentText": "Senior engineers may earn 2–3 million RUB annually, but currency controls complicate international pay.",
+      "alignmentValue": 4
     },
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Domestic demand exists but sanctions limit international projects and stability.",
-      "alignmentValue": 3
+      "alignmentText": "Banks and state enterprises keep .NET roles available, yet most require in-country presence.",
+      "alignmentValue": 4
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Smaller ecosystem with few high-paying roles.",
-      "alignmentValue": 2
+      "alignmentText": "Ruby teams exist in e-commerce, but many companies relocated talent after 2022.",
+      "alignmentValue": 3
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Foreign tech hires face tight quotas and heightened scrutiny, making sponsorship rare.",
+      "alignmentText": "US citizens face severe scrutiny; few employers will undertake sponsorship amid geopolitical tension.",
       "alignmentValue": 1
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Energy exports prop up GDP, yet sanctions and inflation weigh on growth.",
+      "alignmentText": "Sanctions and wartime spending warp the economy, limiting entrepreneurial stability.",
       "alignmentValue": 3
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Some firms allow remote work, though monitoring and time-zone gaps hinder US collaboration.",
+      "alignmentText": "Broadband is fast in cities, but VPNs are required for many Western services and censorship is tightening.",
       "alignmentValue": 4
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Urban offices often expect long hours and weekend availability.",
-      "alignmentValue": 3
+      "alignmentText": "Tech teams often expect late hours during releases, and vacation can be curtailed by staffing pressures.",
+      "alignmentValue": 4
     },
     {
       "key": "Work Week Hours",
@@ -108,27 +109,27 @@
     },
     {
       "key": "Vacation Days (Minimum)",
-      "alignmentText": "Labor law guarantees 28 paid days plus public holidays.",
+      "alignmentText": "Employees receive at least 28 days plus public holidays, supporting extended travel.",
       "alignmentValue": 7
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Most workers take the legal minimum, with few extended breaks.",
+      "alignmentText": "Many staff take the legal minimum, and managers sometimes discourage long absences.",
       "alignmentValue": 6
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Moscow and St. Petersburg are hectic; provincial towns move slower but offer fewer amenities.",
+      "alignmentText": "Major metros move fast with long commutes; only smaller regional cities offer slower rhythms.",
       "alignmentValue": 4
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "9–6 schedules with short lunches; limited after‑school programs strain family logistics.",
-      "alignmentValue": 3
+      "alignmentText": "Schools run 8:30–14:30 and parents often extend days with extracurriculars to cover childcare gaps.",
+      "alignmentValue": 4
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Families often visit dachas or malls; many services remain open Saturdays.",
+      "alignmentText": "Families split time between city parks and dachas, though political rallies can disrupt public events.",
       "alignmentValue": 5
     },
     {
@@ -238,13 +239,13 @@
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "English spoken in tourist zones but limited outside major cities, requiring Russian proficiency.",
+      "alignmentText": "Outside international firms, daily life requires Russian for paperwork and social integration.",
       "alignmentValue": 3
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Government promotes conservative values and restricts dissent.",
-      "alignmentValue": 2
+      "alignmentText": "State ideology leans nationalist and socially conservative, clashing with the family’s progressive values.",
+      "alignmentValue": 1
     },
     {
       "key": "Marxism (Societal Attitudes)",
@@ -263,12 +264,12 @@
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "\"Gay propaganda\" laws and social stigma create a hostile climate.",
+      "alignmentText": "Broad anti-\"propaganda\" laws criminalize queer visibility, making it unsafe for polyamory-positive families.",
       "alignmentValue": 1
     },
     {
       "key": "Community Vibes",
-      "alignmentText": "Local networks are tight but can feel closed to outsiders.",
+      "alignmentText": "Neighborhood networks are close-knit but can be wary of outspoken foreigners.",
       "alignmentValue": 3
     },
     {
@@ -328,7 +329,7 @@
     },
     {
       "key": "Political System",
-      "alignmentText": "Highly centralized presidency with limited opposition and media control.",
+      "alignmentText": "Power concentrates in the presidency with managed elections and limited opposition.",
       "alignmentValue": 1
     },
     {
@@ -348,7 +349,7 @@
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Already authoritarian with little prospect for liberalization.",
+      "alignmentText": "Ongoing crackdowns on media and NGOs show active democratic erosion.",
       "alignmentValue": 1
     },
     {
@@ -358,8 +359,8 @@
     },
     {
       "key": "Stability",
-      "alignmentText": "Political stability masks repression and economic unpredictability.",
-      "alignmentValue": 3
+      "alignmentText": "Institutions appear stable but mobilization and war-related sanctions create daily uncertainty.",
+      "alignmentValue": 2
     },
     {
       "key": "Propaganda Prevalence",
@@ -373,47 +374,47 @@
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Policies favor conservative norms and limit civil liberties.",
-      "alignmentValue": 2
+      "alignmentText": "Benefits prioritize traditional families and military service over inclusive support.",
+      "alignmentValue": 3
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Reported trust is high but may reflect controlled media rather than genuine approval.",
+      "alignmentText": "Polling shows reported trust, yet it’s shaped by state media and limited alternatives.",
       "alignmentValue": 3
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Transparency International ranks Russia as highly corrupt.",
+      "alignmentText": "Russia ranks near the bottom globally, with corruption embedded in many transactions.",
       "alignmentValue": 2
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Bureaucratic bribery and oligarchic favoritism are common.",
+      "alignmentText": "Bribes and patronage networks influence everything from courts to utilities.",
       "alignmentValue": 2
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Soviet-era apartments dominate; modern housing is costly in major cities.",
+      "alignmentText": "Renovated flats in safe districts command high prices, while Soviet-era blocks need costly upgrades.",
       "alignmentValue": 3
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Violent crime is moderate but police harassment and political risk remain.",
+      "alignmentText": "Street crime is moderate, but arbitrary policing and political risk add stress.",
       "alignmentValue": 3
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal coverage but underfunded facilities and long waits.",
-      "alignmentValue": 4
-    },
-    {
-      "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Private insurance required; quality varies widely.",
+      "alignmentText": "Universal coverage struggles with staffing shortages and outdated equipment outside flagship hospitals.",
       "alignmentValue": 3
     },
     {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Expats rely on private clinics for quality care and often plan for evacuation insurance.",
+      "alignmentValue": 2
+    },
+    {
       "key": "Child Care Support",
-      "alignmentText": "Early education shortages and limited subsidies challenge working parents.",
+      "alignmentText": "Public kindergartens exist but have waitlists, especially in major cities.",
       "alignmentValue": 3
     },
     {
@@ -423,38 +424,38 @@
     },
     {
       "key": "Education",
-      "alignmentText": "Strong math and science tradition but curriculum leans patriotic.",
-      "alignmentValue": 5
+      "alignmentText": "STEM instruction is strong, yet civic curriculum emphasizes state narratives that conflict with progressive values.",
+      "alignmentValue": 4
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Extensive metros and railways enable car-free life in major cities.",
-      "alignmentValue": 7
+      "alignmentText": "Moscow and Saint Petersburg boast efficient metros, though regional coverage is patchier.",
+      "alignmentValue": 6
     },
     {
       "key": "Economic System",
-      "alignmentText": "Mixed economy with heavy state intervention and sanctions distortions.",
+      "alignmentText": "State-owned giants and sanctions limit competition and access to Western markets.",
       "alignmentValue": 3
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "Flat 13% income tax simplifies filing though reporting for foreigners can be complex.",
-      "alignmentValue": 5
-    },
-    {
-      "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "With resident status, income tax around 13% plus social contributions.",
-      "alignmentValue": 6
-    },
-    {
-      "key": "Banking & Payments",
-      "alignmentText": "Modern digital payments exist but sanctions limit international cards and transfers.",
+      "alignmentText": "Flat income tax keeps filing simple, but currency controls and reporting rules complicate expat finances.",
       "alignmentValue": 4
     },
     {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Residents pay 13–15% income tax, yet double-tax treaties and sanctions make compliance tricky.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Domestic cards and QR payments work, but international transfers and cards remain heavily restricted.",
+      "alignmentValue": 3
+    },
+    {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Everyday expenses are lower than in the US, though imported goods cost more.",
-      "alignmentValue": 6
+      "alignmentText": "Groceries and transit stay affordable, while imported goods and tuition have spiked.",
+      "alignmentValue": 5
     },
     {
       "key": "Retirement (Citizens)",
@@ -468,8 +469,8 @@
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Work and temporary residence visas require employer sponsorship and quotas.",
-      "alignmentValue": 2
+      "alignmentText": "Investor and work visas exist on paper, yet approvals for US applicants are exceedingly rare.",
+      "alignmentValue": 1
     },
     {
       "key": "Welcoming of US Migrants",
@@ -478,18 +479,18 @@
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Temporary residency precedes permanent status after several years.",
-      "alignmentValue": 3
+      "alignmentText": "Temporary residence requires employer or family sponsorship and strict annual reporting.",
+      "alignmentValue": 2
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Requires language exam and five years' residency; exceptions are rare.",
-      "alignmentValue": 3
+      "alignmentText": "Naturalization generally demands five years, Russian fluency, and loyalty oaths, with security vetting.",
+      "alignmentValue": 2
     },
     {
       "key": "Family Members",
-      "alignmentText": "Spousal and child visas allowed but paperwork is lengthy and intrusive.",
-      "alignmentValue": 3
+      "alignmentText": "Dependents can join but face registration, schooling, and healthcare hurdles.",
+      "alignmentValue": 2
     },
     {
       "key": "Timelines & Costs",
@@ -498,8 +499,8 @@
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Strict registration laws and political risks make noncompliance costly.",
-      "alignmentValue": 2
+      "alignmentText": "Registration lapses, political speech, or visa technicalities can trigger fines or deportation.",
+      "alignmentValue": 1
     },
     {
       "key": "Dual Citizenship Allowed",
@@ -508,33 +509,33 @@
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Movement between regions can require permits and some jobs restrict foreign workers.",
+      "alignmentText": "Expect travel restrictions, data monitoring, and difficulties accessing Western platforms for work.",
       "alignmentValue": 2
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Studios exist but many professionals have left, shrinking opportunities.",
-      "alignmentValue": 3
-    },
-    {
-      "key": "Notable Game Studios",
-      "alignmentText": "Gaijin Entertainment and Saber Interactive maintain offices despite relocations.",
-      "alignmentValue": 4
-    },
-    {
-      "key": "Notable Game Development Communities",
-      "alignmentText": "Small meetups and online forums continue but are subdued by emigration.",
-      "alignmentValue": 3
-    },
-    {
-      "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Access to funding is limited and international publishing hampered by sanctions.",
+      "alignmentText": "Studios operate, but sanctions limit publishing and many peers have relocated.",
       "alignmentValue": 2
     },
     {
+      "key": "Notable Game Studios",
+      "alignmentText": "Teams like Gaijin and Saber keep Russian branches, though leadership often sits abroad.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Meetups persist but are smaller due to emigration and censorship concerns.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Access to capital and global distribution is severely limited under sanctions.",
+      "alignmentValue": 1
+    },
+    {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "Urban centers boast fast internet and e-payments while rural areas lag considerably.",
-      "alignmentValue": 5
+      "alignmentText": "Urban infrastructure remains modern, yet import bans create maintenance challenges and rural gaps.",
+      "alignmentValue": 4
     }
   ]
 }

--- a/reports/south_korea_report.json
+++ b/reports/south_korea_report.json
@@ -1,29 +1,30 @@
 {
+  "version": 2,
   "iso": "KR",
   "values": [
     {
       "key": "Environment",
-      "alignmentText": "Mountainous terrain and well-kept parks offer plentiful outdoor escapes despite dense cities.",
-      "alignmentValue": 7
+      "alignmentText": "National parks and coastal trails are easy to reach, yet dense metros mean weekend nature breaks require travel planning.",
+      "alignmentValue": 6
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Heatwaves and rising seas threaten coastal zones though mitigation planning is active.",
-      "alignmentValue": 5
-    },
-    {
-      "key": "Seasonal Weather",
-      "alignmentText": "Four distinct seasons bring humid summers and cold winters, challenging our mild-climate preference.",
+      "alignmentText": "Hotter summers, stronger typhoons, and sea-level rise around Busan raise adaptation stakes.",
       "alignmentValue": 4
     },
     {
-      "key": "Air Quality",
-      "alignmentText": "Frequent fine-dust episodes from industry and China degrade urban air.",
+      "key": "Seasonal Weather",
+      "alignmentText": "Humid monsoon summers and below-freezing winters clash with the family’s mild-weather wish list.",
       "alignmentValue": 3
     },
     {
+      "key": "Air Quality",
+      "alignmentText": "Spring yellow dust and winter coal emissions push PM2.5 well above WHO guidance several times a year.",
+      "alignmentValue": 4
+    },
+    {
       "key": "Natural Disasters",
-      "alignmentText": "Typhoons and occasional quakes occur but building standards reduce impact.",
+      "alignmentText": "Typhoons, flash floods, and the remote risk of DPRK escalation require contingency plans despite strong preparedness.",
       "alignmentValue": 5
     },
     {
@@ -33,8 +34,8 @@
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "22–30°C (72–86°F) and humid monsoon rains.",
-      "alignmentValue": 4
+      "alignmentText": "July–August highs reach 30–33°C (86–91°F) with heavy humidity and tropical nights.",
+      "alignmentValue": 3
     },
     {
       "key": "Fall Temperature Range (C/F)",
@@ -43,7 +44,7 @@
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "-2–5°C (28–41°F) with occasional snow.",
+      "alignmentText": "Winter lows dip to -7°C (19°F) in Seoul, with dry winds that limit playground time.",
       "alignmentValue": 3
     },
     {
@@ -63,73 +64,73 @@
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "2024 rate about ₩9,860/hour (~$7.50) provides modest baseline.",
-      "alignmentValue": 5
+      "alignmentText": "The 2024 minimum wage is ₩9,860/hour (~$7.40), supporting service workers but still tight in Seoul.",
+      "alignmentValue": 6
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Seoul devs earn roughly $45k–$70k USD, lower than US but livable.",
+      "alignmentText": "Senior engineers earn ₩70–100M ($55–78k), with bonuses in major studios and fintech firms.",
       "alignmentValue": 6
     },
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Enterprise and game studios use .NET but market is smaller than Java.",
+      "alignmentText": "Finance, telecom, and public agencies run .NET stacks, though many roles expect Korean fluency and office time.",
       "alignmentValue": 5
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Ruby is niche with limited openings outside startups.",
+      "alignmentText": "Ruby is niche beyond startups like Coupang or Woowa Brothers, so openings are sporadic.",
       "alignmentValue": 4
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "E‑7 and other work visas exist yet require sponsorship and degree.",
+      "alignmentText": "Large companies sponsor E-7 visas, but documentation and points-based reviews can slow onboarding.",
       "alignmentValue": 5
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Advanced high-income economy with strong exports and tech sector.",
-      "alignmentValue": 8
+      "alignmentText": "A resilient export economy with strong R&D keeps unemployment low despite global slowdowns.",
+      "alignmentValue": 7
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Pandemic normalized some remote work but office presence remains standard.",
-      "alignmentValue": 4
-    },
-    {
-      "key": "Work-Life Balance",
-      "alignmentText": "Long hours culture clashes with our family’s balance goals despite reforms.",
-      "alignmentValue": 3
-    },
-    {
-      "key": "Work Week Hours",
-      "alignmentText": "Legal 40 but overtime often pushes weeks toward 50–60.",
-      "alignmentValue": 3
-    },
-    {
-      "key": "Vacation Days (Minimum)",
-      "alignmentText": "15 days after first year by labor law.",
+      "alignmentText": "Hybrid schedules are growing, yet many teams still value in-office collaboration.",
       "alignmentValue": 5
     },
     {
+      "key": "Work-Life Balance",
+      "alignmentText": "The 52-hour cap exists, but presenteeism and late client calls remain common in tech.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Official weeks are 40 hours, yet unpaid overtime or weekend sprints surface near launches.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Annual leave starts around 15 days after the first year, backed by national holidays.",
+      "alignmentValue": 6
+    },
+    {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Workers often take fewer than allowed due to culture.",
+      "alignmentText": "Many employees leave days unused due to workload and cultural pressure.",
       "alignmentValue": 4
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Seoul’s pace is fast and competitive; smaller cities slower.",
+      "alignmentText": "Seoul moves fast with crowded commutes; coastal cities like Busan feel marginally slower.",
       "alignmentValue": 4
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
-      "alignmentText": "Parents often return after 7 pm; kids attend after-school hagwons.",
-      "alignmentValue": 3
+      "alignmentText": "Schools run 8:30–15:00, but cram schools extend evenings, and parents often sync late office hours.",
+      "alignmentValue": 4
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
-      "alignmentText": "Family outings to parks, cafes, or hiking; catch up on rest.",
-      "alignmentValue": 5
+      "alignmentText": "Families split weekends between kid activities, markets, and short rail trips to national parks.",
+      "alignmentValue": 6
     },
     {
       "key": "Family Life",
@@ -238,13 +239,13 @@
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "English taught widely; proficiency moderate outside tourist areas.",
-      "alignmentValue": 5
+      "alignmentText": "English signage helps in Seoul, yet bureaucracy and social circles still rely on Korean.",
+      "alignmentValue": 4
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Democratic politics with active civil society yet conservative social views linger.",
-      "alignmentValue": 5
+      "alignmentText": "Younger voters push progressive reforms, but national politics remain centrist-conservative on many issues.",
+      "alignmentValue": 4
     },
     {
       "key": "Marxism (Societal Attitudes)",
@@ -263,8 +264,8 @@
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Activism growing but legal recognition and social acceptance remain limited.",
-      "alignmentValue": 3
+      "alignmentText": "Pride events occur, yet there’s no legal recognition for same-sex or polyamorous families and stigma persists.",
+      "alignmentValue": 2
     },
     {
       "key": "Community Vibes",
@@ -328,8 +329,8 @@
     },
     {
       "key": "Political System",
-      "alignmentText": "Presidential republic with regular competitive elections.",
-      "alignmentValue": 7
+      "alignmentText": "A robust democracy with competitive elections and independent courts, despite polarization.",
+      "alignmentValue": 8
     },
     {
       "key": "Religion in Politics",
@@ -348,8 +349,8 @@
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Institutions are stable though past military rule prompts vigilance.",
-      "alignmentValue": 5
+      "alignmentText": "Institutions are strong, though national security laws and surveillance powers merit monitoring.",
+      "alignmentValue": 6
     },
     {
       "key": "State of Capitalism",
@@ -373,48 +374,48 @@
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Gradual expansion of welfare and child incentives.",
+      "alignmentText": "Universal healthcare and expanding childcare subsidies help, but social safety nets still lag Nordic peers.",
       "alignmentValue": 6
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Varies with scandals; moderate overall.",
+      "alignmentText": "Trust swings with political scandals; citizens often rely on civic activism to push reforms.",
       "alignmentValue": 5
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Chaebol-political ties continue to raise concerns.",
-      "alignmentValue": 4
+      "alignmentText": "Transparency scores are mid-to-high, though chaebol influence prompts periodic investigations.",
+      "alignmentValue": 5
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Influence peddling and favoritism linked to conglomerates.",
-      "alignmentValue": 4
+      "alignmentText": "Elite favoritism and corporate collusion surface more than street-level bribery.",
+      "alignmentValue": 5
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Seoul housing costly with heavy reliance on jeonse deposits.",
+      "alignmentText": "Seoul’s jeonse deposits and condo prices are high, demanding significant savings.",
       "alignmentValue": 4
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Violent crime rates are low and streets feel safe.",
+      "alignmentText": "Violent crime is rare; late-night transit feels safe for the kids and adults alike.",
       "alignmentValue": 8
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal National Health Insurance offers affordable care.",
+      "alignmentText": "National Health Insurance offers fast access to quality hospitals and specialists.",
       "alignmentValue": 8
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Foreign residents can enroll after registration and pay into the system.",
+      "alignmentText": "Most long-term visas can join NHI, though initial enrollment requires paperwork in Korean.",
       "alignmentValue": 7
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Government subsidies help with daycare but long waits in cities.",
-      "alignmentValue": 6
+      "alignmentText": "Government stipends and public daycare slots are expanding, yet hours can be shorter than US standards.",
+      "alignmentValue": 5
     },
     {
       "key": "Family Policy (Common Family)",
@@ -423,38 +424,38 @@
     },
     {
       "key": "Education",
-      "alignmentText": "Students excel in OECD rankings but pressure and rote learning are concerns.",
+      "alignmentText": "Public schools deliver excellent academics, albeit with intense exam culture that may stress the kids.",
       "alignmentValue": 7
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Subways and buses are extensive, punctual, and affordable.",
+      "alignmentText": "Extensive subways, KTX high-speed rail, and cashless fare systems enable car-free living.",
       "alignmentValue": 9
     },
     {
       "key": "Economic System",
-      "alignmentText": "Advanced mixed economy with strong export base.",
+      "alignmentText": "A market economy led by chaebol conglomerates balances innovation with regulatory oversight.",
       "alignmentValue": 7
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "Income tax withheld monthly with annual reconciliation.",
-      "alignmentValue": 6
+      "alignmentText": "E-filing is streamlined, and year-end settlements auto-populate many deductions.",
+      "alignmentValue": 7
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "Middle-income families face roughly 10–20% effective rates.",
+      "alignmentText": "Combined income around ₩150M incurs marginal rates near 24% plus pension and health contributions.",
       "alignmentValue": 5
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "Highly digitized banking; mobile payments ubiquitous.",
+      "alignmentText": "Contactless payments and fast bank transfers are ubiquitous, though some apps require Korean ID verification.",
       "alignmentValue": 8
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Seoul living costs are high relative to local wages.",
-      "alignmentValue": 4
+      "alignmentText": "Groceries and transit are affordable, but housing, education, and imported goods can be costly.",
+      "alignmentValue": 5
     },
     {
       "key": "Retirement (Citizens)",
@@ -468,38 +469,38 @@
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Multiple work and business visas exist but paperwork is detailed.",
-      "alignmentValue": 5
+      "alignmentText": "Points-based F-2 residence and D-8 startup visas exist, yet they demand language, income, or investment proof.",
+      "alignmentValue": 4
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Generally neutral reception; cultural adaptation expected.",
-      "alignmentValue": 5
+      "alignmentText": "Koreans are generally friendly, though social integration hinges on learning Korean and respecting norms.",
+      "alignmentValue": 6
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "E and D visas typically valid 1–3 years before renewal.",
+      "alignmentText": "Most visas renew yearly initially, with longer F-series options after meeting residence and language criteria.",
       "alignmentValue": 5
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Requires 5+ years residency, language test, and renouncing prior citizenship.",
+      "alignmentText": "Naturalization requires five years, TOPIK level 4, and renouncing prior citizenship unless special cases apply.",
       "alignmentValue": 4
     },
     {
       "key": "Family Members",
-      "alignmentText": "Spouses and children can accompany on dependent visas.",
+      "alignmentText": "Spouses and children can join on dependent visas once the main applicant meets income and housing standards.",
       "alignmentValue": 6
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Processing takes several months with moderate legal fees.",
+      "alignmentText": "Immigration offices process applications in 2–4 months with moderate legal and translation fees.",
       "alignmentValue": 5
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Strict immigration checks; overstays result in fines or bans.",
-      "alignmentValue": 5
+      "alignmentText": "Maintaining address registration, visa-specific employment, and health insurance is essential to avoid fines.",
+      "alignmentValue": 4
     },
     {
       "key": "Dual Citizenship Allowed",
@@ -508,32 +509,32 @@
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Must maintain employment and address changes; bureaucracy in Korean.",
+      "alignmentText": "Expect mandatory national pension contributions and periodic document checks, but services are reliable.",
       "alignmentValue": 5
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Large online and mobile game sector offers many roles.",
-      "alignmentValue": 8
+      "alignmentText": "Major studios like Nexon, NCSoft, and Pearl Abyss actively hire and partner globally.",
+      "alignmentValue": 7
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Home to Nexon, NCSoft, Netmarble, and others.",
+      "alignmentText": "Seoul houses Nexon, NCSoft, Smilegate, and Krafton with sizable dev teams.",
       "alignmentValue": 8
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "Indie meetups and university clubs support collaboration.",
-      "alignmentValue": 6
+      "alignmentText": "KR G-Star, Seoul Indies, and campus clubs provide strong networking and mentorship.",
+      "alignmentValue": 7
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Government incubators and esports culture aid startups, though competition is stiff.",
+      "alignmentText": "Government grants and accelerator programs exist, though competition and labor costs are high.",
       "alignmentValue": 6
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "World-class broadband, transit, and smart-city tech everywhere.",
+      "alignmentText": "Gigabit internet, efficient transit, and smart-city services make daily life highly connected.",
       "alignmentValue": 9
     }
   ]


### PR DESCRIPTION
## Summary
- refresh Greenland’s report with Arctic climate risks, remote-work limitations, and Danish-controlled visa hurdles while marking the file as version 2
- recalibrate Italy’s climate, labor-market, and migration guidance to align with current EU realities and the family’s priorities
- downgrade Laos’s scores for climate exposure, governance, and services while flagging limited visa pathways for long-term stays
- update Russia’s entry to reflect wartime authoritarianism, sanctions-era economics, and heightened immigration barriers
- refine South Korea’s profile with sharper climate notes, work-culture caveats, and detailed visa and game-dev ecosystem guidance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e315cbdc388321a99a2268afb746b0