### PR TITLE
Refresh Czechia, Ecuador, Estonia, France, and Greece reports for v2

### DIFF
--- a/reports/czechia_report.json
+++ b/reports/czechia_report.json
@@ -1,10 +1,11 @@
 {
+  "version": 2,
   "iso": "CZ",
   "values": [
     {"key": "Environment", "alignmentText": "Extensive forests, well-maintained parks, and EU environmental enforcement keep air and water quality generally high, giving the family easy access to green space near Prague and Brno.", "alignmentValue": 7},
-    {"key": "Global Warming Risk", "alignmentText": "Being inland shields Czechia from sea-level rise, yet recent droughts and Central European heatwaves show growing climate volatility that planners are only partially addressing.", "alignmentValue": 6},
+    {"key": "Global Warming Risk", "alignmentText": "Being inland avoids sea-level threats, yet Central Europe now sees multi-year droughts, bark beetle die-offs, and heatwaves every few summers, so the family should plan for recurring water and forest-stress disruptions.", "alignmentValue": 5},
     {"key": "Seasonal Weather", "alignmentText": "The country swings from pleasantly warm summers to grey, chilly winters; shoulder seasons can be damp, so overall comfort is mixed for a family seeking mild weather.", "alignmentValue": 5},
-    {"key": "Air Quality", "alignmentText": "Cities usually meet EU PM2.5 targets thanks to cleaner heating and industry, but winter inversions around Ostrava and Prague occasionally push pollution into unhealthy ranges.", "alignmentValue": 6},
+    {"key": "Air Quality", "alignmentText": "Cities usually meet EU PM2.5 limits with gas heating and tram-focused commuting, yet winter inversions around Ostrava and Prague trigger several smog days each month that call for monitoring and occasional indoor days for sensitive family members.", "alignmentValue": 7},
     {"key": "Natural Disasters", "alignmentText": "Major earthquakes and hurricanes are absent; the main risks are Vltava basin floods and localized windstorms, which authorities monitor closely with modern defenses.", "alignmentValue": 7},
     {"key": "Spring Temperature Range (C/F)", "alignmentText": "March–May daytime highs typically run 10–18 °C (50–64 °F) with cool nights and intermittent rain as the country transitions out of winter.", "alignmentValue": 5},
     {"key": "Summer Temperature Range (C/F)", "alignmentText": "June–August averages hover around 15–26 °C (59–79 °F); humidity is moderate, though sporadic heatwaves now spike into the 30s °C (mid-80s °F).", "alignmentValue": 6},

--- a/reports/ecuador_report.json
+++ b/reports/ecuador_report.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "iso": "EC",
   "values": [
     {
@@ -8,7 +9,7 @@
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Coastal areas face sea-level rise and stronger El Niño floods while Andean glaciers are retreating, signaling notable medium-term climate risk.",
+      "alignmentText": "Coastal provinces now see severe El Niño floods every few years, Andean glaciers feeding Quito shrink quickly, and drought alternates with landslides, so climate disruptions are a recurring planning factor.",
       "alignmentValue": 4
     },
     {
@@ -93,8 +94,8 @@
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Fiber internet is expanding and co-working spaces exist in Quito and Cuenca, but business culture still leans in-person and power outages occur in some regions.",
-      "alignmentValue": 5
+      "alignmentText": "Fiber is expanding and Cuenca/Quito host coworking hubs, yet rolling blackouts and in-person expectations outside tech hubs mean Trey and Sarah must keep backup connectivity for remote work.",
+      "alignmentValue": 4
     },
     {
       "key": "Work-Life Balance",
@@ -398,8 +399,8 @@
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Crime spiked in 2023–24 with gang violence near ports; Andean cities stay calmer but require caution with petty theft.",
-      "alignmentValue": 3
+      "alignmentText": "Homicide rates surged past 40 per 100k in 2023, with gangs controlling port cities and extortion creeping inland; even quieter Andean bases now require curfews, vetted transport, and avoiding night travel.",
+      "alignmentValue": 2
     },
     {
       "key": "Healthcare (Citizens)",

--- a/reports/estonia_report.json
+++ b/reports/estonia_report.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "iso": "EE",
   "values": [
     {
@@ -8,8 +9,8 @@
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Baltic Sea level rise and peatland fire risk are rising concerns, yet Estonia sits outside major hurricane or drought belts and is investing in coastal defenses, keeping overall climate risk moderate for the family.",
-      "alignmentValue": 6
+      "alignmentText": "Baltic sea-level rise, peat bog fires, and infrastructure stress from thaw cycles are watched closely, but adaptation projects in Tallinn and the small hazard footprint keep risk manageable so far for the family.",
+      "alignmentValue": 7
     },
     {
       "key": "Seasonal Weather",

--- a/reports/france_report.json
+++ b/reports/france_report.json
@@ -1,14 +1,15 @@
 {
+  "version": 2,
   "iso": "FR",
   "values": [
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Strong enterprise adoption keeps demand steady.",
+      "alignmentText": "Paris, Lyon, and Toulouse banks and consultancies run large .NET teams, and hybrid norms let Trey pair on-site sprints with remote days, though French language skills help with legacy clients.",
       "alignmentValue": 7
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Urban pollution persists but overall air quality is improving.",
+      "alignmentText": "Paris and Lyon still see commuter NO₂ peaks, yet nationwide PM2.5 averages sit near 12 µg/m³ with low wildfire smoke, so the family can enjoy parks while tracking occasional smog alerts.",
       "alignmentValue": 6
     },
     {
@@ -18,22 +19,22 @@
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Stable democracy with active civil society.",
+      "alignmentText": "Courts, media, and frequent protests keep checks on executive power; even with emergency powers during crises, institutions remain resilient.",
       "alignmentValue": 8
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "Modern banking and widespread contactless payments.",
+      "alignmentText": "SEPA transfers clear quickly, contactless cards and Apple Pay are ubiquitous, and online banks like Boursorama ease setup once residency documents are ready.",
       "alignmentValue": 8
     },
     {
       "key": "Beach Life",
-      "alignmentText": "Mediterranean and Atlantic coasts offer ample beaches and amenities.",
+      "alignmentText": "Atlantic beaches like Biarritz and Mediterranean spots near Nice offer lifeguarded sands, though peak tourist season brings crowds and higher prices.",
       "alignmentValue": 7
     },
     {
       "key": "Boardgaming & Tabletop",
-      "alignmentText": "Growing hobby scene with dedicated cafés.",
+      "alignmentText": "Publishers like Asmodee are headquartered near Paris, and cities host board-game cafés and festivals such as Paris Est Ludique, aligning with Trey’s tabletop interests.",
       "alignmentValue": 7
     },
     {
@@ -48,42 +49,42 @@
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "CAF benefits (PAJE/CMG), free maternelle from 3, parental leave options; tax credits for care; generous by OECD standards.",
-      "alignmentValue": 8.0
+      "alignmentText": "CAF benefits (PAJE, CMG), free école maternelle from age 3, and generous parental leave let working parents line up structured care without crushing costs—ideal for Sarah’s search for predictable coverage.",
+      "alignmentValue": 8
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Eligibility tied to residence status/social contributions; many CAF supports available to residents; documentation and waiting apply.",
-      "alignmentValue": 7.0
+      "alignmentText": "Long-stay visa holders who pay into social security can access CAF reimbursements, though paperwork in French and processing delays mean expat families should budget bridging funds.",
+      "alignmentValue": 7
     },
     {
       "key": "Common Hobbies",
-      "alignmentText": "Café culture, football, outdoor markets.",
+      "alignmentText": "Locals cherish café culture, hiking in the Alps or Pyrenees, and neighborhood sports clubs, offering easy ways for Trey and Sarah to plug into community life.",
       "alignmentValue": 7
     },
     {
       "key": "Community Vibes",
-      "alignmentText": "Locals can be reserved but strong communities once integrated.",
+      "alignmentText": "Neighbors may seem reserved at first, yet school parent groups, sports clubs, and local associations open doors once the family shows steady participation.",
       "alignmentValue": 6
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Must maintain residency days and health coverage.",
+      "alignmentText": "Visa holders must maintain French tax residence, update prefecture records, and keep health insurance active; missed renewals can trigger exit orders.",
       "alignmentValue": 6
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "High in Paris; moderate in other regions.",
+      "alignmentText": "Expect €3,500–€4,500 monthly for a family in Paris including rent; relocating to cities like Lille or Toulouse trims budgets by a third.",
       "alignmentValue": 5
     },
     {
       "key": "Dual Citizenship Allowed",
       "alignmentText": "Yes—dual nationality is allowed.",
-      "alignmentValue": 9.0
+      "alignmentValue": 9
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Large diverse economy with moderate growth and low unemployment.",
+      "alignmentText": "France’s €3 trillion economy posts unemployment near 7% and moderate 1–2% growth, offering diversified job markets even during EU downturns.",
       "alignmentValue": 7
     },
     {
@@ -98,58 +99,58 @@
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Tech firms sponsor visas but bureaucracy is heavy.",
+      "alignmentText": "Talent Passport and EU Blue Card programs are common for Paris tech hires, yet employers expect French resumes and patience with OFII appointments, so sponsorship is viable but paperwork-heavy.",
       "alignmentValue": 5
     },
     {
       "key": "Environment",
-      "alignmentText": "Diverse landscapes from Alps to Atlantic coast with strong environmental protections.",
+      "alignmentText": "From the Alps to Atlantic dunes, France maintains vast protected areas and clean water standards, giving the family easy escapes to nature close to major cities.",
       "alignmentValue": 8
     },
     {
       "key": "Expected Tax Rate (Our Family)",
-      "alignmentText": "High income and social taxes compared to US.",
+      "alignmentText": "High earners face marginal income taxes up to 45% plus ~25% social contributions; with France’s family quotient the effective rate still lands in the low 40s, higher than the family pays today.",
       "alignmentValue": 4
     },
     {
       "key": "Fall Temperature Range (C/F)",
-      "alignmentText": "Pleasant in many regions; 10–18 °C typical; increasing rain/wind into Nov; good shoulder season.",
-      "alignmentValue": 7.0
+      "alignmentText": "September stays around 18 °C (64 °F) in Paris before sliding to 10 °C (50 °F) with more rain by November, giving the family a long shoulder season for museum trips and markets.",
+      "alignmentValue": 7
     },
     {
       "key": "Family Life",
-      "alignmentText": "Family-centric culture with childcare and education supports.",
+      "alignmentText": "Weekend markets, public parks, and subsidized sports clubs keep families active, and employers expect parents to take school holidays seriously—great for balancing Trey’s work with kid time.",
       "alignmentValue": 8
     },
     {
       "key": "Family Members",
-      "alignmentText": "Spouses can work and children attend public schools.",
+      "alignmentText": "Long-stay visas allow spouses to work once OFII paperwork is cleared, and children access public schools and healthcare on par with locals.",
       "alignmentValue": 8
     },
     {
       "key": "Family Policy (Citizens)",
-      "alignmentText": "Parental leave allowances, child benefits via CAF, family quotient in taxes; evolving flexibility on remote/hours.",
-      "alignmentValue": 8.0
+      "alignmentText": "Citizens tap 16+ weeks paid parental leave, monthly CAF allowances, and tax splitting via the family quotient, all of which underpin generous time with young kids.",
+      "alignmentValue": 8
     },
     {
       "key": "Family Policy (Common Family)",
-      "alignmentText": "Traditional policies with support for parents.",
+      "alignmentText": "Typical families rely on state-run childcare, employer meal vouchers, and long school vacations; coordinating all the paperwork takes effort but pays off.",
       "alignmentValue": 7
     },
     {
       "key": "Family Policy (Visa Holders)",
-      "alignmentText": "Access depends on residence and contributions; many benefits extend to residents; exact eligibility varies.",
-      "alignmentValue": 7.0
+      "alignmentText": "Once the family contributes to Sécurité sociale they can apply for CAF benefits, though proving income and residency history can delay payouts for new arrivals.",
+      "alignmentValue": 7
     },
     {
       "key": "Fashion Trends (Female)",
       "alignmentText": "Minimalist to chic; dresses/knits/trousers with layers; strong fashion/beauty culture.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Fashion Trends (Male)",
       "alignmentText": "Smart‑casual tailoring, minimalist chic, quality sneakers/boots; weather‑appropriate outerwear.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Femininity Norms",
@@ -158,77 +159,77 @@
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Growing indie scene and some AAA studios.",
+      "alignmentText": "Studios like Ubisoft, Dontnod, and Amplitude hire engineers regularly, and remote collaboration with EU teams is common, giving Trey steady options.",
       "alignmentValue": 7
     },
     {
       "key": "Gender Fluidity",
-      "alignmentText": "Legal recognition exists though social acceptance varies.",
+      "alignmentText": "Legal recognition for gender marker changes exists, yet everyday acceptance varies outside major cities, so queer and trans communities concentrate in urban areas.",
       "alignmentValue": 6
     },
     {
       "key": "Gender Rights",
-      "alignmentText": "Strong legal protections and parental leave policies.",
+      "alignmentText": "Anti-discrimination laws, reproductive rights, and generous parental leave policies align with the family’s equity expectations.",
       "alignmentValue": 8
     },
     {
       "key": "Gender Roles",
-      "alignmentText": "Progressive yet some traditional expectations remain.",
+      "alignmentText": "Dual-income households are common and men take more parental leave, though household labor still skews female compared with Nordic norms.",
       "alignmentValue": 7
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "OFII/ANEF procedures for long‑stay visas; health coverage via PUMA after residence; bank/lease documentation; translate key records.",
-      "alignmentValue": 6.0
+      "alignmentText": "Expect ANEF online submissions, in-person OFII visits, French-language leases, and notarized translations; hiring a relocation attorney eases the learning curve.",
+      "alignmentValue": 6
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Heatwaves and sea-level rise threaten southern and coastal regions.",
+      "alignmentText": "France already faces deadly canicules, drought-stressed rivers, and Atlantic storm surge planning, so the family should expect periodic climate disruptions but benefits from strong adaptation funding.",
       "alignmentValue": 6
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal system with high quality care.",
+      "alignmentText": "France’s universal Sécurité sociale system covers GP visits, maternity care, and prescriptions with low co-pays, delivering reliable care for families.",
       "alignmentValue": 9
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Public coverage accessible after residency.",
+      "alignmentText": "After three months of residence the family can enroll in PUMA for public coverage, with supplemental mutuelle plans filling gaps for faster specialist access.",
       "alignmentValue": 8
     },
     {
       "key": "Higher Education Access (Citizens)",
-      "alignmentText": "Low public tuition; CPGE/grandes écoles track; scholarships and CROUS housing; strong national network.",
-      "alignmentValue": 8.0
+      "alignmentText": "Public universities charge a few hundred euros per year, with prestigious CPGE tracks feeding grandes écoles and CROUS housing keeping living costs manageable for future college-aged kids.",
+      "alignmentValue": 8
     },
     {
       "key": "Higher Education Access (Visa Holders)",
-      "alignmentText": "International tuition higher but moderate vs. US; scholarships exist; options improve with residence/PR.",
-      "alignmentValue": 6.0
+      "alignmentText": "Non-EU students pay a few thousand euros annually unless they secure waivers; scholarships and residency status can bring fees closer to citizen rates over time.",
+      "alignmentValue": 6
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "High housing costs in Paris; more affordable in regions.",
+      "alignmentText": "Paris rents exceed €2,500 for family flats and require guarantors, but mid-sized cities like Nantes or Montpellier offer larger housing at 30–40% less.",
       "alignmentValue": 5
     },
     {
       "key": "How Taxes Are Handled",
-      "alignmentText": "Pay-as-you-earn with annual filing.",
+      "alignmentText": "France uses pay-as-you-earn withholding plus a streamlined online declaration; expect forms only in French, so hiring an accountant the first year helps.",
       "alignmentValue": 6
     },
     {
       "key": "K-12 Education Access (Citizens)",
-      "alignmentText": "Free, secular public system (laïcité); zoning applies; quality varies by académie; options for international sections.",
-      "alignmentValue": 9.0
+      "alignmentText": "Citizens enjoy free, secular schools with strong math/language curricula, and larger cities offer international sections that could give Anduin bilingual exposure.",
+      "alignmentValue": 9
     },
     {
       "key": "K-12 Education Access (Visa Holders)",
-      "alignmentText": "Resident children enroll in public schools; documentation (proof of address, vaccines) needed; FLE support for newcomers.",
-      "alignmentValue": 8.0
+      "alignmentText": "Resident children enroll easily once they show address, vaccination, and birth certificates; specialized French-as-a-second-language support helps new arrivals acclimate.",
+      "alignmentValue": 8
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "French dominates; English less common outside large cities.",
+      "alignmentText": "French remains essential for bureaucracy and daily life; English is workable in Paris tech circles but drops fast in prefectures, so the family should plan for classes and translation help.",
       "alignmentValue": 4
     },
     {
@@ -248,117 +249,117 @@
     },
     {
       "key": "Meetups & Communities",
-      "alignmentText": "Active tech and cultural meetup scene.",
+      "alignmentText": "Meetup groups cover startup pitches, queer communities, and parenting circles, especially in Paris and Lyon, giving Trey and Sarah ready-made networks.",
       "alignmentValue": 7
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "National SMIC provides a decent baseline compared to cost of living.",
+      "alignmentText": "The SMIC sits near €1,766 gross per month in 2024, supporting local hires better than many EU peers but still tight for Paris rent.",
       "alignmentValue": 7
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "High-speed rail, fiber internet, and modern amenities.",
+      "alignmentText": "High-speed TGV lines, nationwide fiber rollout, and reliable utilities keep daily logistics smooth for tech professionals.",
       "alignmentValue": 8
     },
     {
       "key": "Natural Beauty",
-      "alignmentText": "Historic towns, vineyards, and mountains create rich scenery.",
+      "alignmentText": "From Loire Valley châteaux to the Alps and lavender fields in Provence, weekend getaways deliver diverse scenery for the family.",
       "alignmentValue": 9
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Moderate risk from floods and occasional storms.",
+      "alignmentText": "River flooding, Atlantic windstorms, and the odd Mediterranean wildfire appear regularly, so insurance and alerts are important but manageable.",
       "alignmentValue": 6
     },
     {
       "key": "Nature Access",
-      "alignmentText": "Countryside, mountains, and coasts reachable by train.",
+      "alignmentText": "Regional trains reach hiking trails, vineyards, and coasts within a few hours, making spontaneous nature trips realistic without a car.",
       "alignmentValue": 8
     },
     {
       "key": "Nightlife & Music",
-      "alignmentText": "Vibrant nightlife especially in Paris and major cities.",
+      "alignmentText": "Paris hosts everything from jazz cellars to arena tours, and even mid-sized cities keep late-night music scenes active for occasional date nights.",
       "alignmentValue": 8
     },
     {
       "key": "Nightlife Culture",
       "alignmentText": "Paris/Lyon/Marseille vibrant; smaller cities quieter; café/bar culture late dining; safety varies by arrondissement.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "Events like Paris Games Week support networking.",
+      "alignmentText": "Paris Games Week, IndieCade Europe, and local IGDA chapters provide frequent networking touchpoints for Trey’s studio ambitions.",
       "alignmentValue": 8
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Ubisoft, Quantic Dream, and Asobo Studio operate locally.",
+      "alignmentText": "AAA teams like Ubisoft, Asobo, and Arkane share space with indies such as Motion Twin, ensuring a deep talent pool for collaboration.",
       "alignmentValue": 9
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Government grants and EU funds foster startups.",
+      "alignmentText": "Tax credits (CIJV), CNC grants, and Ubisoft’s entrepreneur labs support indie studios, making France a strong launchpad if Trey builds a local team.",
       "alignmentValue": 7
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Varies; slower in countryside, moderate in cities.",
+      "alignmentText": "Paris runs brisk with late dinners, while regional cities balance work and leisure—giving Sarah options between urban energy and calmer rhythms.",
       "alignmentValue": 7
     },
     {
       "key": "Parenting Expectations",
-      "alignmentText": "Education-focused with moderate extracurricular load.",
+      "alignmentText": "Schools emphasize academics and respect for teachers, with manageable extracurricular commitments compared to US over-scheduling.",
       "alignmentValue": 6
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Five-year residency with integration requirements; dual citizenship allowed.",
+      "alignmentText": "After five years of residence (or three if married to a citizen), applicants need B1 French and a civics interview; dual citizenship is allowed so the family can retain US passports.",
       "alignmentValue": 7
     },
     {
       "key": "Perceived Corruption",
-      "alignmentText": "Relatively low corruption by global standards.",
+      "alignmentText": "France scores well on Transparency International indices, though periodic political finance scandals remind us to watch procurement processes.",
       "alignmentValue": 7
     },
     {
       "key": "Political System",
-      "alignmentText": "Semi-presidential republic with multi-party democracy.",
+      "alignmentText": "A semi-presidential system with proportional parliamentary elections keeps multiple parties in play and encourages civic engagement.",
       "alignmentValue": 7
     },
     {
       "key": "Polyamory",
-      "alignmentText": "Limited social acceptance; communities operate discreetly.",
+      "alignmentText": "Polyamory lacks legal recognition and is primarily embraced within urban queer networks, so openness requires discretion outside big cities.",
       "alignmentValue": 3
     },
     {
       "key": "Pre-K / Early Childcare Landscape",
-      "alignmentText": "École maternelle (age 3–6) free/compulsory; crèches/assistantes maternelles subsidized via CAF; availability varies by commune.",
-      "alignmentValue": 8.0
+      "alignmentText": "École maternelle is free and near-universal from age 3, while crèche spots and licensed nannies receive CAF subsidies—Trey and Sarah just need to join waitlists early in dense arrondissements.",
+      "alignmentValue": 8
     },
     {
       "key": "Private Education",
-      "alignmentText": "Private sous contrat (often Catholic) with low fees; fully private/international schools higher tuition and selective.",
-      "alignmentValue": 6.0
+      "alignmentText": "Sous contrat schools cost a few hundred euros per year, while international campuses run €12–€20k and require early applications—important if the family wants English-heavy curricula.",
+      "alignmentValue": 6
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Generally progressive on social issues though tensions exist.",
+      "alignmentText": "France legalised marriage equality and maintains robust secular policies, yet debates over laïcité and policing show tensions—urban areas feel progressive overall for the family.",
       "alignmentValue": 7
     },
     {
       "key": "Propaganda Messaging",
-      "alignmentText": "Public service messaging focuses on unity and civic duty.",
+      "alignmentText": "Government campaigns emphasize republican values, anti-extremism, and climate action—messages the family may appreciate even if they can feel frequent after major protests.",
       "alignmentValue": 6
     },
     {
       "key": "Propaganda Prevalence",
-      "alignmentText": "Independent media with limited state propaganda.",
+      "alignmentText": "Public broadcasters operate independently and investigative journalism is robust, though government messaging spikes during security incidents.",
       "alignmentValue": 7
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Extensive metro, rail, and bus networks.",
+      "alignmentText": "Paris’ RER and metro run every few minutes, TGV links regional cities quickly, and even mid-sized towns maintain reliable buses, letting the family skip owning a car.",
       "alignmentValue": 8
     },
     {
@@ -368,118 +369,118 @@
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Remote work has gained acceptance post-pandemic.",
+      "alignmentText": "Hybrid schedules became standard in tech and many government roles post-pandemic, though fully remote contracts may still require occasional on-site weeks.",
       "alignmentValue": 7
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Temporary permits lead to long-term cards after five years.",
+      "alignmentText": "Multi-year Talent Passports renew in four-year blocks, and after five years of residence the family can seek 10-year cartes de résident if they maintain income and integration.",
       "alignmentValue": 6
     },
     {
       "key": "Retirement (Citizens)",
-      "alignmentText": "Pay‑as‑you‑go pension system; legal age recently increased; adequacy depends on contributions and housing costs.",
-      "alignmentValue": 6.0
+      "alignmentText": "France’s pay-as-you-go system now targets retirement around age 64; benefits cover basics but assume homeowners supplement with savings.",
+      "alignmentValue": 6
     },
     {
       "key": "Retirement (Immigrants)",
-      "alignmentText": "Access to pensions with contributions; rules complex.",
+      "alignmentText": "Immigrants earning in France accrue the same pension rights once they pay into Sécurité sociale, yet navigating credited quarters and bilateral treaties can be complex.",
       "alignmentValue": 6
     },
     {
       "key": "Retirement (Visa Holders)",
-      "alignmentText": "Eligibility tied to contributions and residence; totalization treaties may help; private savings advisable.",
-      "alignmentValue": 5.0
+      "alignmentText": "US–France totalization lets long-term residents combine contributions, but the family would still rely on private savings given modest state payouts.",
+      "alignmentValue": 5
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Active startup scene uses Ruby on Rails but not dominant.",
+      "alignmentText": "Paris SaaS startups and e-commerce teams still hire Rails engineers, and remote-friendly scaleups like Doctolib or BlaBlaCar keep pipelines open, though competition is stronger than in the US.",
       "alignmentValue": 6
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Generally safe with petty crime in tourist areas.",
+      "alignmentText": "Violent crime is low, but the family should watch for pickpockets on transit and steer clear of occasional protest hotspots in Paris.",
       "alignmentValue": 7
     },
     {
       "key": "Schooling Options",
-      "alignmentText": "Strong public schools and bilingual options in major cities.",
+      "alignmentText": "Public collèges/lycées are solid, and Paris/Lyon host bilingual and international schools, though the latter charge €10–15k and require early applications.",
       "alignmentValue": 7
     },
     {
       "key": "Seasonal Beach Water Temp",
-      "alignmentText": "Comfortable swimming from late spring through early fall in the south.",
+      "alignmentText": "Mediterranean waters warm to 24–26 °C (75–79 °F) by July, while Atlantic coasts stay closer to 19–21 °C, giving the family options depending on comfort.",
       "alignmentValue": 7
     },
     {
       "key": "Seasonal Weather",
-      "alignmentText": "Mild winters and warm summers in many areas; northern regions can be chilly.",
-      "alignmentValue": 7
+      "alignmentText": "Atlantic France brings mild, wet winters and comfortable springs, but July–August heatwaves now spike above 35 °C, so the family gets variety with a need for good cooling plans in Paris or Lyon.",
+      "alignmentValue": 6
     },
     {
       "key": "Sex (Attitudes)",
-      "alignmentText": "Relatively open attitudes toward sexuality.",
+      "alignmentText": "Sex education is comprehensive and public conversation around relationships is open, though polyamory remains niche outside major cities.",
       "alignmentValue": 7
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Progressive on healthcare, education, and LGBTQ rights.",
+      "alignmentText": "Universal healthcare, extensive family benefits, and strong LGBTQ protections align with the family’s progressive values, even if bureaucracy can feel heavy.",
       "alignmentValue": 8
     },
     {
       "key": "Spring Temperature Range (C/F)",
-      "alignmentText": "Varied but generally mild: NW/Atlantic ~8–15 °C (46–59 °F), Paris ~8–16 °C; South warmer; frequent showers.",
-      "alignmentValue": 8.0
+      "alignmentText": "Atlantic regions hover around 8–15 °C (46–59 °F) and Paris reaches 16 °C (61 °F) by May, with showers but plenty of terrace days the family would enjoy.",
+      "alignmentValue": 8
     },
     {
       "key": "Stability",
-      "alignmentText": "Political protests occur but institutions remain stable.",
+      "alignmentText": "Frequent strikes and protests create noise, yet NATO/EU membership and predictable institutions keep the long-term outlook steady.",
       "alignmentValue": 7
     },
     {
       "key": "State Ideology",
-      "alignmentText": "Mix of social welfare and capitalism.",
+      "alignmentText": "France blends dirigiste economic planning with social welfare, funding public services while courting strategic industries.",
       "alignmentValue": 7
     },
     {
       "key": "State of Capitalism",
-      "alignmentText": "Regulated market economy with strong safety net.",
+      "alignmentText": "Heavy regulation and worker protections coexist with vibrant private enterprise, offering stability at the cost of some bureaucracy.",
       "alignmentValue": 7
     },
     {
       "key": "Summer Temperature Range (C/F)",
-      "alignmentText": "Warm to hot; Paris ~18–25 °C typical with episodic heatwaves >35 °C; South hot/drier; humidity moderate on coasts.",
-      "alignmentValue": 4.0
+      "alignmentText": "Paris summer highs average 25 °C (77 °F) but increasingly jump past 35 °C during canicules, while Mediterranean cities exceed 30 °C with warm nights—manageable if the family secures air conditioning.",
+      "alignmentValue": 4
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Application fees moderate with several months processing.",
+      "alignmentText": "Consular appointments and OFII validation often stretch 2–4 months, with fees of €200–€450 per adult plus translation costs.",
       "alignmentValue": 6
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Moderate trust; protest culture common.",
+      "alignmentText": "Eurobarometer surveys show trust hovering near 35%, with protests expressing frustration but not eroding core institutions.",
       "alignmentValue": 6
     },
     {
       "key": "Type of Corruption",
-      "alignmentText": "Occasional political scandals but limited daily impact.",
+      "alignmentText": "Corruption tends to surface in campaign financing or public procurement rather than day-to-day bribery, so diligence on contracts is enough.",
       "alignmentValue": 7
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Competitive pay in Paris and tech hubs though taxed heavily.",
+      "alignmentText": "Senior engineers in Paris earn roughly €65k–€85k plus bonuses; after France’s higher taxes the take-home is leaner than US remote roles, but still supports urban living if housing is managed.",
       "alignmentValue": 7
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
       "alignmentText": "Family meals, markets, parks, sports; many shops open Sat, limited Sun opening outside big cities; cultural outings.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
       "alignmentText": "Primary ~08:30–16:30 (long lunch); Wed often half-day; offices ~09:00–18:00; after‑school care (garderie/études) common.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Vacation Days (Minimum)",
@@ -493,12 +494,12 @@
     },
     {
       "key": "View of Neighboring Countries",
-      "alignmentText": "Cooperative within EU with mild rivalries.",
+      "alignmentText": "Relations with Germany and Spain are pragmatic and cooperative, while historic rivalries show up mostly in sports banter.",
       "alignmentValue": 6
     },
     {
       "key": "View of self",
-      "alignmentText": "Proud of cultural heritage and republican values.",
+      "alignmentText": "French identity emphasizes republican ideals, culinary heritage, and the role of the state, which locals discuss with pride.",
       "alignmentValue": 7
     },
     {
@@ -508,37 +509,37 @@
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Talent Passport and EU Blue Card options for skilled workers.",
+      "alignmentText": "Talent Passport, EU Blue Card, and Profession Libérale visas cover most scenarios, but each demands diplomas, work contracts, or business plans translated into French.",
       "alignmentValue": 6
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Generally welcoming though bureaucracy heavy.",
+      "alignmentText": "Large American communities in Paris and Bordeaux smooth integration, yet officials expect French fluency and meticulous paperwork, so patience is required.",
       "alignmentValue": 6
     },
     {
       "key": "What Is Intriguing",
-      "alignmentText": "Rich history, cuisine, and art culture.",
+      "alignmentText": "Centuries of art, Michelin-level food, and easy train trips to UNESCO sites keep weekends stimulating for the family.",
       "alignmentValue": 8
     },
     {
       "key": "Winter Temperature Range (C/F)",
-      "alignmentText": "North/NW ~3–8 °C damp chill; South milder; mountain snow; severe cold rare at sea level.",
-      "alignmentValue": 6.0
+      "alignmentText": "Northern cities hover around 3–8 °C (37–46 °F) with damp chill, while the south stays milder; snow is rare away from the Alps, matching the family’s dislike of harsh winters.",
+      "alignmentValue": 6
     },
     {
       "key": "Work Week Hours",
-      "alignmentText": "Legal 35-hour workweek with limited overtime.",
+      "alignmentText": "Statutory 35-hour weeks and overtime caps are enforced, and many tech firms add RTT days, keeping schedules family-friendly.",
       "alignmentValue": 9
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Strong labor protections support healthy balance.",
+      "alignmentText": "The 35-hour week, legally mandated rest days, and August shutdowns mean managers expect people to disconnect—great for Sarah’s need for predictable downtime.",
       "alignmentValue": 8
     },
     {
       "key": "Workers' Rights",
-      "alignmentText": "Strong unions and protective labor laws.",
+      "alignmentText": "Powerful unions, collective bargaining, and strict dismissal rules give employees leverage if workloads creep up.",
       "alignmentValue": 8
     }
   ]

--- a/reports/greece_report.json
+++ b/reports/greece_report.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "iso": "GR",
   "values": [
     {
@@ -8,7 +9,7 @@
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Heatwaves, drought, and wildfire seasons are intensifying in Greece, and low-lying islands face sea-level rise that could disrupt the stability you want.",
+      "alignmentText": "Triple-digit heatwaves, water rationing, and island evacuations during near-annual wildfire seasons now punctuate Greek summers, so climate shocks remain a serious planning concern for the family.",
       "alignmentValue": 4
     },
     {
@@ -23,8 +24,8 @@
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Regular seismic activity, flash floods, and severe wildfire seasons raise resilience concerns compared with safer locales.",
-      "alignmentValue": 4
+      "alignmentText": "Frequent earthquakes, Attica flash floods, and record wildfire seasons mean evacuation plans and insurance buffers are essential compared with safer locales.",
+      "alignmentValue": 3
     },
     {
       "key": "Spring Temperature Range (C/F)",
@@ -98,8 +99,8 @@
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Greeks value late-evening family time, but long work hours and overtime norms can undercut the slower pace Sarah wants.",
-      "alignmentValue": 5
+      "alignmentText": "While dinners stretch late with family, salaried roles often expect 45+ hour weeks and weekend availability, making it tougher for Sarah to maintain the gentle pace she prioritizes.",
+      "alignmentValue": 4
     },
     {
       "key": "Work Week Hours",


### PR DESCRIPTION
## Summary
- mark the Czechia, Ecuador, Estonia, France, and Greece country reports as version 2 and recalibrate key climate and safety scores to match the updated guidance
- expand the France report with detailed work, childcare, taxation, and lifestyle narratives that align with the family profile while keeping alignment values consistent with the rating guides

## Testing
- node -e "['czechia','ecuador','estonia','france','greece'].forEach(c=>JSON.parse(require('fs').readFileSync('reports/'+c+'_report.json','utf8'))); console.log('ok');"


------
https://chatgpt.com/codex/tasks/task_e_68e315b05f48832193be0c54c9664845