### PR TITLE
Add city navigation tree with Munich report

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,9 +108,18 @@
     .country-item.selected { background: color-mix(in srgb, var(--md-color-primary) 16%, var(--md-color-surface)); border-color: var(--md-color-primary); }
     .country-item .name { font-size: 13px; }
     .country-item .right-chip { margin-left: auto; }
+    .country-group { display: flex; flex-direction: column; gap: 4px; }
+    .country-item-root { padding-left: 2px; }
+    .country-item .tree-toggle { border: none; background: transparent; color: inherit; width: 22px; height: 22px; border-radius: 4px; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; font-size: 14px; }
+    .country-item .tree-toggle:hover { background: color-mix(in srgb, var(--md-color-primary) 12%, transparent); }
+    .country-item .tree-toggle:focus-visible { outline: 2px solid var(--md-color-primary); outline-offset: 2px; }
+    .city-list { display: flex; flex-direction: column; gap: 4px; margin-left: 24px; }
+    .city-item { background: color-mix(in srgb, var(--md-color-surface) 92%, var(--md-color-background)); }
+    .city-item .name { font-size: 12px; }
     body[data-theme="dark"] .country-list { background: #0f172a; border-color: #334155; }
     body[data-theme="dark"] .country-item { background: #111827; border-color: #334155; }
     body[data-theme="dark"] .country-item.selected { background: color-mix(in srgb, var(--md-color-primary) 24%, #111827); border-color: var(--md-color-primary); }
+    body[data-theme="dark"] .city-item { background: color-mix(in srgb, #111827 92%, transparent); }
     .hero { background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 45%, #10b981 100%); color: #fff; padding: 14px 16px; border-radius: 12px; box-shadow: 0 6px 18px rgba(0,0,0,0.15); }
     .hero-full { border-radius: 0; padding: 18px 0; }
     .hero-full .hero-inner h1 { margin: 0; font-size: 24px; }

--- a/main.json
+++ b/main.json
@@ -522,7 +522,13 @@
     },
     {
       "name": "Germany",
-      "file": "reports/germany_report.json"
+      "file": "reports/germany_report.json",
+      "cities": [
+        {
+          "name": "Munich",
+          "file": "reports/germany_munich_report.json"
+        }
+      ]
     },
     {
       "name": "Canada",

--- a/reports/germany_munich_report.json
+++ b/reports/germany_munich_report.json
@@ -1,0 +1,81 @@
+{
+  "version": 1,
+  "iso": "DE",
+  "values": [
+    {
+      "key": "Air Quality",
+      "alignmentText": "Munich keeps annual PM2.5 around 12 µg/m³ thanks to low-emission zones and strong transit, though winter inversions can briefly trap Alpine wood smoke in the valley.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Hot July afternoons can touch 28 °C yet evenings cool quickly; winters hover just below freezing with regular snow that makes sledding at the Englischer Garten practical for the kids.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "The Alpine foothills shield Munich from sea-level rise and extreme heat, leaving summer thunderstorms and occasional river flooding as the main climate-change watch points.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The MVV’s S-Bahn, U-Bahn, and tram grid is dense enough that Sarah can commute without a car, while regional trains reach the Alps for weekend hikes in under an hour.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Munich’s mix of automotive HQs and thriving startups keeps senior .NET and Ruby salaries near €85k–€95k, though many employers still expect at least partial German fluency.",
+      "alignmentValue": 8
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Siemens, Allianz, and a dozen enterprise consultancies maintain .NET teams that regularly hire internationals, especially those comfortable with cloud migration projects.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "E-commerce and fintech firms along Isar Valley rely on Rails for product teams, giving Trey realistic options with English-first engineering cultures.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Since 2020 most tech employers offer two to three remote days per week, and coworking hubs like Werk1 and Mindspace cater to bilingual teams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Bavarian labor norms keep overtime rare; schools end by early afternoon but Hort programs and plentiful playgrounds make family afternoons manageable.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidized Kinderkrippen and Kindergärten cost around €150–€250 monthly once residency paperwork clears, though popular bilingual centers require early waitlist applications.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Crime rates stay low and the Altstadt is well-lit, with most incidents limited to bike theft—comforting for teens walking home after evening activities.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Culture & Values Fit",
+      "alignmentText": "The city blends engineering pragmatism with a relaxed beer-garden social life, letting the family toggle between introverted studio days and lively community meetups.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Weekly meetups at community centers plus Spielwarenmesse spillover events keep the tabletop scene vibrant and welcoming to English speakers.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Startup & Game Dev Ecosystem",
+      "alignmentText": "LMU and TU Munich feed accelerators like UnternehmerTUM, giving Trey deep mentorship networks for a small game studio.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "University Hospital Rechts der Isar anchors a strong medical network, and appointments for pediatricians are easier to secure than in Berlin.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const appState = { items: [], selected: [] };
+const appState = { countries: [], selected: [], nodesByFile: new Map() };
 
 function saveSelectedToStorage() {
   try {
@@ -7,12 +7,16 @@ function saveSelectedToStorage() {
   } catch {}
 }
 
-function loadSelectedFromStorage(items) {
+function loadSelectedFromStorage(nodesMap) {
   const saved = getStored('selectedCountries', null);
   if (!Array.isArray(saved) || saved.length === 0) return [];
-  const byFile = new Map(items.map(it => [it.file, it]));
   const result = [];
-  saved.forEach(f => { if (byFile.has(f) && result.length < 4) result.push(byFile.get(f)); });
+  saved.forEach(f => {
+    if (!nodesMap || typeof nodesMap.get !== 'function') return;
+    if (nodesMap.has(f) && result.length < 4) {
+      result.push(nodesMap.get(f));
+    }
+  });
   return result;
 }
 
@@ -24,10 +28,29 @@ async function loadMain() {
   // Initialize UI preferences and toggles
   initUiPreferences();
 
-  // Build items for custom list (sorted by name)
-  appState.items = mainData.Countries
-    .map(c => ({ name: c.name, file: c.file, iso: '' }))
-    .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+  const countries = Array.isArray(mainData.Countries) ? mainData.Countries.map(c => {
+    const country = { name: c.name, file: c.file, iso: '', type: 'country', expanded: false, cities: [] };
+    const cityList = Array.isArray(c.cities) ? c.cities : [];
+    country.cities = cityList.map(city => ({
+      name: city.name,
+      file: city.file,
+      iso: '',
+      type: 'city',
+      parentCountry: country,
+    })).sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+    if (country.cities.length > 0) country.expanded = true;
+    return country;
+  }) : [];
+
+  countries.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+  appState.countries = countries;
+  appState.nodesByFile = new Map();
+  countries.forEach(country => {
+    appState.nodesByFile.set(country.file, country);
+    (country.cities || []).forEach(city => {
+      appState.nodesByFile.set(city.file, city);
+    });
+  });
 
   // Setup sort dropdown (adds person options and reads stored preference)
   try { setupCountrySortControls(mainData, listEl, notice); } catch {}
@@ -38,26 +61,37 @@ async function loadMain() {
     if (s && s.value && s.value !== 'alpha') {
       await applyCountrySort(mainData, listEl, notice);
     } else {
-      renderCountryList(listEl, appState.items, notice, () => onSelectionChanged(mainData, notice));
+      renderCountryList(listEl, appState.countries, notice, () => onSelectionChanged(mainData, notice));
     }
   } catch {
-    renderCountryList(listEl, appState.items, notice, () => onSelectionChanged(mainData, notice));
+    renderCountryList(listEl, appState.countries, notice, () => onSelectionChanged(mainData, notice));
   }
   // Restore previously selected countries or default to first
-  const restored = loadSelectedFromStorage(appState.items);
+  const restored = loadSelectedFromStorage(appState.nodesByFile);
   if (restored.length > 0) {
     appState.selected = restored;
-  } else if (appState.items.length > 0) {
-    appState.selected = [appState.items[0]];
+  } else if (appState.countries.length > 0) {
+    appState.selected = [appState.countries[0]];
   }
   updateCountryListSelection(listEl);
   onSelectionChanged(mainData, notice);
   // Enrich with ISO in the background and refresh flags
   try {
-    await Promise.all(appState.items.map(async it => {
-      try { const data = await fetchCountry(it.file); if (data && data.iso) it.iso = String(data.iso); } catch {}
+    const allNodes = [];
+    appState.countries.forEach(country => {
+      allNodes.push(country);
+      (country.cities || []).forEach(city => allNodes.push(city));
+    });
+    await Promise.all(allNodes.map(async node => {
+      try {
+        const data = await fetchCountry(node.file);
+        if (data && data.iso && !node.iso) node.iso = String(data.iso);
+        if (!node.metrics) {
+          node.metrics = computeRoundedMetrics(data, mainData);
+        }
+      } catch {}
     }));
-    renderCountryList(listEl, appState.items, notice, () => onSelectionChanged(mainData, notice));
+    renderCountryList(listEl, appState.countries, notice, () => onSelectionChanged(mainData, notice));
     updateCountryListSelection(listEl);
   } catch {}
 
@@ -186,19 +220,23 @@ function computeCountryScoresForSorting(countryData, mainData, peopleList) {
   return { overall, personTotals, allAvg };
 }
 
-async function ensureCountryMetrics(item, mainData) {
-  if (item.metrics) return item.metrics;
-  const data = await fetchCountry(item.file);
-  if (data && data.iso && !item.iso) item.iso = String(data.iso);
-  const m = computeCountryScoresForSorting(data, mainData, getEffectivePeople(mainData));
-  // Normalize to 1 decimal to match chips
+function computeRoundedMetrics(countryData, mainData) {
+  const m = computeCountryScoresForSorting(countryData, mainData, getEffectivePeople(mainData));
   const round1 = (x) => isFinite(x) ? Number(x.toFixed(1)) : NaN;
   const metrics = {
     overall: round1(m.overall),
     allAvg: round1(m.allAvg),
-    personTotals: {}
+    personTotals: {},
   };
   Object.keys(m.personTotals || {}).forEach(name => { metrics.personTotals[name] = round1(m.personTotals[name]); });
+  return metrics;
+}
+
+async function ensureReportMetrics(item, mainData) {
+  if (item.metrics) return item.metrics;
+  const data = await fetchCountry(item.file);
+  if (data && data.iso && !item.iso) item.iso = String(data.iso);
+  const metrics = computeRoundedMetrics(data, mainData);
   item.metrics = metrics;
   return metrics;
 }
@@ -207,22 +245,22 @@ async function applyCountrySort(mainData, listEl, notice) {
   const sel = document.getElementById('countrySort');
   if (!sel) return;
   const mode = sel.value || 'alpha';
-  const items = appState.items.slice();
+  const items = appState.countries.slice();
 
   function byName(a,b){ return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }); }
   function descNum(a,b){ return (b - a); }
 
   if (mode === 'alpha') {
     items.sort(byName);
-    appState.items = items;
-    renderCountryList(listEl, appState.items, notice, () => onSelectionChanged(mainData, notice));
+    appState.countries = items;
+    renderCountryList(listEl, appState.countries, notice, () => onSelectionChanged(mainData, notice));
     updateCountryListSelection(listEl);
     return;
   }
 
   // For numeric sorts, compute metrics first
   try {
-    await Promise.all(items.map(it => ensureCountryMetrics(it, mainData)));
+    await Promise.all(items.map(it => ensureReportMetrics(it, mainData)));
   } catch {}
 
   if (mode === 'alignment') {
@@ -249,8 +287,8 @@ async function applyCountrySort(mainData, listEl, notice) {
     });
   }
 
-  appState.items = items;
-  renderCountryList(listEl, appState.items, notice, () => onSelectionChanged(mainData, notice));
+  appState.countries = items;
+  renderCountryList(listEl, appState.countries, notice, () => onSelectionChanged(mainData, notice));
   updateCountryListSelection(listEl);
 }
 
@@ -298,42 +336,62 @@ function onSelectionChanged(mainData, notice) {
   renderComparison(selected, mainData, { diffEnabled: getStored('diffEnabled', false), restoreScroll });
 }
 
-function renderCountryList(listEl, items, notice, onChange) {
+function renderCountryList(listEl, countries, notice, onChange) {
   if (!listEl) return;
   listEl.innerHTML = '';
-  items.forEach(it => {
-    const row = document.createElement('div');
-    row.className = 'country-item';
-    row.setAttribute('role', 'option');
-    row.dataset.file = it.file;
-    row.dataset.name = it.name;
-    row.dataset.iso = it.iso || '';
-    if (it.iso) {
-      const img = createFlagImg(it.iso, 18);
-      if (img) row.appendChild(img);
+  countries.forEach(country => {
+    const group = document.createElement('div');
+    group.className = 'country-group';
+    if ((country.cities || []).length > 0) {
+      group.classList.toggle('expanded', !!country.expanded);
+      group.classList.toggle('collapsed', !country.expanded);
     }
-    const nameSpan = document.createElement('span');
-    nameSpan.className = 'name';
-    nameSpan.textContent = it.name;
-    row.appendChild(nameSpan);
 
-    // Optional right-aligned chip depending on current sort mode
-    try {
-      const chipWrap = buildCountryListChip(it);
-      if (chipWrap) row.appendChild(chipWrap);
-    } catch {}
+    const countryRow = buildTreeRow(country, { listEl, notice, onChange });
+    countryRow.classList.add('country-node');
 
-    row.addEventListener('click', () => {
-      toggleSelectCountry(it, notice);
-      updateCountryListSelection(listEl);
-      onChange && onChange();
-    });
+    let cityList = null;
+    if ((country.cities || []).length > 0) {
+      const toggle = document.createElement('button');
+      toggle.type = 'button';
+      toggle.className = 'tree-toggle';
+      const updateToggle = () => {
+        toggle.textContent = country.expanded ? '▾' : '▸';
+        toggle.setAttribute('aria-label', `${country.expanded ? 'Collapse' : 'Expand'} ${country.name}`);
+        toggle.setAttribute('aria-expanded', country.expanded ? 'true' : 'false');
+      };
+      country.expanded = country.expanded !== false; // default to expanded when undefined
+      updateToggle();
+      toggle.addEventListener('click', ev => {
+        ev.stopPropagation();
+        country.expanded = !country.expanded;
+        group.classList.toggle('expanded', country.expanded);
+        group.classList.toggle('collapsed', !country.expanded);
+        if (cityList) cityList.hidden = !country.expanded;
+        updateToggle();
+      });
+      countryRow.prepend(toggle);
+    }
 
-    listEl.appendChild(row);
+    group.appendChild(countryRow);
+
+    if ((country.cities || []).length > 0) {
+      cityList = document.createElement('div');
+      cityList.className = 'city-list';
+      cityList.hidden = !country.expanded;
+      country.cities.forEach(city => {
+        const cityRow = buildTreeRow(city, { listEl, notice, onChange });
+        cityRow.classList.add('city-node');
+        cityList.appendChild(cityRow);
+      });
+      group.appendChild(cityList);
+    }
+
+    listEl.appendChild(group);
   });
 }
 
-function buildCountryListChip(item) {
+function buildTreeNodeChip(item) {
   const sel = document.getElementById('countrySort');
   if (!sel) return null;
   const mode = sel.value || 'alpha';
@@ -359,26 +417,66 @@ function buildCountryListChip(item) {
 
 function updateCountryListSelection(listEl) {
   const selectedFiles = new Set(appState.selected.map(s => s.file));
-  Array.from(listEl.children).forEach(child => {
-    if (!(child instanceof HTMLElement)) return;
-    const isSel = selectedFiles.has(child.dataset.file);
-    child.classList.toggle('selected', isSel);
-    child.setAttribute('aria-selected', isSel ? 'true' : 'false');
+  const nodes = listEl.querySelectorAll('[data-file]');
+  nodes.forEach(node => {
+    if (!(node instanceof HTMLElement)) return;
+    const isSel = selectedFiles.has(node.dataset.file);
+    node.classList.toggle('selected', isSel);
+    node.setAttribute('aria-selected', isSel ? 'true' : 'false');
   });
 }
 
-function toggleSelectCountry(item, notice) {
+function buildTreeRow(item, ctx) {
+  const { listEl, notice, onChange } = ctx || {};
+  const row = document.createElement('div');
+  row.className = 'country-item';
+  if (item.type === 'city') {
+    row.classList.add('city-item');
+  } else {
+    row.classList.add('country-item-root');
+  }
+  row.setAttribute('role', 'option');
+  row.dataset.file = item.file;
+  row.dataset.name = item.name;
+  row.dataset.iso = item.iso || '';
+  row.dataset.type = item.type || '';
+
+  if (item.type === 'country' && item.iso) {
+    const img = createFlagImg(item.iso, 18);
+    if (img) row.appendChild(img);
+  }
+
+  const nameSpan = document.createElement('span');
+  nameSpan.className = 'name';
+  nameSpan.textContent = item.name;
+  row.appendChild(nameSpan);
+
+  try {
+    const chipWrap = buildTreeNodeChip(item);
+    if (chipWrap) row.appendChild(chipWrap);
+  } catch {}
+
+  row.addEventListener('click', () => {
+    toggleSelectNode(item, notice);
+    updateCountryListSelection(listEl);
+    onChange && onChange();
+  });
+
+  return row;
+}
+
+function toggleSelectNode(item, notice) {
   const idx = appState.selected.findIndex(s => s.file === item.file);
   if (idx >= 0) {
     appState.selected.splice(idx, 1);
-    notice.textContent = '';
+    if (notice) notice.textContent = '';
   } else {
     if (appState.selected.length >= 4) {
-      notice.textContent = 'Limited to 4 countries; deselect one to add more.';
+      if (notice) notice.textContent = 'Limited to 4 countries; deselect one to add more.';
       return;
     }
     appState.selected.push(item);
-    notice.textContent = '';
+    if (notice) notice.textContent = '';
   }
   saveSelectedToStorage();
 }
@@ -943,7 +1041,14 @@ function getEffectivePeople(mainData) {
 }
 
 function invalidateCountryMetricsCache() {
-  try { (appState.items || []).forEach(it => { if (it) delete it.metrics; }); } catch {}
+  try {
+    (appState.countries || []).forEach(country => {
+      if (country) {
+        delete country.metrics;
+        (country.cities || []).forEach(city => { if (city) delete city.metrics; });
+      }
+    });
+  } catch {}
 }
 
 function openWeightsDialog(mainData) {


### PR DESCRIPTION
## Summary
- add nested city support to the sidebar while keeping country-only sorting and flag rendering
- extend styling and data loading logic to understand countries with attached city reports
- seed the first city entry with a detailed Munich report referenced from Germany's metadata

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e3261a3a288321a01d5b1122557622