### PR TITLE
Update Sweden report to version 2

### DIFF
--- a/reports/sweden_report.json
+++ b/reports/sweden_report.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "iso": "SE",
   "values": [
     {
@@ -63,8 +64,8 @@
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "No statutory minimum wage; sectoral union contracts set high floors, but newcomers must secure covered employment to benefit.",
-      "alignmentValue": 4
+      "alignmentText": "Collective agreements cover roughly 90% of workers and set wages near a living standard, so once Trey or Sarah lands a unionized contract pay keeps pace even if uncovered gigs stay precarious.",
+      "alignmentValue": 7
     },
     {
       "key": "Typical Software Salaries",
@@ -138,8 +139,8 @@
     },
     {
       "key": "Polyamory",
-      "alignmentText": "Poly relationships are legal and Sweden is sex-positive, yet social acceptance and legal recognition beyond two adults remain limited.",
-      "alignmentValue": 4
+      "alignmentText": "Urban LGBTQ+ communities normalize consensual non-monogamy and legal protections exist, though schools and agencies still default to couple-based paperwork so we may need to explain our family structure.",
+      "alignmentValue": 7
     },
     {
       "key": "Parenting Expectations",
@@ -393,8 +394,8 @@
     },
     {
       "key": "Housing Situation",
-      "alignmentText": "Strong demand and rent controls create long apartment queues and expensive condos, challenging for newcomers.",
-      "alignmentValue": 4
+      "alignmentText": "Rental queues in Stockholm run years and cooperatives demand sizable buy-ins, meaning we should budget for temporary sublets or smaller suburbs while hunting a long-term family home.",
+      "alignmentValue": 6
     },
     {
       "key": "Safety & Crime",


### PR DESCRIPTION
## Summary
- mark the Sweden country report as version 2
- refresh the minimum wage, polyamory, and housing assessments to reflect the latest rating guides and family priorities

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e31a333c6883219e9033b7b91d1bdd