### PR TITLE
Refresh migration reports for Albania, Australia, Belgium, China, and Cuba

### DIFF
--- a/reports/albania_report.json
+++ b/reports/albania_report.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "iso": "AL",
   "values": [
     {
@@ -238,12 +239,12 @@
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "Albanian is dominant; younger urban residents speak English, but bureaucracy and schooling operate mainly in Albanian.",
+      "alignmentText": "Albanian dominates daily life; younger tech workers handle English, yet schools, healthcare, and government forms stay Albanian-only, so the family would need tutors for paperwork.",
       "alignmentValue": 5
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Parties campaign on EU integration and social reforms, yet conservative social attitudes still shape many policies.",
+      "alignmentText": "Mainstream parties court EU accession with anti-corruption planks, but day-to-day policy still bows to conservative social norms, leaving progressive families pushing from the margins.",
       "alignmentValue": 4
     },
     {
@@ -263,7 +264,7 @@
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Same-sex relationships are legal and Pride occurs in Tirana, but social stigma and few queer spaces limit openness.",
+      "alignmentText": "Same-sex relationships are legal and Pride marches in Tirana, yet stigma, limited venues, and weak hate-crime enforcement mean a poly/LGBTQ+ family still navigates cautiously.",
       "alignmentValue": 3
     },
     {
@@ -328,8 +329,8 @@
     },
     {
       "key": "Political System",
-      "alignmentText": "A parliamentary republic with competitive elections and ongoing judicial reforms.",
-      "alignmentValue": 6
+      "alignmentText": "Parliamentary elections are competitive, yet executive power and patronage networks still sway courts and media, so reforms toward EU standards require constant civic watchdogging.",
+      "alignmentValue": 5
     },
     {
       "key": "Religion in Politics",
@@ -348,7 +349,7 @@
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Institutions are improving but still vulnerable to ruling-party pressure and media capture.",
+      "alignmentText": "Judicial vetting and EU monitoring help, yet ruling-party influence over broadcasters and courts still chips away at checks, so a progressive family should track watchdog alerts.",
       "alignmentValue": 5
     },
     {
@@ -403,17 +404,17 @@
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal coverage provides basic care, but public hospitals suffer from wait times and outdated equipment—many locals pay for private clinics.",
+      "alignmentText": "Universal coverage exists, yet public hospitals struggle with equipment and wait times, so middle-class families routinely budget for private clinics to ensure timely pediatric care.",
       "alignmentValue": 4
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Foreign residents must carry private insurance for reliable service; English-speaking specialists cluster in Tirana.",
+      "alignmentText": "Residence permits require private insurance, and dependable English-speaking specialists cluster in Tirana clinics, making routine care pricier but manageable for remote earners.",
       "alignmentValue": 3
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Limited public preschool hours mean parents juggle schedules or hire family caregivers.",
+      "alignmentText": "Municipal kindergartens run short days and spots are scarce, so dual-career parents often rely on grandparents or private sitters to cover work hours.",
       "alignmentValue": 3
     },
     {
@@ -423,12 +424,12 @@
     },
     {
       "key": "Education",
-      "alignmentText": "Test scores lag OECD averages; reforms are underway, yet teacher training and facilities remain uneven.",
+      "alignmentText": "PISA scores trail the EU and public schools still grapple with outdated materials, so we would likely pair Albanian schooling with tutoring or private options to hit the family’s high standards.",
       "alignmentValue": 4
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "City buses are cheap but crowded, national rail is limited, and intercity travel relies on furgon minibuses.",
+      "alignmentText": "Tirana’s buses are inexpensive yet packed and slow, intercity rail is skeletal, and most weekend trips depend on informal furgon minibuses or a family car.",
       "alignmentValue": 4
     },
     {
@@ -468,7 +469,7 @@
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Residence permits cover work, self-employment, family reunification, and a 1-year digital nomad 'Unique Permit' launched in 2022.",
+      "alignmentText": "Residence permits cover work, self-employment, and family reunification, plus the 1-year Unique Permit for remote earners that extends to five years with proof of income.",
       "alignmentValue": 5
     },
     {
@@ -478,7 +479,7 @@
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Most permits start at 1 year, renewable up to 5 years before permanent residence; digital nomads can extend to 5 years with income proof.",
+      "alignmentText": "Most permits issue in one-year increments, renewable to five before permanent residence; the Unique Permit follows the same path if income documentation stays current.",
       "alignmentValue": 5
     },
     {
@@ -498,7 +499,7 @@
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Annual renewals require landlord registrations, bank statements, and criminal record checks; missing paperwork can reset the residency clock.",
+      "alignmentText": "Renewals demand notarized leases, Albanian-language bank statements, and clean FBI reports; missing a document can reset the residency clock, so keeping a fixer on retainer is wise.",
       "alignmentValue": 4
     },
     {
@@ -533,7 +534,7 @@
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "Fiber broadband is available in central Tirana with 50–200 Mbps plans, but power outages and rural infrastructure gaps persist.",
+      "alignmentText": "Central Tirana offers 100–200 Mbps fiber and decent latency for game dev, yet periodic power flickers and limited redundancy outside the capital demand backup gear for remote work.",
       "alignmentValue": 5
     }
   ]

