### PR TITLE
Add Germany city reports for Berlin, Hamburg, and Cologne

### DIFF
--- a/main.json
+++ b/main.json
@@ -527,6 +527,18 @@
         {
           "name": "Munich",
           "file": "reports/germany_munich_report.json"
+        },
+        {
+          "name": "Berlin",
+          "file": "reports/germany_berlin_report.json"
+        },
+        {
+          "name": "Hamburg",
+          "file": "reports/germany_hamburg_report.json"
+        },
+        {
+          "name": "Cologne",
+          "file": "reports/germany_cologne_report.json"
         }
       ]
     },

--- a/reports/germany_berlin_report.json
+++ b/reports/germany_berlin_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Berlin’s tech corridor of Zalando, Delivery Hero, and SAP/Google cloud teams constantly needs senior .NET architects, and English-first product squads mean Trey can land a role or contracts while his German improves.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Dense traffic on the A100 ring and Kreuzberg arterials keeps annual PM2.5 around 15 µg/m³, so the family follows AQI alerts on still winter days even though parks and low-sulfur heating moderate summer pollution.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Berlin’s population is majority non-religious, church tax participation is rare, and public schools avoid mandatory worship, giving openly atheist parents an easy social fit.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Berlin benefits from Germany’s federal checks—coalition politics, constitutional courts, and an assertive press—that keep far-right surges from eroding the civil liberties the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Opening a Girokonto at N26 or Deutsche Kreditbank can be done largely online, but plenty of neighborhood bakeries remain cash-preferred, so the family still carries Girocards alongside Apple Pay.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Berlin has no coastline, yet Strandbad Wannsee, Müggelsee, and the clean Havel lakes deliver sandy beaches by S-Bahn, giving the kids real swim options on hot weekends.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Meeple cafés like Spielwiese, the annual Berlin Brettspiel Con, and English-friendly tabletop meetups keep the scene vibrant, letting Trey playtest prototypes weekly.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Berlin’s Gebührenfreiheit covers Kita fees after year one, but chronic educator shortages mean joining the Kita-Navigator waitlist a year in advance and budgeting for interim Tagesmutter care.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Traffic-calmed Spielstraßen, 1,800 playgrounds, and late-night transit let the kids roam, though cyclists and delivery vans in Mitte require vigilant crossing habits.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens tap free Kita hours, Kindergeld, and Landeszuschüsse for childcare staff shortages, but still need to reconfirm spots each spring to hold bilingual programs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once Anmeldung and health insurance are complete, expat families access fee waivers and Kindergeld, yet paperwork translations and residence permit renewals keep admin time-consuming.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Berlin’s clubs cover bouldering, hacker spaces, VR labs, and English-speaking D&D groups, giving every family member an easy-fit hobby within 30 minutes by transit.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighborhoods start reserved, but Elterninitiativ Kitas, coworking Stammtische, and queer community centers help Sarah build steady circles at a pace she can manage.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Keeping Anmeldung current, reporting freelance income to the Finanzamt, and renewing residence permits on time keeps Berlin bureaucracy predictable—missed deadlines usually mean fines rather than status threats.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and BVG passes remain affordable, yet a renovated three-bedroom in Prenzlauer Berg or Friedrichshain now runs €2,000–€2,400 monthly plus Nebenkosten, so Trey’s salary must cover high rents.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Germany’s 2024 reform lets naturalized residents keep their U.S. passport, and Berlin’s Landesamt für Einwanderung already processes dual applications with clear checklists.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Berlin’s economy leans on startups, creative industries, and federal administration; unemployment hovers near 8%, but venture-backed tech hiring offsets the slower public sector.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "The city mirrors Germany’s social market model—strong social safety nets and co-determination—while Berlin’s business registration and tax reporting remain paperwork-heavy for freelancers like Sarah.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Berlin schools emphasize inclusion and all-day Betreuung, yet Abitur outcomes trail Bavaria, so the family needs to stay engaged with teachers to keep Anduin on a Gymnasium track.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Global companies and startups alike sponsor EU Blue Cards, and Berlin’s migration office hosts English-language info sessions, though notarized diplomas are still mandatory.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Berlin mixes vast parks and the Spree’s waterways with pockets of traffic pollution; weekend escapes to Brandenburg forests are easy, but inner-ring neighborhoods feel urban.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "As dual earners with two kids, the family would land in tax class IV, facing roughly 35–38% combined income tax plus solidarity and church-tax opt-outs, though child allowances soften the net bite.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September hovers around 18 °C (64 °F) before sliding to 10 °C (50 °F) by November, with frequent drizzle and earlier sunsets nudging more indoor play.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "All-day schools, playground density, and family-friendly museums make daily life manageable, while shared custody norms and progressive parenting circles give Trey and Sarah social support.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Berlin’s residence permits allow dependent visas with proof of housing and income, but annual renewals and mandatory school attendance reports require careful documentation.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens benefit from Elternzeit, Kinderzuschlag, and Berlin’s extended parental leave supplements, though navigating Jobcenter paperwork takes patience.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Families with two working parents commonly stagger Elternzeit and rely on Kita vouchers; Berlin’s social services can advise, yet appointments need early booking.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Once residence permits are issued, the family qualifies for parental leave and Kindergeld, but proving health insurance and local leases remains a recurring admin chore.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Berlin favors eclectic, sustainable fashion—think indie designers and secondhand boutiques—which lets Sarah blend tech casual with expressive streetwear.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Menswear leans toward minimalist street style, so Trey can toggle between startup hoodies and smart-casual looks without feeling underdressed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Berlin workplaces prize gender equity, with strong parental leave uptake and visible female leadership, keeping expectations flexible for Sarah.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Ubisoft Berlin, Yager, and Wooga hire senior engineers, and federal games funding often routes through Berlin’s cluster, keeping opportunities steady.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal name-change support, visible trans pride, and inclusive nightlife make Berlin one of Europe’s most gender-fluid-friendly hubs.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Berlin enforces Germany’s strong anti-discrimination laws, offers third-gender markers, and funds queer support centers citywide.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are the norm, and Berlin employers back part-time Elternzeit for fathers, so Trey won’t face stigma for leaning into childcare.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Carrying health insurance proof, rental contracts, and notarized documents keeps visa renewals smooth, while Berlin’s online appointment portal fills fast so planning ahead is key.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Berlin faces more summer heatwaves and occasional drought stress on city trees, yet flood and storm risks stay low compared with coastal Europe.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Charité and Vivantes hospitals anchor strong care, though citizens still navigate waitlists for non-urgent specialists.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Once insured through public Krankenkassen, expats access the same doctors, but English-language appointments can require private clinics or extra wait time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Humboldt, TU Berlin, and arts universities stay low-cost for citizens, with broad study tracks and strong dual-education options.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU residents pay the same tuition but must maintain residency status and proof of funds, adding paperwork to otherwise accessible universities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Berlin’s vacancy rate sits near 1%, so families rely on employer brokers, housing cooperatives, or temporary furnished leases while competing with EU talent for long-term apartments.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Employers withhold income tax and social contributions monthly, and couples choose a Steuerklasse split before filing an annual return—Elster online makes submission manageable once translated.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizen children attend local Grundschule automatically, and slots in sought-after Gymnasien use a mix of grades, sibling priority, and proximity, so proactive school meetings matter.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children enroll tuition-free, but parents must present translated transcripts and may request DaZ (German-as-second-language) support during the first semesters.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English is common in tech, startup, and nightlife circles, yet most bureaucracy, healthcare, and school meetings run in German, so steady language study remains essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Christopher Street Day, queer community centers, and inclusive nightlife signal broad acceptance, and Berlin’s senate funds anti-discrimination programs that protect poly and LGBTQ+ families.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas animate parts of Neukölln and university activism, but mainstream voters favor social-market pragmatism over revolutionary rhetoric.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Expectations emphasize active fatherhood and emotional openness; macho posturing is rare in Berlin’s workplaces.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Meetup.com lists dozens of English-speaking tech, parenting, and gaming groups, and Factory Berlin or betahaus host weekly founder breakfasts that welcome newcomers.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Berlin follows the national €12.41 hourly minimum, though hospitality and logistics often pay slightly more to offset the city’s rent pressure.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fiber-to-the-building rollouts, 5G coverage, and the combined S-Bahn/U-Bahn network keep daily logistics modern, even if BER airport operations still suffer occasional hiccups.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Tiergarten, Tempelhofer Feld, and day trips to the Spreewald or Wannsee provide ample greenery, though alpine scenery requires longer travel than southern Germany.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Berlin avoids earthquakes and hurricanes; climate risks mainly involve heavy summer storms or localized flooding, both mitigated by solid drainage and insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Dozens of lakes, forests like Grunewald, and Brandenburg day trips sit within an hour by regional rail, so the family can grab fresh air without a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "From techno institutions like Berghain to world-class orchestras at the Philharmonie and countless indie venues, Berlin offers late-night options once childcare is arranged.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife runs late with relaxed door policies and diverse scenes; Sundays often include family-friendly street festivals that ease parents back into the week.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "GamesCapitalBerlin meetups, Saftladen collective, and Womenize! events connect indie founders with peers, publishers, and funding advisors.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Ubisoft Berlin, Wooga, Yager, King, and numerous indies anchor the local scene, creating steady networking touchpoints for Trey.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Median, federal, and EU games funds run frequent calls out of Berlin, and incubators like games:net Accelerator pair capital with mentorship for new studios.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Workdays move quickly, but late retail hours and abundant parks slow evenings; Sundays stay quiet due to trading laws, giving the family intentional downtime.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools expect parents to join Klassenpflegschaft councils and coordinate holiday care, yet norms respect work-life balance and gender-equal caregiving.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Reforms allow naturalization after five years (three with integration milestones), so a stable residency in Berlin can yield dual passports before the children hit middle school.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany highly; local scandals surface via investigative journalism and usually trigger resignations or court reviews.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Germany’s federal parliamentary system with proportional representation, strong courts, and coalition governance keeps policy shifts measured and rule-of-law strong.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Poly-friendly therapists, meetup groups, and queer venues make non-monogamous households socially accepted, though legal recognition still stops at monogamous partnerships.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Krippen accept toddlers from age one with city subsidies, but staff shortages make early applications and personal networking critical for bilingual spots.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International schools like Berlin Cosmopolitan or John F. Kennedy offer English curricula, yet tuition often tops €15k annually, so they’re backup options rather than defaults.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Berlin’s coalition leans social-liberal and green, advancing climate action, queer rights, and renter protections that match the family’s progressive priorities.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters cover politics with balanced analysis, and algorithmic echo chambers are easy to avoid by curating trusted outlets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "State influence over media is minimal; sensational tabloids exist but are countered by investigative outlets like Tagesspiegel and RBB.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "BVG’s U-Bahn, S-Bahn, tram, and bus mesh with €49 Deutschlandtickets, dense bike lanes, and regional rail, letting the family skip car ownership comfortably.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Berlin politics stay largely secular, with religious arguments rarely shaping policy beyond debates on school holidays or headscarves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Tech employers typically offer hybrid schedules, and coworking spaces like betahaus, St. Oberholz, and Factory Berlin provide reliable hubs for remote days.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "EU Blue Cards run four years with early permanent residence after 33 months (21 with B1 German); freelancers can secure permits once they show client contracts and health insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, Riester/Rürup supplements, and subsidized senior housing keep citizen retirees stable, though private savings help offset Berlin’s rents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Non-EU residents vest in pensions after five contribution years, and Germany’s U.S. totalization agreement protects accrued credits if the family later returns stateside.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Long-term visa holders accrue pension rights, yet leaving Germany before vesting or without permanent residency can reduce payouts, so the family should plan long stays.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "E-commerce, fintech, and gov-tech teams use Rails, and many operate English-first, giving Sarah a steady pool of hybrid or remote roles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Berlin’s crime rate is moderate for a large city; petty theft and bicycle loss require vigilance, but violent crime remains relatively rare in family districts.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Berlin offers neighborhood Gesamtschulen, specialized arts/STEM tracks, and bilingual state schools, yet navigating the transition to Gymnasium demands parental advocacy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Nearby lakes warm to 20–23 °C (68–73 °F) in July and August, comfortable for swimming but far from coastal warmth.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Expect grey winters, mild springs, warm but manageable summers around 26 °C (79 °F), and autumn drizzle—humidity is moderate compared with the U.S. Midwest.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Berlin embraces sex-positive culture with visible consent education, sex shops, and open dialogue in media, supporting the family’s values.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Berlin aggressively funds public housing, transit, and climate projects, reflecting Germany’s strong welfare framework and the city’s progressive bend.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Daytime highs climb from 10 °C (50 °F) in March to 18 °C (64 °F) by May with frequent showers, so layers and rain gear stay in rotation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany’s diversified economy, EU backing, and strong institutions keep Berlin stable even when national GDP slows.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Berlin’s senate aligns social-democratic and green, prioritizing climate, housing, and social equity—far from authoritarian rhetoric.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Market competition thrives alongside co-determination and tenant protections, giving Trey space to found a studio without facing laissez-faire extremes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Highs hover between 24–28 °C (75–82 °F) with occasional heatwaves into the low 30s °C (mid-80s °F); nights drop near 15 °C (59 °F).",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing usually wraps in 8–10 weeks with €100–€140 in fees plus sworn translations of degrees and marriage certificates.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show relatively high trust in Berlin’s administration and federal ministries, boosted by transparent budgeting and open-data portals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "When issues emerge they involve procurement favoritism or party donations, and watchdog agencies investigate quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior .NET or full-stack roles pay €80k–€90k at Zalando, Delivery Hero, or SAP Labs, with €100k packages for cloud leadership or equity-heavy startups.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays often include farmers’ markets, playground meetups, or lake trips; Sundays stay quiet due to retail closures, encouraging board games and museum visits.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools start around 8 a.m., Kita care runs until 5 p.m., and hybrid tech teams respect logging off near 4:30–5 p.m., giving the family predictable evenings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Employees receive the federal 20-day minimum plus Berlin’s 10 public holidays, ensuring predictable downtime.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech firms commonly offer 28–30 days off, and many add bridge days around major holidays.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Berliners travel frequently across the EU, fostering a pragmatic, cooperative view of neighbors like Poland and the Czech Republic.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Berliners pride themselves on being edgy, creative, and socially progressive compared with the rest of Germany.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Berlin as creative yet chaotic—admiring its culture while noting bureaucratic hiccups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, skilled worker visas, Chancenkarte, and artist/freelancer permits all run through Berlin’s Landesamt with clear checklists once appointments are secured.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "A sizable U.S. expat community, English-speaking schools, and relocation agencies ease landing, though some landlords still prefer EU tenants.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Berlin blends a cutting-edge tech scene, rich arts culture, and progressive politics—letting the family pursue creative careers without sacrificing values.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect −2 to 5 °C (28–41 °F) with damp cold, occasional snow, and short daylight; proper gear keeps commutes manageable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Collective agreements target 37.5–40 hours, and works councils reinforce boundaries on overtime.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Hybrid schedules, protected vacation, and a culture that disconnects on weekends give the family room for childcare, hobbies, and indie projects.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Works councils, strong unions, and enforceable leave policies let employees push back on unreasonable demands without risking termination.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_cologne_report.json
+++ b/reports/germany_cologne_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Cologne’s mix of Deutsche Telekom teams, Ford’s IT hub, and media-tech firms in the Rheinauhafen keeps senior .NET roles available, though German fluency accelerates leadership opportunities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Traffic on the Cologne Belt and lignite power from nearby Rhineland raises annual PM2.5 to roughly 14 µg/m³, so the family tracks AQI during stagnant winter weeks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Cologne remains culturally Catholic, yet urban neighborhoods and universities are secular enough that openly atheist parents meet little friction.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Cologne benefits from Germany’s federal checks—coalition politics, constitutional courts, and a vigilant press—that keep far-right surges from eroding civil liberties.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Sparkasse KölnBonn, DKB, and N26 offer quick account setups, and contactless payments work nearly everywhere, though some Brauhäuser still prefer Girocard.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Rhine riverfront beaches and lakes like Fühlinger See give summer splash options, but true seaside trips mean driving to the North Sea for the weekend.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Café Seetroll, top-tier Spiel fair in nearby Essen, and English-language tabletop groups keep the board-gaming scene thriving for Trey.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "North Rhine-Westphalia guarantees Kita spots from age three and subsidizes fees, yet waitlists for under-threes require applying early and bridging with Tagespflege.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Traffic-calmed Altstadt lanes, abundant playgrounds, and the Rheinpromenade feel family-friendly, though car congestion around the ring road needs vigilance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens benefit from NRW childcare subsidies, Kindergeld, and Familienzentren support, though annual re-registration keeps parents on their toes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "After Anmeldung and insurance proof, expat families access Kita subsidies and Kindergeld, but documentation translation remains a recurring chore.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Climbing gyms, carnival clubs, makerspaces, and English-speaking gaming nights give each family member outlets within a short tram ride.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Cologne’s Karneval culture and neighborhood festivals make it easy to meet people; Sarah can build friendships through Elterncafés and community centers at a relaxed pace.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Keeping Anmeldung current, submitting freelance tax declarations, and renewing permits on schedule keeps Cologne’s bureaucracy predictable—late filings mostly trigger fines.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and KVB transit are manageable, yet a three-bedroom in Südstadt or Ehrenfeld runs €1,800–€2,200 plus utilities, so Trey’s salary must absorb steady rent.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Germany’s 2024 reform applies statewide, and Cologne’s Ausländerbehörde processes dual applications with clear documentation lists.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Media, chemicals, auto manufacturing, and a large service sector keep unemployment near 7%, offering resilience but less explosive growth than Berlin or Munich.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "North Rhine-Westphalia reflects Germany’s social market mix—strong welfare supports and co-determination—though business registration still involves paperwork marathons.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Cologne follows NRW’s comprehensive school reforms; Gymnasium access depends on grades and teacher recommendations, so family engagement stays important.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Multinationals like Bayer, Ford, and Telekom sponsor Blue Cards, though SMEs expect German-language contracts and degree recognition.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Cologne balances Rhine greenways, Stadtwald parks, and nearby Eifel forests with industrial corridors to the north; weekend nature escapes are straightforward.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual earners with two children fall into tax class IV, paying roughly 35–37% combined income tax plus solidarity surcharges; child allowances help offset the burden.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September averages 19 °C (66 °F) before tapering to 10 °C (50 °F) by November with frequent showers, so light rain gear stays handy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "All-day schools, children’s museums, and the Rheinauhafen promenade keep family time easy, while Karneval traditions welcome kids into community rituals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Residence permits extend to dependents with proof of income and housing; annual renewals and school attendance confirmations require organized record-keeping.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens access Elternzeit, Landeserziehungsgeld, and NRW childcare subsidies, though applications need persistence with district offices.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Most families stagger Elternzeit and rely on Kita vouchers; Familienbüros guide paperwork if appointments are booked early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Once permits and insurance are secured, the family qualifies for parental leave and Kindergeld, but translating leases and pay slips is part of the routine.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Cologne mixes relaxed streetwear with bold Karneval flair, letting Sarah blend tech casual with colorful touches.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Menswear leans toward smart-casual layers; Trey can rotate between startup hoodies and button-downs without standing out.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Workplaces promote gender equity, and NRW policies encourage long parental leaves for all genders, keeping expectations flexible.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Electronic Arts (in nearby Cologne-Ehrenfeld), and indie outfits create opportunities, but the market is smaller than Berlin or Hamburg.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Cologne Pride, queer churches, and inclusive nightlife around Schaafenstraße support gender-diverse residents, even if services are more spread out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Cologne enforces Germany’s anti-discrimination laws, funds queer counseling, and offers third-gender registration pathways.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are typical, and employers support flexible schedules so fathers can participate in childcare.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Proof of insurance, income, and housing keeps visa renewals smooth; Cologne’s online booking portal fills fast, so planning ahead is essential.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heatwaves and Rhine flooding are moderate risks; recent summers saw more 30 °C days, but flood defenses and early warnings mitigate extremes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Universitätsklinikum Köln and private clinics offer high-quality care, though specialist appointments can require advance booking.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Public Krankenkassen cover expats once enrolled, but finding English-speaking doctors may take referrals or private clinics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "University of Cologne, TH Köln, and nearby Bonn campuses provide broad, low-cost study options for citizens.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students pay minimal tuition but must maintain residence permits and proof of funds, adding paperwork to accessible universities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Vacancy is tight but slightly better than Berlin; families still rely on Genossenschaften, employer assistance, or interim furnished rentals while searching for long-term leases.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Employers withhold income tax and social contributions monthly; couples choose Steuerklasse splits and file annual returns via Elster or a trusted Steuerberater.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizen children attend local Grundschule, and popular Gymnasien combine academic recommendations with lottery systems, so proactive school engagement helps.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children enroll tuition-free but need translated transcripts; DaZ language support is available during the first year.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English pops up in media, tech, and tourism, yet daily bureaucracy and healthcare remain German-first, pushing the family to keep language lessons going.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Cologne Pride draws one of Europe’s largest parades, and queer-friendly neighborhoods like Ehrenfeld feel welcoming to poly and LGBTQ+ families.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas exist within university circles and trade unions, but broader politics favor pragmatic social democracy.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Men are expected to be dependable and involved parents; macho posturing clashes with Cologne’s friendly, open culture.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Meetup groups for tech, board games, and parenting plus local coworking spaces like Startplatz help newcomers plug into networks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Cologne follows the €12.41 national minimum, with higher collective agreements in chemicals and automotive sectors.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fiber and 5G rollouts are progressing, KVB trams link the metro, and Cologne/Bonn Airport adds international connections despite some Deutsche Bahn delays.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Rhine parks, the nearby Siebengebirge hills, and Eifel National Park offer greenery, though dramatic mountain scenery requires longer trips.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "The main risks are Rhine flooding and summer storms; 2021 floods prompted stronger defenses but households near floodplains should maintain insurance.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Bike paths along the Rhine and regional trains to the Eifel or Mosel make outdoor escapes easy without a car.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Cologne’s club scene, live music venues, and classical concerts at Kölner Philharmonie give parents abundant date-night choices.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Karneval keeps nightlife exuberant, and many venues stay family-friendly until evening before turning adult-focused later at night.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "devcom, Cologne Game Lab, and local IGDA meetups connect game creators thanks to Gamescom’s annual presence.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Ubisoft Blue Byte, EA, and indie studios around Cologne Game Lab anchor the local industry, giving Trey a starting network.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Gamescom, the Mediennetzwerk.NRW accelerator, and state grants supply mentorship and prototype funding for new studios.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Cologne balances productive workdays with relaxed evenings on the Rhine; Sundays and Karneval season slow the pace dramatically for family time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools encourage active Elternrat participation and shared holiday planning, with both parents expected to pitch in.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Reforms allow naturalization after five years (three with integration milestones); Cologne’s offices process applications steadily if paperwork is complete.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Germany’s strong rankings hold, and investigative reporters quickly spotlight municipal procurement concerns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Germany’s federal parliamentary system with proportional representation and coalition governance keeps policy shifts measured.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Poly-friendly therapists and meetups exist, especially in Ehrenfeld; social acceptance is high even though legal recognition remains monogamous.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Kitas accept toddlers from age one, but waitlists require early applications; Tagespflege offers interim coverage when spots lag.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International schools like St. George’s or Internationale Friedensschule provide English curricula at €15k+, positioning them as fallback options.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Cologne city hall leans progressive, championing climate, LGBTQ+, and integration programs aligned with the family’s values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters and local outlets cover politics with balanced reporting; sensational tabloids are easy to avoid.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "State influence over media remains minimal, with WDR and Kölner Stadt-Anzeiger maintaining critical coverage.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The KVB tram and bus network ties into Deutsche Bahn regional lines and the €49 ticket, though older tunnels occasionally slow service.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Catholic heritage shapes some public holidays, but policy debates focus more on housing, climate, and transit than religious doctrine.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid work is common in media and tech; coworking spaces like Startplatz and The Ship offer reliable setups for remote days.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years with early permanent residency after 33 months (21 with B1 German); freelancers can qualify with client letters and insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions plus industry supplements from chemicals and media firms provide stability, though extra savings help with housing costs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants vest after five contribution years, and Germany’s pact with the U.S. protects accrued credits if the family returns stateside.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Visa holders build pension rights over time but must plan for long stays or permanent residency to realize full benefits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Rails roles exist in media companies, Cologne/Bonn startups, and digital agencies, yet the market is smaller than Berlin so networking matters.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Cologne is generally safe; petty theft clusters around main station nightlife, but family neighborhoods stay calm.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Families choose between Gesamtschulen, Gymnasien, and bilingual programs like Europaschule; transitions require parental involvement.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Rhine and lake swimming tops out around 21 °C (70 °F) in July and August—refreshing but not tropical.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Winters are mild and damp, springs warm gradually, and summers reach 25–27 °C (77–81 °F) with occasional humid spells.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Cologne’s sex-positive culture, comprehensive education, and queer communities create open conversations about relationships and consent.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Cologne invests in housing, transit, and integration, aligning with Germany’s generous welfare infrastructure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March sits around 10 °C (50 °F) and May climbs to 19 °C (66 °F) with scattered showers—pleasant for outdoor play.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany’s diversified economy and EU backing keep Cologne stable even as certain industries transition to greener tech.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "North Rhine-Westphalia combines Social Democratic leadership with Green coalition partners focused on climate and social cohesion.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Co-determination and strong unions balance a competitive market, giving Trey room to launch ventures without cutthroat extremes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Expect highs between 24–28 °C (75–82 °F) with warm evenings around 16 °C (61 °F); occasional heatwaves push higher but short-lived.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically takes 8–10 weeks with €100–€140 in fees plus sworn translations of degrees and marriage certificates.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Citizen surveys show solid trust in Cologne’s city hall and federal institutions, bolstered by participatory budgeting efforts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "When procurement or zoning issues arise, regional courts and watchdog journalists intervene quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers earn €70k–€82k at Telekom, insurers, or media firms, with €90k offers tied to leadership or scarce cloud skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends feature Rheinpark walks, trips to Phantasialand or museums, and Sunday board games due to store closures.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools start near 8 a.m., OGATA all-day programs run until 4–5 p.m., and hybrid teams expect logging off around 5 p.m.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Employees receive the federal 20-day minimum plus NRW’s 11 public holidays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech and media employers typically offer 28–30 days off with extra Karneval bridge days.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Cologne’s location fosters friendly ties with Belgium, the Netherlands, and Luxembourg, encouraging weekend travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Colognes see themselves as warm, inclusive, and a bit irreverent—proud of their cathedral and Karneval spirit.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Cologne as open and celebratory, sometimes teasing its carnival chaos but valuing its hospitality.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, skilled worker visas, Chancenkarte, and artist/freelancer permits run through Cologne’s immigration office with clear checklists once appointments are secured.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "A sizable expat and military-connected community, international schools, and relocation agencies ease landing, though landlords still favor long-term German tenants.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Cologne blends a creative media economy, inclusive culture, and legendary festivals—offering the family progressive values with big-city warmth.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect 0–7 °C (32–45 °F) with damp air and light snow; Rhine humidity makes it feel cooler but manageable with good gear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Collective agreements target 37.5–40 hours, and works councils enforce strict overtime limits.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Hybrid schedules, mandated vacation, and a culture that pauses for Karneval give the family ample time for hobbies and childcare.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Works councils, strong unions, and legal protections ensure employees can challenge unreasonable demands without risking termination.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_hamburg_report.json
+++ b/reports/germany_hamburg_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Hamburg’s tech corridor around HafenCity, Otto Group, and Airbus Digital keeps .NET teams hiring, and Microsoft cloud partners like SinnerSchrader offer English-friendly roles for senior architects.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "North Sea breezes and district heating keep annual PM2.5 near 12 µg/m³, though Elbtunnel traffic can trigger brief NO₂ spikes, so the family watches AQI on calm winter days.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Hamburg is historically Lutheran yet now majority non-religious, and public schools steer clear of worship, so atheist parents blend in easily.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Hamburg benefits from Germany’s federal checks—coalition politics, constitutional courts, and a vigilant press—that keep far-right surges from eroding civil liberties.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Opening a Girokonto at Hamburger Sparkasse or DKB is straightforward, and contactless payments are common, though fish market stalls still prefer cash.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Elbstrand, Övelgönne, and easy weekend trips to the Baltic Sea give the kids real sand and swimmable water, even if summers stay brisk.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Cafés like Würfel & Zucker, Spielwerk Hamburg, and the annual Hamburg Brettspiel Con keep the tabletop scene active with English-friendly nights.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Hamburg funds five free Kita hours daily, yet educator shortages mean applying early through the Kita-Gutschein system and bridging with Tagesmutter care.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Playgrounds dot every district, ferries allow stroller-friendly rides, and traffic-calmed Altbau streets feel safe, though port trucks require extra caution.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive subsidized full-day Kita vouchers and Kindergeld, but renewing placement each year is necessary to keep bilingual programs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "After Anmeldung and insurance proof, expat families access Kita vouchers and Kindergeld, yet paperwork and proof of work contracts remain time-consuming.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Sailing clubs, climbing halls, board-game nights, and VR labs give each family member a niche, though some groups expect intermediate German.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Hamburgers start reserved, but Elterninitiativen, English-speaking meetup groups, and neighborhood HafenCity events help Sarah build steady circles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Staying registered, filing local taxes, and renewing residence permits on time keeps Hamburg’s bureaucracy predictable—missed deadlines mainly incur fines.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and HVV passes are fair, yet a renovated three-bedroom in Eimsbüttel or Winterhude costs €2,200–€2,600 plus Nebenkosten, so Trey needs strong income.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Germany’s 2024 reform applies citywide, and Hamburg’s Einwanderungsbehörde already handles dual applications with clear requirements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Hamburg’s port, logistics, media, and aviation industries keep unemployment near 5% and buffer national slowdowns with export demand.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "The city follows Germany’s social market mix—strong welfare supports and co-determination—while business registration still requires notarized paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Hamburg’s Gesamtschule reforms delay tracking and invest in all-day Betreuung; academic outcomes are mid-pack but improving, so parent engagement still matters.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Aviation, logistics, and consulting firms sponsor Blue Cards, though HR teams expect degree verification and German-language contracts.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Waterfront parks, protected wetlands, and widespread cycling make daily life green, even with port industry humming in the background.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "As dual earners with two kids, the family sits near 35–37% combined income tax plus solidarity and church-tax opt-outs; child allowances soften the net hit.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September averages 18 °C (64 °F) before sliding to 9 °C (48 °F) by November with breezy drizzle—layered jackets keep outings comfortable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "All-day schools, family-friendly museums, and ferry rides make weekends easy, and shared parenting norms give Trey and Sarah supportive peer networks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Residence permits cover dependents with proof of housing and income; annual renewals and school attendance confirmations keep the paperwork cycle steady.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens access Elternzeit, Kinderzuschlag, and Hamburg’s Familienkasse supplements, though applications require persistence.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical families stagger Elternzeit and rely on Kita vouchers; municipal family centers offer planning support if booked ahead.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Once permits and insurance are in place, the family qualifies for parental leave and Kindergeld, but furnishing German documentation remains routine.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Hamburg leans toward maritime-chic and sustainable labels, letting Sarah mix tech casual with understated style.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Menswear favors smart-casual layers—think knit sweaters and waterproof jackets—so Trey’s startup wardrobe fits right in.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women balance careers and family with strong institutional support, and leadership roles are visible across the port economy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like InnoGames, Daedalic, and Goodgame keep hiring pipelines open, though senior engineering roles are fewer than in Berlin.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Hamburg Pride, queer health centers, and municipal support make gender-diverse residents visible, even if the nightlife is less experimental than Berlin.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Hamburg enforces Germany’s anti-discrimination laws, offers third-gender registration, and funds queer counseling services.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are standard, and employers support part-time Elternzeit for fathers without stigma.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Proof of insurance, income, and housing keeps visa renewals smooth, while Hamburg’s appointment portal requires booking weeks in advance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Sea-level rise and heavier rain pose moderate risk, but dikes and flood protection reduce day-to-day concern for most neighborhoods.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "University Medical Center Hamburg-Eppendorf anchors excellent care, though non-urgent specialists still involve waitlists.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Public Krankenkassen cover expats once insured, yet English-speaking doctors sometimes require private clinics or longer waits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Universities like HAW, Universität Hamburg, and HafenCity University stay low-cost for citizens with diverse study programs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students pay similar tuition but must show residency proof and finances, adding paperwork to accessible campuses.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Vacancy rates hover near 1%, so families lean on employer brokers, Genossenschaften, or temporary furnished leases while house-hunting in competitive districts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Employers withhold income tax and social contributions monthly; couples choose a Steuerklasse split and file annual returns via Elster or a Steuerberater.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizen children attend neighborhood primary schools, and entry into popular Gymnasien or Stadtteilschulen balances grades with proximity lotteries.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children enroll tuition-free but need translated records; DaZ language support is widely available the first year.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English is common in logistics, aviation, and media sectors, and many locals have strong skills, though bureaucracy still runs in German.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Hamburg Pride, St. Georg’s queer hubs, and city grants show broad acceptance, even if nightlife is more subdued than Berlin’s.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist discourse surfaces in port unions and student politics, yet mainstream governance favors pragmatic social democracy.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Professional men balance reliability with active fatherhood; overt machismo is discouraged in Hamburg workplaces.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Startup docks, Geekettes, and international parent meetups provide regular gathering spots, though events skew smaller than Berlin’s.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Hamburg follows the €12.41 national minimum; collective agreements in logistics and aviation often exceed it to attract labor.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fiber rollout, 5G coverage, and the well-maintained HVV network keep the city modern, and the port drives investment in smart logistics.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "The Alster lakes, Elbe beaches, and nearby Lüneburg Heath offer scenic escapes, though mountains require longer trips.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Storm surges and heavy rain remain the main risks, but dikes and flood barriers protect most neighborhoods; insurance is advisable near the Elbe.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Canals, parks, and regional rail to Schleswig-Holstein make nature easy to reach without a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Elbphilharmonie concerts, Reeperbahn clubs, and live music venues give the family diverse date-night choices once childcare is arranged.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Reeperbahn nightlife runs late yet inclusive; harbor festivals and night markets provide family-friendly options earlier in the evening.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamecity Hamburg, Indie Treff, and the Prototype Fund community connect developers, though the network is tighter than Berlin’s.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "InnoGames, Goodgame Studios, Bytro, and Daedalic offer networking touchpoints, supplemented by smaller VR and mobile teams.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Gamecity Hamburg’s Prototype Funding, plus federal grants, supply seed capital and mentorship for new studios.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Workdays are efficient, yet waterfront promenades and Sunday quiet time slow the overall pace to something calmer than Berlin.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools encourage active Elternrat participation and shared holiday planning, with strong buy-in from both parents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Reforms allow naturalization after five years (three with integration milestones), and Hamburg’s offices keep processing predictable.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Germany scores well on corruption indices, and Hamburg media quickly exposes procurement or port contracting issues.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Germany’s federal parliamentary system with proportional representation and coalition governance keeps policy shifts measured.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Poly-friendly therapists and meetups exist, mainly clustered around St. Pauli and Sternschanze; social acceptance is solid though quieter than Berlin.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Kitas accept children from age one with city vouchers, but staffing gaps mean applying early and considering Tagesmutter bridges.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International schools like Phorms or International School of Hamburg offer English curricula with €15k+ tuition, so they’re plan B options.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Hamburg politics blend social-democratic and green priorities—climate action, renter protections, and LGBTQ+ rights stay front and center.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters present balanced reporting; sensational tabloids are easy to filter out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "State influence is minimal, and independent outlets like NDR and Zeit keep information pluralistic.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The HVV network of U-Bahn, S-Bahn, ferries, and buses plus the €49 Deutschlandticket covers most needs, though late-night frequencies drop outside the core.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Religious rhetoric rarely shapes policy; debates focus more on social housing and port strategy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid work is common in tech and media; coworking spaces like Mindspace and betahaus provide flexible desks, though options are fewer than Berlin.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years with early permanent residence after 33 months (21 with B1 German); freelancers can secure permits with client letters and insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions plus company plans from logistics giants keep retirees stable, though housing costs encourage extra savings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants vest after five contribution years, and U.S.-Germany agreements protect credits if the family returns to America.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Long-term visa holders accrue pension rights but must stay vested or secure permanent residency to retain full benefits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Rails roles exist in media, logistics, and e-commerce teams like About You, but the market is smaller than Berlin’s, making networking key.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Hamburg feels safe in residential districts; petty theft clusters around Reeperbahn nightlife, while violent crime stays low.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Families choose between Stadtteilschulen, Gymnasien, and bilingual programs like Ida Ehre; transitions require active parent coordination.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Elbe waters stay cool, but Baltic beaches reach 18–21 °C (64–70 °F) in midsummer—refreshing yet swimmable.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Maritime weather brings mild winters, frequent drizzle, and summers around 22–24 °C (72–75 °F) with low humidity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Hamburg’s Reeperbahn history and comprehensive sex education foster open, consent-focused attitudes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Hamburg invests heavily in public housing, transit, and climate resilience while aligning with Germany’s strong welfare model.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March starts near 8 °C (46 °F) and May reaches 17 °C (63 °F) with breezy showers—mild compared with continental Europe.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany’s diversified economy and EU backing keep Hamburg stable even when global shipping slows.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Hamburg’s coalition blends Social Democrats and Greens, emphasizing climate-neutral port operations and social equity.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Strong unions and co-determination coexist with competitive port businesses, giving Trey room to build a studio without wild market swings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Highs hover between 22–26 °C (72–79 °F); nights cool to 14 °C (57 °F), keeping heat manageable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing generally takes 8–10 weeks with €100–€140 in fees plus certified translations of degrees.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Citizen surveys show solid trust in Hamburg’s senate and federal ministries, supported by transparent budgeting.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Occasional procurement favoritism or port lobbying issues surface, but ombudsman offices and courts respond quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers earn €75k–€85k at logistics and aviation firms, reaching €90k+ with cloud leadership or maritime IT expertise.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends include Alster bike rides, Planten un Blomen parks, and ferry trips; Sundays encourage museums or board games due to store closures.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools start around 8 a.m., Kita care runs until 5 p.m., and hybrid teams respect logging off by early evening.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Employees receive the federal 20-day minimum plus Hamburg’s 9 public holidays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Logistics and tech firms commonly grant 28–30 days off with extra port shutdown days around Christmas.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Hamburg’s trade ties foster a cooperative view of Denmark, Scandinavia, and the Netherlands.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Hamburgers view their city as a Hanseatic, maritime metropolis that balances commerce with culture.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Hamburg as a reliable trading partner—efficient but sometimes formal.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, skilled worker visas, Chancenkarte, and artist permits are processed through Hamburg Welcome Center with organized checklists.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Relocation agencies, international schools, and port-area expat networks help newcomers, though competitive housing is a hurdle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Hamburg combines maritime commerce, vibrant music scenes, and quick access to the Baltic—offering career stability with coastal leisure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect −1 to 6 °C (30–43 °F) with damp air but limited snow; coastal winds make it feel cooler than the thermometer.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Collective agreements target 37.5–40 hours, and port unions enforce clear overtime rules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Hybrid schedules, mandated vacation, and waterfront recreation give the family ample downtime.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Works councils, strong unions, and enforceable leave policies support employees in pushing back on unreasonable demands.",
+      "alignmentValue": 9
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Berlin city report with refreshed alignment values across all evaluation keys
- add a Hamburg city report detailing port economy strengths, childcare access, and transit trade-offs
- add a Cologne city report covering media-sector jobs, Karneval culture, and family services while registering each city in main.json

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3320bd82083218e26078abf1700d0