--- a/reports/australia_report.json
+++ b/reports/australia_report.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "iso": "AU",
   "values": [
     {
@@ -18,7 +19,7 @@
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Stable institutions and a free press keep risk low.",
+      "alignmentText": "Independent courts, a muscular press, and compulsory voting keep power rotations healthy, though activists still monitor surveillance laws and media concentration.",
       "alignmentValue": 8
     },
     {
@@ -38,7 +39,7 @@
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Means-tested subsidies help offset childcare expenses.",
+      "alignmentText": "The Child Care Subsidy covers up to 90% for middle-income families, yet capped hours and long waitlists mean we still budget for significant out-of-pocket costs.",
       "alignmentValue": 6
     },
     {
@@ -48,12 +49,12 @@
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "Subsidies help reduce costs for eligible families.",
+      "alignmentText": "Citizens tap the Child Care Subsidy and paid parental leave, but urban demand still pushes fees to AUD 120–180 per day.",
       "alignmentValue": 6
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Temporary residents receive limited subsidies.",
+      "alignmentText": "Temporary skilled visas can access limited subsidies after meeting residency tests; others pay full private rates until permanent residency.",
       "alignmentValue": 4
     },
     {
@@ -68,12 +69,12 @@
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Strict adherence to visa conditions required; tax residency rules apply.",
+      "alignmentText": "Bridging visa lapses and work-hour limits are enforced electronically, and once you pass 183 days the ATO expects full tax filings on worldwide income.",
       "alignmentValue": 6
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "High costs in Sydney and Melbourne are offset by wages.",
+      "alignmentText": "Sydney and Melbourne rents top AUD 700–900 per week for family homes, so remote USD income must stretch to cover premium housing and groceries.",
       "alignmentValue": 4
     },
     {
@@ -93,7 +94,7 @@
     },
     {
       "key": "Education",
-      "alignmentText": "Strong education system with high literacy rates.",
+      "alignmentText": "Public schools score above OECD averages in literacy and science, with selective and international options for advanced learners, though outcomes vary between states.",
       "alignmentValue": 8
     },
     {
@@ -183,17 +184,17 @@
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Rising heat and bushfire exposure pose moderate climate risks.",
+      "alignmentText": "Climate models point to hotter summers, megafires, and coastal flooding, so long-term planning requires evacuation kits and careful city selection.",
       "alignmentValue": 4
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Medicare provides universal coverage with minimal cost.",
+      "alignmentText": "Medicare covers GP visits and hospital care with low out-of-pocket costs, and families often add private cover to skip waitlists for elective procedures.",
       "alignmentValue": 8
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Some visas require private insurance; limited public coverage.",
+      "alignmentText": "Many skilled visas require private insurance until permanent residency; US citizens rely on Overseas Visitor Cover because no reciprocal Medicare agreement exists.",
       "alignmentValue": 5
     },
     {
@@ -233,7 +234,7 @@
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "English is the primary language nationwide.",
+      "alignmentText": "English dominates government, schooling, and business, so the family can operate immediately while exploring community languages on the side.",
       "alignmentValue": 10
     },
     {
@@ -258,7 +259,7 @@
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "Advanced infrastructure and reliable broadband in urban areas.",
+      "alignmentText": "Capital cities boast reliable power, modern healthcare, and 250+ Mbps NBN fiber plans, though regional coverage still depends on slower fixed wireless.",
       "alignmentValue": 8
     },
     {
@@ -268,7 +269,7 @@
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Bushfires, floods, and cyclones occur, especially in certain regions.",
+      "alignmentText": "Black Summer bushfires, Brisbane floods, and northern cyclones highlight the need for disaster insurance and evacuation plans depending on region.",
       "alignmentValue": 4
     },
     {
@@ -343,7 +344,7 @@
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Political culture leans center-left with social-liberal policies.",
+      "alignmentText": "Urban states back climate policy, marriage equality, and Indigenous reconciliation, while resource-heavy regions temper how fast reforms move.",
       "alignmentValue": 7
     },
     {
@@ -358,7 +359,7 @@
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Comprehensive in big cities but sparse in rural areas.",
+      "alignmentText": "Sydney and Melbourne run dense train, tram, and bus networks with contactless payment, yet coverage thins quickly in outer suburbs, so a car remains handy for weekend adventures.",
       "alignmentValue": 6
     },
     {
@@ -368,12 +369,12 @@
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Hybrid work is gaining ground though office presence is still common.",
+      "alignmentText": "Tech firms embrace hybrid schedules and coworking hubs abound, but East Coast time zones are 16–18 hours ahead of US clients, so late calls persist.",
       "alignmentValue": 6
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Temporary visas can lead to permanent residency after several years.",
+      "alignmentText": "Temporary Skill Shortage visas run up to four years and can transition to permanent residency after employer nomination or points-tested pathways.",
       "alignmentValue": 6
     },
     {
@@ -503,12 +504,12 @@
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Points-based skilled visas and entrepreneur routes exist but are competitive.",
+      "alignmentText": "Points-tested skilled visas favor younger applicants with degrees and high English scores; business and global talent visas exist but require significant assets or endorsements.",
       "alignmentValue": 6
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Generally positive attitude toward Americans.",
+      "alignmentText": "Australians are accustomed to US expats in tech hubs, though visa gatekeeping means enthusiasm rises once paperwork proves you’re committed.",
       "alignmentValue": 7
     },
     {
@@ -528,7 +529,7 @@
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Cultural emphasis on leisure and outdoor time promotes balance.",
+      "alignmentText": "A 38-hour workweek, enforced leave, and colleagues who unplug on weekends support Sarah’s quest for calmer schedules, though big-city commutes can still stretch days.",
       "alignmentValue": 8
     },
     {

--- a/reports/belgium_report.json
+++ b/reports/belgium_report.json
@@ -1,135 +1,136 @@
 {
+  "version": 2,
   "iso": "BE",
   "values": [
     {
       "key": ".NET Work Prospects",
       "alignmentText": "Strong in enterprise, finance, and government IT (Brussels/Antwerp); multilingual teams common.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Air Quality",
       "alignmentText": "Urban NO2/PM in cores (ring roads); overall improving; stricter low-emission zones in cities.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Atheism",
       "alignmentText": "Secular society with residual cultural Catholicism.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Low; strong institutions and EU frameworks.",
-      "alignmentValue": 9.0
+      "alignmentText": "Consensus coalitions, independent courts, and EU oversight keep illiberal drift minimal despite occasional nationalist rhetoric.",
+      "alignmentValue": 9
     },
     {
       "key": "Banking & Payments",
       "alignmentText": "SEPA/IBAN; contactless and instant payments; easy account opening with address ID.",
-      "alignmentValue": 9.0
+      "alignmentValue": 9
     },
     {
       "key": "Beach Life",
       "alignmentText": "North Sea coast with dunes/boardwalks; water cool; good walking/cycling; summer bathing short window.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Boardgaming & Tabletop",
       "alignmentText": "Active café and club scenes in Brussels/Antwerp/Ghent.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Allowances and subsidized care depend on region; tax credits; capped fees in some schemes.",
-      "alignmentValue": 8.0
+      "alignmentText": "Regional family allowances, subsidized crèches, and income-based fees create robust support, though spots fill quickly so waitlists should be tackled before arrival.",
+      "alignmentValue": 8
     },
     {
       "key": "Child-Friendliness of Cities",
       "alignmentText": "Playgrounds, libraries, leisure centres; compact cities ease access.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "Regional family allowances; subsidized creches; parental leave; tax benefits depending on region.",
-      "alignmentValue": 8.0
+      "alignmentText": "Citizens receive monthly allowances, generous parental leave, and subsidized crèche places capped around €30 per day.",
+      "alignmentValue": 8
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Residents with social security contributions access many supports; eligibility varies by status/region.",
-      "alignmentValue": 6.0
+      "alignmentText": "Non-EU residents enrolled in social security can access subsidies after registration, but timing varies by region and status.",
+      "alignmentValue": 6
     },
     {
       "key": "Common Hobbies",
       "alignmentText": "Cycling, football, hiking, festivals; cafés and board games popular.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Community Vibes",
       "alignmentText": "Friendly locals; strong expat scene in Brussels; language communities active.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Commune registration, health insurance, tax residence; language integration requirements.",
-      "alignmentValue": 7.0
+      "alignmentText": "You must register within eight days, enroll in a mutualité, file annual Belgian taxes on worldwide income, and track integration courses if the region mandates them.",
+      "alignmentValue": 7
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Moderate-to-high in Brussels; reasonable in secondary cities; transport/energy costs meaningful.",
-      "alignmentValue": 5.0
+      "alignmentText": "Brussels three-bedroom rents hover €1,600–1,900 and energy tariffs are steep, but Ghent or Leuven ease costs without sacrificing amenities.",
+      "alignmentValue": 5
     },
     {
       "key": "Dual Citizenship Allowed",
       "alignmentText": "Yes—Belgium permits dual nationality.",
-      "alignmentValue": 9.0
+      "alignmentValue": 9
     },
     {
       "key": "Economic Health",
       "alignmentText": "Advanced EU economy; strong services/logistics; regional differences.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Economic System",
       "alignmentText": "Social market economy with robust safety nets.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Education",
-      "alignmentText": "Quality public education; multilingual options; regional curricula.",
-      "alignmentValue": 8.0
+      "alignmentText": "Flemish schools score near the top of Europe and bilingual tracks abound, but French-speaking systems show more inequality, so choosing the right commune matters.",
+      "alignmentValue": 8
     },
     {
       "key": "Employer Visa Sponsorship",
       "alignmentText": "Available via Single Permit/EU Blue Card; larger firms and consultancies sponsor.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Environment",
       "alignmentText": "Diverse landscapes; strong environmental regulation; generally good environmental quality.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Expected Tax Rate (Our Family)",
       "alignmentText": "Mid-to-high effective rates depending on income/region; benefits offset for families.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Fall Temperature Range (C/F)",
       "alignmentText": "Mild: ~10-18 C (50-64 F); increased rain/wind; pleasant shoulder season.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Family Life",
       "alignmentText": "Parks, cycling culture, family-friendly amenities; museums and community facilities.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Family Members",
       "alignmentText": "Spouse/partner/dependents eligible under reunification rules; documentation required.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Family Policy (Citizens)",
       "alignmentText": "Parental leave allowances, family allowances, subsidized childcare; varies by region/employer.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Family Policy (Common Family)",
@@ -139,402 +140,402 @@
     {
       "key": "Family Policy (Visa Holders)",
       "alignmentText": "Residents with social security contributions access many supports; exact eligibility depends on status/region.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Fashion Trends (Female)",
       "alignmentText": "Practical chic; minimalist to casual; layered for weather.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Fashion Trends (Male)",
       "alignmentText": "Smart-casual with cycling/outdoor practicality; layers and quality footwear.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Femininity Norms",
       "alignmentText": "Modern European fashion; weather-aware layering; practical chic.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Game Dev Work Prospects",
       "alignmentText": "Growing indie and serious games; fewer AAA; Brussels/Flanders hubs.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Gender Fluidity",
       "alignmentText": "Legal recognition; social acceptance rising in cities.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Gender Rights",
       "alignmentText": "Strong legal protections and EU alignment.",
-      "alignmentValue": 9.0
+      "alignmentValue": 9
     },
     {
       "key": "Gender Roles",
       "alignmentText": "Increasingly egalitarian; high female workforce participation; policy supports.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "General Considerations for Visa Holders",
       "alignmentText": "Commune registration, health insurance, bank/lease proofs; driver licence exchange; language admin in Dutch/French.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Global Warming Risk",
       "alignmentText": "Increasing heatwaves and rainfall extremes; localized river/coastal flood risk; mitigation ongoing.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "High-quality healthcare via compulsory insurance with mutualités/ziekenfondsen; modest co-pays.",
-      "alignmentValue": 8.0
+      "alignmentText": "Compulsory mutualité insurance reimburses 60–75% of costs and pediatric specialists are easy to access, with modest co-pays.",
+      "alignmentValue": 8
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Residents must enroll in health insurance; coverage comparable; initial private cover may be needed.",
-      "alignmentValue": 7.0
+      "alignmentText": "Once registered, visa holders join the same mutualité system; newcomers often carry private insurance for the first months until residence paperwork clears.",
+      "alignmentValue": 7
     },
     {
       "key": "Higher Education Access (Citizens)",
       "alignmentText": "Domestic tuition at public universities; grants/loans; strong networks in Leuven/Brussels/Ghent/Liege.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Higher Education Access (Visa Holders)",
       "alignmentText": "International tuition for most temporary visas; scholarships limited; improves with long-term residence/EU status.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Housing Situation",
       "alignmentText": "Moderate prices outside Brussels; Brussels rents higher; energy standards tightening.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "How Taxes Are Handled",
       "alignmentText": "PAYE for employees; annual returns; progressive tax with social contributions; complex but well-documented.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "K-12 Education Access (Citizens)",
       "alignmentText": "Free public K-12; zoning applies; quality varies by network/region; strong language education.",
-      "alignmentValue": 9.0
+      "alignmentValue": 9
     },
     {
       "key": "K-12 Education Access (Visa Holders)",
       "alignmentText": "Resident children generally enroll in public schools; language support available; documentation required.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "English widely used in Brussels/international settings; Dutch/French dominant elsewhere.",
-      "alignmentValue": 7.0
+      "alignmentText": "English works well in Brussels’ EU bubble, but schools and paperwork run in Dutch or French, so the family should plan language study for long-term integration.",
+      "alignmentValue": 7
     },
     {
       "key": "LGBTQ+ Attitudes",
       "alignmentText": "Legal equality; strong acceptance in cities; pride events.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Marxism (Societal Attitudes)",
       "alignmentText": "Limited mainstream; present in academic/activist circles.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Masculinity Norms",
       "alignmentText": "Smart-casual; focus on practicality and cycling/outdoor wear.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Meetups & Communities",
       "alignmentText": "Strong meetup culture, especially in Brussels tech/NGO spheres.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Minimum Wage",
       "alignmentText": "Statutory minimum wage with sectoral agreements; uprated periodically.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Modernity & Infrastructure",
       "alignmentText": "High modernity: broadband/5G, cycling networks, digital gov; occasional regional gaps.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Natural Beauty",
       "alignmentText": "Ardennes forests/hills, Flemish countryside, coastal dunes; charming historic towns.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Natural Disasters",
       "alignmentText": "Low seismic risk; main hazards are floods, windstorms, and heatwaves.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Nature Access",
       "alignmentText": "Dense trail/canal networks; short travel to parks/forests/coast from major cities.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Nightlife & Music",
       "alignmentText": "Vibrant in Brussels/Antwerp/Ghent; festivals year-round; smaller towns quieter.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Nightlife Culture",
       "alignmentText": "Active in Brussels/Antwerp/Ghent; cafes/bars/clubs; smaller towns quieter; generally safe.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Notable Game Development Communities",
       "alignmentText": "Local meetups/jams in Brussels/Antwerp/Ghent; access to nearby EU events.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Notable Game Studios",
       "alignmentText": "Larian (BE-origin), Happy Volcano; proximity to EU hubs.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Opportunities for Video Game Startup",
       "alignmentText": "Regional funds (VAF/Gamefonds, screen.brussels), EU programs; good publisher access across EU.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Pace of Life",
       "alignmentText": "Moderate; Brussels faster, regional cities/towns calmer.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Parenting Expectations",
       "alignmentText": "Balanced; extracurriculars common; emphasis on languages/sports.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Path to Citizenship",
       "alignmentText": "Typically 5 years of legal residence plus integration and language proof.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Perceived Corruption",
       "alignmentText": "Low by international standards; strong oversight.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Political System",
       "alignmentText": "Federal parliamentary monarchy with regional governments; complex but stable.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Polyamory",
       "alignmentText": "Social acceptance limited; discretion advisable outside progressive circles.",
-      "alignmentValue": 4.0
+      "alignmentValue": 4
     },
     {
       "key": "Pre-K / Early Childcare Landscape",
       "alignmentText": "Creches (0-3) subsidized; maternelle widely available from ~2.5; capacity varies by commune.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Private Education",
       "alignmentText": "Independent/international schools in Brussels/Antwerp; higher fees; selective admissions.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Progressivism",
       "alignmentText": "High on social policies; pragmatic politics; coalition culture.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Propaganda Messaging",
       "alignmentText": "Pluralistic media; state and private broadcasters; partisan framing exists.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Propaganda Prevalence",
       "alignmentText": "Moderate; counterbalanced by public and independent outlets.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Dense rail and bus networks; cycling infrastructure strong; good intercity links.",
-      "alignmentValue": 8.0
+      "alignmentText": "STIB/De Lijn/SNCB networks weave trams, buses, and trains across cities with real-time apps and easy bike connections, keeping car-free living practical.",
+      "alignmentValue": 8
     },
     {
       "key": "Religion in Politics",
       "alignmentText": "Limited direct influence; secular governance predominant.",
-      "alignmentValue": 4.0
+      "alignmentValue": 4
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Hybrid normalized; cross-border EU collaboration common.",
-      "alignmentValue": 7.0
+      "alignmentText": "EU institutions normalized remote collaboration, coworking hubs span Brussels and Ghent, and time zones align well with both US East Coast evenings and EU partners.",
+      "alignmentValue": 7
     },
     {
       "key": "Residency Types & Durations",
       "alignmentText": "A-card residence permits; renewals leading to long-term residence (EU LTR).",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Retirement (Citizens)",
       "alignmentText": "Pension via social insurance; adequacy depends on contributions/housing; private pillars helpful.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Retirement (Visa Holders)",
       "alignmentText": "Eligibility/portability tied to contributions/status; bilateral treaties may help.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Ruby Work Prospects",
       "alignmentText": "Smaller market; present in startups/scale-ups; fewer roles than Java/.NET.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Safety & Crime",
       "alignmentText": "Generally safe; petty theft in tourist cores; low violent crime.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Schooling Options",
       "alignmentText": "Free public schools (secular and faith streams); Dutch/French systems; some immersion/bilingual programs.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Seasonal Beach Water Temp",
       "alignmentText": "~7-19 C (45-66 F); short late-summer comfort; wetsuits common for longer season.",
-      "alignmentValue": 3.0
+      "alignmentValue": 3
     },
     {
       "key": "Seasonal Weather",
       "alignmentText": "Temperate maritime: cool summers, mild winters, frequent rain/overcast; regional differences Flanders/Wallonia/Ardennes.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Sex (Attitudes)",
       "alignmentText": "Liberal urban norms; comprehensive sex ed; media openness.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Social Policies",
       "alignmentText": "Robust social security, healthcare, and family benefits systems.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Spring Temperature Range (C/F)",
       "alignmentText": "Typical daytime ~9-16 C (48-61 F); frequent showers; more sun toward late spring.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Stability",
       "alignmentText": "Stable but frequent coalition negotiations; daily life largely unaffected.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "State Ideology",
       "alignmentText": "Social market economy; centrist coalitions.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "State of Capitalism",
       "alignmentText": "Advanced mixed capitalist economy.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Summer Temperature Range (C/F)",
       "alignmentText": "Typical ~17-24 C (63-75 F); episodic heatwaves >30 C; humidity moderate; cooler near coast.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Timelines & Costs",
       "alignmentText": "Processing usually months; fees moderate; commune-level variation.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Trust in Government",
       "alignmentText": "Moderate; coalition dynamics can lower trust during stalemates.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Type of Corruption",
       "alignmentText": "Low systemic corruption; occasional procurement/local issues.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Typical Software Salaries",
       "alignmentText": "Lower than NL/DE but competitive locally; benefits often strong; costs moderate in secondary cities.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
       "alignmentText": "Markets, parks, cycling, festivals; retail hours vary Sundays; family/cafe culture.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
       "alignmentText": "Schools often ~08:30-15:30; offices ~08:30-17:30; after-school care varies by commune; biking/transit common.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Vacation Days (Minimum)",
       "alignmentText": "Legal minimum ~20 days for full-time plus public holidays.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Vacation Days (Typical)",
       "alignmentText": "Often 25-30+ including seniority/sectoral additions.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "View of Neighboring Countries",
       "alignmentText": "Positive/pragmatic engagement with NL/FR/DE/LU/UK.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "View of self",
       "alignmentText": "Pragmatic, multilingual, community-focused, European.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "View of Them by Neighboring Countries",
       "alignmentText": "Seen as cooperative EU partner; Brussels as administrative hub.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Single Permit (work residence), EU Blue Card, researcher, family reunification.",
-      "alignmentValue": 6.0
+      "alignmentText": "Single Permit and EU Blue Card routes hinge on employer sponsorship and salary thresholds; self-employed visas demand business plans reviewed by regional authorities.",
+      "alignmentValue": 6
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Positive in international communities; English accepted in Brussels; integration needed elsewhere.",
-      "alignmentValue": 7.0
+      "alignmentText": "Brussels’ expat bubble is warm to US families, while Flemish communes expect quick Dutch acquisition before you feel fully included.",
+      "alignmentValue": 7
     },
     {
       "key": "What Is Intriguing",
       "alignmentText": "Multilingual culture, EU hub (Brussels), great cycling, central EU location for travel.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Winter Temperature Range (C/F)",
       "alignmentText": "Cool: ~1-7 C (34-45 F); damp chill; frost/ice possible; snow mainly Ardennes.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Work Week Hours",
       "alignmentText": "Typically around 38 hours; flex/time-credit schemes exist.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Good by EU norms; hybrid options; generous leave vs US.",
-      "alignmentValue": 8.0
+      "alignmentText": "A 38-hour cap, time-credit schemes, and five-plus weeks of leave help Sarah maintain calmer rhythms, though bilingual offices can stretch meetings across time zones.",
+      "alignmentValue": 8
     },
     {
       "key": "Workers' Rights",
       "alignmentText": "Strong protections, collective bargaining, workplace safety; unions influential.",
-      "alignmentValue": 8.0
+      "alignmentValue": 8
     }
   ]
 }

--- a/reports/china_report.json
+++ b/reports/china_report.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "iso": "CN",
   "values": [
     {
@@ -8,7 +9,7 @@
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Major cities often suffer severe pollution despite improvements.",
+      "alignmentText": "Tier 1 cities still see PM2.5 spikes well above WHO limits—sandstorms in Beijing and winter smog in the north make outdoor play risky without air purifiers.",
       "alignmentValue": 2
     },
     {
@@ -18,7 +19,7 @@
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Very high; civil liberties tightly controlled.",
+      "alignmentText": "The one-party system deploys surveillance, censorship, and security laws that leave no space for dissent, representing the lowest possible score for democratic resilience.",
       "alignmentValue": 1
     },
     {
@@ -38,7 +39,7 @@
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Urban childcare expensive and scarce.",
+      "alignmentText": "Public nurseries are limited, private centers are costly, and most families rely on grandparents or nannies to cover long work hours.",
       "alignmentValue": 3
     },
     {
@@ -48,13 +49,13 @@
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "Pronatalist incentives expanding (cash/fee subsidies) vary by city/province; maternity leave typically 98+ days; evolving policies.",
-      "alignmentValue": 5.0
+      "alignmentText": "Select cities now offer monthly stipends and extended maternity leave, but benefits remain patchy and tied to local hukou registration.",
+      "alignmentValue": 5
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Access to subsidies limited; eligibility varies by locality; residence permits and documentation required; often excluded.",
-      "alignmentValue": 3.0
+      "alignmentText": "Foreign residents rarely qualify for subsidies, leaving private care or ayi support as the primary option.",
+      "alignmentValue": 3
     },
     {
       "key": "Common Hobbies",
@@ -68,7 +69,7 @@
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Strict monitoring with penalties for violations.",
+      "alignmentText": "Police registrations, exit permits for kids, and Great Firewall compliance are enforced rigorously; policy shifts can void visas with little notice.",
       "alignmentValue": 2
     },
     {
@@ -79,7 +80,7 @@
     {
       "key": "Dual Citizenship Allowed",
       "alignmentText": "No—dual nationality is not recognized; naturalization typically requires renouncing prior citizenship.",
-      "alignmentValue": 1.0
+      "alignmentValue": 1
     },
     {
       "key": "Economic Health",
@@ -93,12 +94,12 @@
     },
     {
       "key": "Education",
-      "alignmentText": "Top-tier academics but heavy rote learning and pressure.",
-      "alignmentValue": 5
+      "alignmentText": "Flagship schools deliver elite math and science results, yet gaokao pressure, censorship in curricula, and limited progressive pedagogy clash with the family’s priorities.",
+      "alignmentValue": 4
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Strict quotas and paperwork make foreign hiring difficult.",
+      "alignmentText": "Class A/B work permits require degree, experience, and clean police checks; tech firms sponsor sparingly given quota scrutiny.",
       "alignmentValue": 2
     },
     {
@@ -114,7 +115,7 @@
     {
       "key": "Fall Temperature Range (C/F)",
       "alignmentText": "Generally pleasant in many regions; Beijing ~10–20 C; Shanghai ~18–26 C; drier skies; typhoon season lingers along SE coast.",
-      "alignmentValue": 7.0
+      "alignmentValue": 7
     },
     {
       "key": "Family Life",
@@ -129,7 +130,7 @@
     {
       "key": "Family Policy (Citizens)",
       "alignmentText": "Maternity/paternity leave expanding; local cash/childcare incentives; housing/tax perks in some cities; coverage uneven.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Family Policy (Common Family)",
@@ -139,17 +140,17 @@
     {
       "key": "Family Policy (Visa Holders)",
       "alignmentText": "Benefits generally tied to hukou/social insurance; foreign residents often ineligible for local family subsidies.",
-      "alignmentValue": 3.0
+      "alignmentValue": 3
     },
     {
       "key": "Fashion Trends (Female)",
       "alignmentText": "Contemporary street style to minimalist chic; dresses/skirts with layering; strong beauty/skin‑care culture.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Fashion Trends (Male)",
       "alignmentText": "Urban streetwear and smart‑casual tailoring; sneakers/athleisure common; techwear influences in big cities.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Femininity Norms",
@@ -179,7 +180,7 @@
     {
       "key": "General Considerations for Visa Holders",
       "alignmentText": "Residence/work permits tied to employer or category; local registration needed for banking/housing; healthcare insurance; internet controls (VPN use).",
-      "alignmentValue": 4.0
+      "alignmentValue": 4
     },
     {
       "key": "Global Warming Risk",
@@ -199,12 +200,12 @@
     {
       "key": "Higher Education Access (Citizens)",
       "alignmentText": "Extensive public HE; competitive gaokao; tuition moderate; scholarships and aid exist.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Higher Education Access (Visa Holders)",
       "alignmentText": "International student options widely available; tuition higher; scholarships exist; residency status may improve options.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Housing Situation",
@@ -228,12 +229,12 @@
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "Mandarin necessary; limited English outside expat zones.",
+      "alignmentText": "Mandarin is essential for schooling, healthcare, and paperwork; English support exists only in expat enclaves of Shanghai and Shenzhen.",
       "alignmentValue": 2
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Increasing awareness but no legal protections.",
+      "alignmentText": "Pride events are regularly shut down and censorship targets queer media, so openly poly/LGBTQ+ families face persistent state pressure despite decriminalization.",
       "alignmentValue": 2
     },
     {
@@ -284,7 +285,7 @@
     {
       "key": "Nightlife Culture",
       "alignmentText": "Vibrant in tier‑1 cities (bars, clubs, live music); quieter elsewhere; closing times and enforcement vary by locality.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Notable Game Development Communities",
@@ -334,16 +335,16 @@
     {
       "key": "Pre-K / Early Childcare Landscape",
       "alignmentText": "Public kindergartens and private centers; supply/cost vary by city tier; expanding 0–3 services; waitlists in core districts.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Private Education",
       "alignmentText": "International/private schools in major cities (IB/AP/A-Levels); high fees and limited seats; admissions selective.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Progressivism",
-      "alignmentText": "State conservatism limits social freedoms.",
+      "alignmentText": "Party ideology prioritizes social harmony over individual rights, curbing feminist, queer, and labor activism.",
       "alignmentValue": 2
     },
     {
@@ -358,7 +359,7 @@
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Extensive high-speed rail and metro systems.",
+      "alignmentText": "High-speed rail and dense metro networks make city-to-city travel seamless, though real-name ticketing and health-code checks add surveillance overhead.",
       "alignmentValue": 9
     },
     {
@@ -368,18 +369,18 @@
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Office-centric; remote work less common.",
-      "alignmentValue": 3
+      "alignmentText": "996-style expectations keep teams in-office; only multinational branches support sustained remote schedules.",
+      "alignmentValue": 2
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Temporary permits; permanent residency difficult.",
+      "alignmentText": "Z visas convert to 1-year residence permits renewed annually; green cards are rare and require high investment or state sponsorship.",
       "alignmentValue": 2
     },
     {
       "key": "Retirement (Citizens)",
       "alignmentText": "Urban employee basic pension plus enterprise/individual pillars; adequacy varies by region; reforms underway.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Retirement (Immigrants)",
@@ -389,7 +390,7 @@
     {
       "key": "Retirement (Visa Holders)",
       "alignmentText": "Participation depends on city/employer; some contributions refundable on exit; portability limited.",
-      "alignmentValue": 4.0
+      "alignmentValue": 4
     },
     {
       "key": "Ruby Work Prospects",
@@ -429,7 +430,7 @@
     {
       "key": "Spring Temperature Range (C/F)",
       "alignmentText": "Highly regional; e.g., Beijing 5–20 C (41–68 F), Shanghai 10–22 C (50–72 F); drier north, wetter south; occasional dust in north.",
-      "alignmentValue": 5.0
+      "alignmentValue": 5
     },
     {
       "key": "Stability",
@@ -449,7 +450,7 @@
     {
       "key": "Summer Temperature Range (C/F)",
       "alignmentText": "Many cities are hot/humid (e.g., Shanghai 26–35 C / 79–95 F); north can be hot/dry; heat index high in southeast; nights warm.",
-      "alignmentValue": 3.0
+      "alignmentValue": 3
     },
     {
       "key": "Timelines & Costs",
@@ -474,12 +475,12 @@
     {
       "key": "Typical Weekend Schedule (Family of Four)",
       "alignmentText": "Weekends: parks, malls, dining, family visits; extracurriculars common; some sectors work Saturdays; long retail hours in large cities.",
-      "alignmentValue": 6.0
+      "alignmentValue": 6
     },
     {
       "key": "Typical Workday Schedule (Family of Four)",
       "alignmentText": "Primary ~08:00–15:30; secondary often longer with evening study. Many offices 09:00–18:00; some sectors have long-hours norms (e.g., 996).",
-      "alignmentValue": 4.0
+      "alignmentValue": 4
     },
     {
       "key": "Vacation Days (Minimum)",
@@ -508,13 +509,13 @@
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Work visas available but strict quotas and employer ties.",
+      "alignmentText": "Z visas demand employer sponsorship, background checks, and health exams; entrepreneur or talent visas target high-investment applicants and are rarely approved.",
       "alignmentValue": 2
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Political tensions create mixed reception.",
-      "alignmentValue": 3
+      "alignmentText": "Hospitality at the neighborhood level coexists with rising geopolitical suspicion; regular visa renewals face tighter scrutiny for US citizens.",
+      "alignmentValue": 2
     },
     {
       "key": "What Is Intriguing",
@@ -524,7 +525,7 @@
     {
       "key": "Winter Temperature Range (C/F)",
       "alignmentText": "North: cold/dry with central heating (e.g., Beijing −5–5 C); South: cool/damp (5–12 C) often without central heating; snow varies.",
-      "alignmentValue": 4.0
+      "alignmentValue": 4
     },
     {
       "key": "Work Week Hours",

--- a/reports/cuba_report.json
+++ b/reports/cuba_report.json
@@ -1,14 +1,15 @@
 {
+  "version": 2,
   "iso": "CU",
   "values": [
     {
       "key": "Environment",
-      "alignmentText": "Rich biodiversity and preserved natural areas; urban infrastructure can be aged.",
+      "alignmentText": "UNESCO biosphere reserves and reefs are pristine, but aging city infrastructure and fuel shortages create periodic pollution spikes in Havana.",
       "alignmentValue": 6
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Caribbean location faces sea-level rise and stronger hurricanes.",
+      "alignmentText": "Sea-level rise, stronger hurricanes, and saltwater intrusion threaten coastal housing and agriculture, demanding resilient construction and evacuation plans.",
       "alignmentValue": 3
     },
     {
@@ -18,8 +19,8 @@
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Generally decent outside traffic corridors; limited heavy industry.",
-      "alignmentValue": 6
+      "alignmentText": "Outside Havana the air is clean, but aging diesel buses and classic cars can leave city corridors hazy, so indoor air filters help sensitive family members.",
+      "alignmentValue": 5
     },
     {
       "key": "Natural Disasters",
@@ -93,28 +94,28 @@
     },
     {
       "key": "Remote-Friendly Culture",
-      "alignmentText": "Internet access improving but inconsistent; power and connectivity reliability vary.",
-      "alignmentValue": 3
+      "alignmentText": "Wi-Fi hotspots require prepaid cards, home broadband rarely exceeds 10–20 Mbps, and power cuts still interrupt remote meetings.",
+      "alignmentValue": 2
     },
     {
       "key": "Work-Life Balance",
-      "alignmentText": "Cultural emphasis on family and community, but practical constraints can add stress.",
-      "alignmentValue": 5
+      "alignmentText": "Neighbors prioritize family gatherings and music, yet ration lines and power outages consume hours that would otherwise be downtime.",
+      "alignmentValue": 4
     },
     {
       "key": "Work Week Hours",
       "alignmentText": "",
-      "alignmentValue": -1
+      "alignmentValue": 0
     },
     {
       "key": "Vacation Days (Minimum)",
       "alignmentText": "",
-      "alignmentValue": -1
+      "alignmentValue": 0
     },
     {
       "key": "Vacation Days (Typical)",
       "alignmentText": "",
-      "alignmentValue": -1
+      "alignmentValue": 0
     },
     {
       "key": "Pace of Life",
@@ -124,12 +125,12 @@
     {
       "key": "Typical Workday Schedule (Family of Four)",
       "alignmentText": "",
-      "alignmentValue": -1
+      "alignmentValue": 0
     },
     {
       "key": "Typical Weekend Schedule (Family of Four)",
       "alignmentText": "",
-      "alignmentValue": -1
+      "alignmentValue": 0
     },
     {
       "key": "Family Life",
@@ -153,8 +154,8 @@
     },
     {
       "key": "Schooling Options",
-      "alignmentText": "Public system is the default; international/private options are limited.",
-      "alignmentValue": 3
+      "alignmentText": "Outside a handful of Havana schools tied to foreign embassies, international curricula are scarce, so homeschooling or online programs would fill gaps.",
+      "alignmentValue": 2
     },
     {
       "key": "Pre-K / Early Childcare Landscape",
@@ -163,27 +164,27 @@
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "State services exist but resources can be constrained.",
+      "alignmentText": "Citizens can enroll children in círculos infantiles and receive subsidized meals, but staffing and supplies fluctuate.",
       "alignmentValue": 4
     },
     {
       "key": "Childcare Support (Visa Holders)",
-      "alignmentText": "Access unclear for non-residents; limited information.",
+      "alignmentText": "Foreign families rarely secure subsidized slots without residency; most hire private caregivers informally.",
       "alignmentValue": 2
     },
     {
       "key": "K-12 Education Access (Citizens)",
-      "alignmentText": "Universal access with strong emphasis on literacy and STEM.",
-      "alignmentValue": 7
+      "alignmentText": "Enrollment is universal with high literacy, yet classroom materials and technology lag due to shortages.",
+      "alignmentValue": 6
     },
     {
       "key": "K-12 Education Access (Visa Holders)",
-      "alignmentText": "Eligibility and language support for foreigners unclear.",
+      "alignmentText": "Foreign children may attend public schools but instruction is entirely in Spanish and supplies can be scarce, so most expats seek private tutors.",
       "alignmentValue": 2
     },
     {
       "key": "Private Education",
-      "alignmentText": "Few private/international schools; admission options limited.",
+      "alignmentText": "Only a small set of embassy-linked schools operate in Havana with high fees payable in foreign currency and long waitlists.",
       "alignmentValue": 2
     },
     {
@@ -238,12 +239,12 @@
     },
     {
       "key": "Language & English Ubiquity",
-      "alignmentText": "Spanish is essential; English less common outside tourism hubs.",
+      "alignmentText": "Spanish dominates government offices and schools; beyond resort zones we would rely on fluent Spanish to manage bureaucracy.",
       "alignmentValue": 3
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Some social services are universal, but civil liberties and pluralism are limited.",
+      "alignmentText": "Universal healthcare and education coexist with restrictions on speech and association, leaving progressive reforms tightly state-managed.",
       "alignmentValue": 3
     },
     {
@@ -263,7 +264,7 @@
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Legal changes have advanced in recent years; lived acceptance varies.",
+      "alignmentText": "Marriage equality passed in 2022 and Havana hosts Pride events, yet outside urban centers queer families still face gossip and limited legal enforcement.",
       "alignmentValue": 5
     },
     {
@@ -403,17 +404,17 @@
     },
     {
       "key": "Healthcare (Citizens)",
-      "alignmentText": "Universal coverage; outcomes constrained by shortages and infrastructure.",
-      "alignmentValue": 6
+      "alignmentText": "Preventive care and doctor density are high, yet medicine and equipment shortages require rationing or trips abroad for complex treatment.",
+      "alignmentValue": 5
     },
     {
       "key": "Healthcare (Visa Holders)",
-      "alignmentText": "Tourists access clinics; long-term foreigner pathways unclear.",
+      "alignmentText": "Foreigners rely on international clinics priced in hard currency, and evacuations are common for serious care.",
       "alignmentValue": 3
     },
     {
       "key": "Child Care Support",
-      "alignmentText": "Formal childcare exists but capacity and consistency vary.",
+      "alignmentText": "State-run daycares operate with low fees yet limited slots and occasional closures tied to shortages, so parents lean on relatives.",
       "alignmentValue": 4
     },
     {
@@ -428,7 +429,7 @@
     },
     {
       "key": "Public Transportation",
-      "alignmentText": "Buses and shared taxis operate; reliability and comfort vary.",
+      "alignmentText": "Havana’s buses and colectivos are inexpensive but irregular, so planning family outings requires patience and backup rides.",
       "alignmentValue": 4
     },
     {
@@ -444,17 +445,17 @@
     {
       "key": "Expected Tax Rate (Our Family)",
       "alignmentText": "",
-      "alignmentValue": -1
+      "alignmentValue": 0
     },
     {
       "key": "Banking & Payments",
-      "alignmentText": "Sanctions and banking restrictions complicate accounts and payments for US persons.",
-      "alignmentValue": 2
+      "alignmentText": "US cards do not work; most transactions require cash or MLC cards loaded via third-country accounts.",
+      "alignmentValue": 1
     },
     {
       "key": "Cost of Living (Optional)",
-      "alignmentText": "Local prices can be low; imported goods and tourist sectors are costly.",
-      "alignmentValue": 4
+      "alignmentText": "Staples are cheap when available, yet imported groceries, internet access, and generator fuel priced in MLC quickly consume remote income.",
+      "alignmentValue": 3
     },
     {
       "key": "Retirement (Citizens)",
@@ -464,22 +465,22 @@
     {
       "key": "Retirement (Visa Holders)",
       "alignmentText": "",
-      "alignmentValue": -1
+      "alignmentValue": 0
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Residence/work authorization for US citizens is highly constrained.",
+      "alignmentText": "Work and residence visas are tightly limited; US citizens typically only qualify for short cultural or humanitarian stays, not long-term relocation.",
       "alignmentValue": 1
     },
     {
       "key": "Welcoming of US Migrants",
-      "alignmentText": "Cultural warmth toward visitors, but policy and sanctions limit settlement.",
-      "alignmentValue": 2
+      "alignmentText": "Cubans are hospitable, yet US sanctions and state scrutiny make long-term settlement impractical for American families.",
+      "alignmentValue": 1
     },
     {
       "key": "Residency Types & Durations",
-      "alignmentText": "Foreign residency options are narrow and tightly regulated.",
-      "alignmentValue": 2
+      "alignmentText": "Temporary residence permits renew yearly and require Cuban family ties or state contracts; independent paths are essentially absent.",
+      "alignmentValue": 1
     },
     {
       "key": "Path to Citizenship",
@@ -488,17 +489,17 @@
     },
     {
       "key": "Family Members",
-      "alignmentText": "Family reunification rules for non-citizens are limited.",
-      "alignmentValue": 2
+      "alignmentText": "Foreign spouses rarely obtain derivative status unless married to Cuban citizens; dependent visas for children are not standard.",
+      "alignmentValue": 1
     },
     {
       "key": "Timelines & Costs",
-      "alignmentText": "Processes can be slow with additional hurdles due to sanctions and bureaucracy.",
-      "alignmentValue": 2
+      "alignmentText": "Permits require multiple ministry approvals and US sanctions complicate payments, so expect long waits and currency hurdles.",
+      "alignmentValue": 1
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "US persons face OFAC restrictions; ensure legal compliance on travel and income.",
+      "alignmentText": "US OFAC rules limit spending, while Cuban authorities can confiscate equipment or revoke permits if regulations shift.",
       "alignmentValue": 2
     },
     {
@@ -508,12 +509,12 @@
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Expect language needs, limited banking, and documentation checks; housing and connectivity hurdles.",
-      "alignmentValue": 3
+      "alignmentText": "Plan for cash-based living, limited access to foreign banking, and frequent police check-ins on rental addresses.",
+      "alignmentValue": 2
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Very small market; few studios or publisher connections.",
+      "alignmentText": "Only small collectives experiment with games, and export controls plus internet limits make commercial releases nearly impossible.",
       "alignmentValue": 1
     },
     {


### PR DESCRIPTION
## Summary
- Marked the Albania, Australia, Belgium, China, and Cuba dossiers as version 2 while tightening high-priority alignment values against the family profile and rating guide expectations.
- Rewrote key governance, social climate, and infrastructure narratives so the updated scores clearly explain trade-offs for a progressive, remote-working family.
- Clarified immigration, childcare, healthcare, and remote-work considerations across the refreshed destinations.

## Testing
- `python - <<'PY'
import json
for name in ['albania','australia','belgium','china','cuba']:
    path=f'reports/{name}_report.json'
    with open(path) as f:
        json.load(f)
print('ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68e3133dc7a48321a6533985e82d2c7a