### PR TITLE
Add Dublin, Cork, and Galway city reports for Ireland

### DIFF
--- a/main.json
+++ b/main.json
@@ -502,7 +502,21 @@
   "Countries": [
     {
       "name": "Ireland",
-      "file": "reports/ireland_report.json"
+      "file": "reports/ireland_report.json",
+      "cities": [
+        {
+          "name": "Dublin",
+          "file": "reports/ireland_dublin_report.json"
+        },
+        {
+          "name": "Cork",
+          "file": "reports/ireland_cork_report.json"
+        },
+        {
+          "name": "Galway",
+          "file": "reports/ireland_galway_report.json"
+        }
+      ]
     },
     {
       "name": "China",

--- a/reports/ireland_cork_report.json
+++ b/reports/ireland_cork_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "IE",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "We trade urban hills and the River Lee’s tidal views for quick drives into lush West Cork countryside, so daily life balances city amenities with easy green escapes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Rising precipitation and storm intensity; coastal flooding risk; less extreme heat than continental Europe.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Oceanic—cool summers, mild winters, frequent rain/overcast; long summer daylight, short winter days.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Atlantic breezes keep Cork’s PM2.5 near 10 µg/m³, with only brief spikes when smoky-fuel bans lapse in winter estates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Low seismic risk; Atlantic storms possible; robust building standards.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 8-15 C (46-59 F); frequent light rain; humidity moderate; longer daylight Mar-May.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 15-20 C (59-68 F); occasional 22-25 C (72-77 F); generally low to moderate humidity; cool evenings.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 9-14 C (48-57 F); increasing rain/wind from October; daylight shortens steadily.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 4-8 C (39-46 F); rare deep freezes; damp cold with occasional frost/sleet; snow uncommon outside uplands.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Inchydoney, Garretstown, and Fountainstown beaches are 30–45 minutes away, with surf schools and cold-water swimming clubs for hardy weekends.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Roughly warmest Jul–Sep; otherwise chilly; wetsuits common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "West Cork’s peninsulas, Cobh’s harbor, and nearby Ballyhoura forests give us postcard views without long road trips.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.70 minimum wage is well-enforced, yet it trails the Living Wage (~€14) and can’t comfortably cover Dublin housing or childcare, so entry-level families feel squeezed.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers in Cork typically land €75–95k packages—less than Dublin but enough to fund a comfortable lifestyle if we keep housing costs in check.",
+      "alignmentValue": 7
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Apple’s European HQ, Johnson Controls, and VMware give Cork steady .NET demand, though roles skew toward enterprise support and expect some on-site weeks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Niche demand concentrated in startups and some fintech/SaaS firms; roles appear irregularly and often expect polyglot skills.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Common for ICT roles via Critical Skills; reliable processes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Low unemployment; GDP volatile due to multinationals; high cost of living.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Republic of Work, Plus10, and strong broadband make hybrid work easy, and many multinationals are comfortable with remote-first teams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "EU norms for leave and hours; team culture varies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Legal max 48; typical around 39–40 in many sectors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "At least 4 weeks annually (plus public holidays).",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech often 23–25+ days, varies by employer.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Commutes rarely top 25 minutes and shops still close earlier on Sundays, so Cork’s rhythm leaves space for slow dinners and bedtime stories.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "School drops around 08:40 and compact commutes keep most offices on a 09:00–17:30 rhythm, with after-school clubs and GAA training covering the 15:00–18:00 gap.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends rotate between Marina Market brunches, day trips to Cobh or Kinsale, and kids’ sports—planning mostly depends on weather rather than reservations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Fitzgerald Park, the Lifetime Lab, and compact school catchments make day-to-day parenting smoother than in larger metros.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Poly Ireland meetups swing through Cork and there’s overlap with the queer kink community, yet privacy still matters with schools and landlords.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Balanced; extracurriculars common; independence encouraged; verify school‑home load.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Traffic-calmed quays, new playgrounds, and family-friendly cafés in Douglas and Bishopstown support stroller life without big-city stress.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "English‑medium public schools; many with Catholic patronage; limited international schools; Irish taught.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "ECCE hours are easy to claim, yet full-day infant care has limited slots—many families blend creches with part-time childminders.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "National Childcare Scheme hourly subsidies; Child Benefit monthly; paid maternity benefit (PRSI-based), paternity and parents leave.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "NCS available to legally resident families with PPSN; supports generally residency/PRSI-based; documentation and status checks apply.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens usually secure seats locally, yet high-demand campuses like Educate Together or Presentation require early applications.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Once we secure a PPS number and address, schools accommodate newcomers, but popular city schools may offer temporary places while waiting for permanent spots.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Cork has a handful of fee-paying schools and international programs, but places are limited and tuition hovers near €10–15k.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "26+ weeks maternity benefit (PRSI-based), paternity leave, about 9 weeks parents leave; child benefit; flexible work practices rising.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Many supports tied to residence and PRSI contributions; some benefits require Habitual Residence Condition; check specific status.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Free Fees Initiative for eligible undergrads; SUSI grants based on income; wide HE options in Dublin/Cork/Galway/Limerick.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU often pay international fees; scholarships limited; pathways improve after longer residence or PR/EU status.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Increasingly egalitarian; traditional norms persist in pockets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Visible in urban areas; acceptance growing.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Strong legal protections; parental leave improving; confirm details.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Broadly flexible; safety relatively high.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Evolving; caregiving more normalized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "West Cork food trails, the Jazz Festival, and easy access to both coastlines and countryside keep Cork feeling adventurous without big-city overwhelm.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominant; Irish is co‑official; high English proficiency.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Significant liberal shifts (e.g., marriage equality, reproductive rights) alongside some conservative currents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Niche in discourse; mainstream politics centrist/center‑left/right mix.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secularization advanced; Church influence diminished but present in schools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Generally moderate‑liberal; sex‑ed improving; verify local norms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Cork Pride, Loafers’ queer nights, and inclusive community centers keep acceptance visible even if the scene is smaller than Dublin’s.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighborhood coffee mornings, strong GAA clubs, and a slower turnover of expats make it easier to feel known after a few months.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Friendly, resilient, proud of heritage; outward-looking and pragmatic.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Positive toward EU partners; close but complex relationship with the UK.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Often seen as friendly, welcoming, and culturally rich.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Pub culture is lively but concentrated downtown, so we plan taxis or designated drivers once the last buses stop around midnight.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart-casual layers and waterproof outerwear; clean sneakers/boots; understated tailoring for nights out.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Smart-casual with practical outerwear; midi dresses/knits, boots/sneakers; modest to contemporary looks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Sea swimming clubs, Munster rugby fandom, and foodie weekends in Kinsale match our outdoor and community interests.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Tabletop Cork, UCC societies, and Warpcon keep the tabletop calendar full, giving Trey plenty of playtest partners and family-friendly events.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Live music thrives at Cyprus Avenue and the Crane Lane, and the Jazz Festival anchors the calendar, but late-night options taper after midnight.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Cork’s tech, maker, and parenting meetups gather weekly around Republic of Work and UCC, though options thin out compared with Dublin’s nightly roster.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Commuter buses and short drives put Kinsale coves and Gougane Barra hikes within an hour, so outdoor days are simple to plan when the rain breaks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Parliamentary republic; PR‑STV voting; multiparty coalition governance common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Generally secular governance; residual church influence in education/health.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "EU standards; unions present; termination processes regulated; non‑competes limited/enforceability varies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Market‑friendly with social supports; strong MNC presence.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Low; independent media/judiciary; EU member checks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Open economy; corporate tax reforms ongoing per OECD.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "High political and economic stability; protest risk low‑moderate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Low systemic propaganda; normal political messaging.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Focus on economy, services, housing; standard partisan frames.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Robust anti‑discrimination; LGBTQ+ legal recognition; reproductive rights.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Moderate; varies with housing/health outcomes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Low by EU standards; transparency relatively strong.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "More administrative/planning than overt; enforcement present.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family houses in Douglas or Ballincollig still hit €2,200–€2,600 and go fast, but stock is less cutthroat than Dublin if we widen our search to commuter villages.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Cork feels safe, with occasional late-night scuffles around Washington Street the main concern.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Public system with long queues for some services; many carry private insurance.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Private insurance often required; access to public services depends on residency status—verify specifics.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Cork creches benefit from NCS subsidies, but limited infant places mean we join waitlists early and lean on childminders when illnesses strike.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Supports for families; verify benefits by status and income.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Gaelscoileanna and Educate Together campuses deliver strong academics, though admission lotteries mean we plan early for preferred ethos.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "BusConnects upgrades are coming, yet today we rely on the Bus Éireann spine plus some suburban routes; most families keep a car for school runs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Open market economy with EU social protections.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "PAYE with USC and PRSI; yearly self‑assessment if needed; credits for couples.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Progressive bands; mid‑to‑high effective rates when including USC/PRSI—model scenarios.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Opening accounts generally requires photo ID and proof of Irish address; a PPSN is helpful but not always mandatory. Retail banks plus fintechs support widespread contactless payments.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and childcare run below Dublin levels, yet €1,000-plus creche fees and higher energy costs still soak up much of a single salary.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "State Pension (Contributory) from about 66 with sufficient PRSI; occupational/private pillars common; EU portability good.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Eligibility depends on PRSI contributions and residence; private/occupational schemes portable; state benefits require contributions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Critical Skills Employment Permit (CSEP), General Employment Permit (GEP), intra‑company transfer, student, family routes; Startup programmes via Enterprise Ireland.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Generally positive; high presence of US companies; straightforward processes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Stamps (1/1G/4 etc.); CSEP can lead to Stamp 4 after a period; GEP longer path.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalisation typically after ~5 years of reckonable residence (with continuity requirements); dual citizenship allowed.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Partner work authorization often available (e.g., Stamp 1G with CSEP spouse); confirm current policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing times vary by route; expect weeks to months; fees apply.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Track tax residency days; keep GNIB/IRP renewals current; maintain health insurance as required.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes - dual nationality permitted; subject to other country rules.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "GNIB/IRP registration, PPSN, address proof; track tax residence days; private health cover early on; rights vary by stamp.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Cork’s game scene leans on indie studios, university labs, and occasional support teams, so Trey would mix contract gigs with remote work to stay busy.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "[Keywords Studios](https://www.keywordsstudios.com) (HQ Dublin), [Vela Games](https://velagames.com) (Dublin), [WarDucks](https://warducks.com) (AR/VR); plus indies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "[Imirt — Irish Game Makers](https://www.imirt.ie) (national association/network).",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Nimbus Research Centre, local enterprise offices, and the GameCraft network offer mentorship, yet funding rounds still require trips to Dublin or London.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "SIRO fiber, resilient power, and ongoing Docklands upgrades deliver modern comforts despite some Victorian pipes still needing replacement.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/ireland_dublin_report.json
+++ b/reports/ireland_dublin_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "IE",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "The Liffey corridor is urban and paved, yet within a DART ride we can reach Howth cliffs or Phoenix Park meadows, so the environmental trade-off is density versus nearby green escapes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Rising precipitation and storm intensity; coastal flooding risk; less extreme heat than continental Europe.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Oceanic—cool summers, mild winters, frequent rain/overcast; long summer daylight, short winter days.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Annual PM2.5 hovers around 13 µg/m³ along the quays thanks to traffic and smoky-fuel bans still phasing in, so we’d keep an AQI app handy for the occasional winter inversion.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Low seismic risk; Atlantic storms possible; robust building standards.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 8-15 C (46-59 F); frequent light rain; humidity moderate; longer daylight Mar-May.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 15-20 C (59-68 F); occasional 22-25 C (72-77 F); generally low to moderate humidity; cool evenings.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 9-14 C (48-57 F); increasing rain/wind from October; daylight shortens steadily.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 4-8 C (39-46 F); rare deep freezes; damp cold with occasional frost/sleet; snow uncommon outside uplands.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Dollymount Strand, Killiney, and the Forty Foot are swift DART trips, but chilly Irish Sea water and frequent red-flag days keep swims seasonal for wetsuit lovers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Roughly warmest Jul–Sep; otherwise chilly; wetsuits common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Dublin’s charm is mostly Georgian streets and coastal cliffs; real alpine drama waits in Wicklow, so weekend trains or car-shares become part of our nature fix.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.70 minimum wage is well-enforced, yet it trails the Living Wage (~€14) and can’t comfortably cover Dublin housing or childcare, so entry-level families feel squeezed.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Total compensation for Dublin senior engineers routinely reaches €90–120k plus bonuses or equity, yet sky-high rents mean we’d still need to budget carefully to stay ahead each month.",
+      "alignmentValue": 8
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Dublin’s docklands keep Microsoft, HubSpot, Stripe, and a dozen consultancies hiring senior .NET engineers, so Trey can jump straight into cloud rebuilds while building founder relationships.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Niche demand concentrated in startups and some fintech/SaaS firms; roles appear irregularly and often expect polyglot skills.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Common for ICT roles via Critical Skills; reliable processes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Low unemployment; GDP volatile due to multinationals; high cost of living.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Huckletree, WeWork, and dog-friendly cafés with fiber make remote work frictionless, and most Dublin employers now budget hybrid setups by default.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "EU norms for leave and hours; team culture varies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Legal max 48; typical around 39–40 in many sectors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "At least 4 weeks annually (plus public holidays).",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech often 23–25+ days, varies by employer.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Commuters pack the Luas before 8:30 and school drop-offs jockey for curb space, so we’d block calendar buffers to keep Dublin’s hustle from bleeding into family time.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Primary drop-off around 08:50, Luas rides into Docklands for 09:30 standups, and after-school clubs until 17:45 mean dinners land close to 19:00 unless we meal-prep.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays swing between farmers’ markets in Marley Park, kids’ GAA in the Phoenix Park, and museum trips timed around rain bands; Sundays often end with an early roast and board games.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Phoenix Park, Imaginosity, and free national museums are weekend staples, yet cramped housing and rain squalls limit spontaneous backyard play.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Poly Coffee, Relationship Anarchy Ireland, and kink-friendly community spaces operate openly in Dublin, but schools and immigration paperwork still assume two parents.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Balanced; extracurriculars common; independence encouraged; verify school‑home load.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Safe-feeling neighborhoods and playground upgrades around Stoneybatter help, but pram access on buses and limited apartment storage keep family logistics tight.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "English‑medium public schools; many with Catholic patronage; limited international schools; Irish taught.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "ECCE hours are guaranteed, yet full-day creches in Dublin 2–8 book out before birth, so au pairs or childminders often bridge the gap until primary school.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "National Childcare Scheme hourly subsidies; Child Benefit monthly; paid maternity benefit (PRSI-based), paternity and parents leave.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "NCS available to legally resident families with PPSN; supports generally residency/PRSI-based; documentation and status checks apply.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens can secure seats, yet Dublin’s catchment boundaries and Catholic patronage mean we’d navigate waitlists or commuter runs to reach a secular Educate Together school.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Visa holders enroll once they show proof of address and PPS numbers, but oversubscribed city schools push many newcomers into temporary offers or longer commutes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International schools like St. Andrew’s and Nord Anglia exist, but €15k+ tuition and limited slots keep them a selective backup plan.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "26+ weeks maternity benefit (PRSI-based), paternity leave, about 9 weeks parents leave; child benefit; flexible work practices rising.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Many supports tied to residence and PRSI contributions; some benefits require Habitual Residence Condition; check specific status.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Free Fees Initiative for eligible undergrads; SUSI grants based on income; wide HE options in Dublin/Cork/Galway/Limerick.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU often pay international fees; scholarships limited; pathways improve after longer residence or PR/EU status.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Increasingly egalitarian; traditional norms persist in pockets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Visible in urban areas; acceptance growing.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Strong legal protections; parental leave improving; confirm details.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Broadly flexible; safety relatively high.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Evolving; caregiving more normalized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Literary festivals, indie tech meetups, and quick Ryanair hops across Europe keep Dublin feeling both cosmopolitan and neighborly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominant; Irish is co‑official; high English proficiency.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Significant liberal shifts (e.g., marriage equality, reproductive rights) alongside some conservative currents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Niche in discourse; mainstream politics centrist/center‑left/right mix.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secularization advanced; Church influence diminished but present in schools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Generally moderate‑liberal; sex‑ed improving; verify local norms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Dublin Pride, gender-affirming clinics, and queer-owned cafés give the kids normalized exposure to inclusive culture most days of the week.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Local GAA clubs and parent WhatsApp groups welcome newcomers, but high rents and expat churn mean friendships take deliberate follow-through.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Friendly, resilient, proud of heritage; outward-looking and pragmatic.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Positive toward EU partners; close but complex relationship with the UK.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Often seen as friendly, welcoming, and culturally rich.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Late pubs, queer nights at Mother, and 2am closing times make for lively weekends, but crowds and limited late-night transit keep us planning rides home.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart-casual layers and waterproof outerwear; clean sneakers/boots; understated tailoring for nights out.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Smart-casual with practical outerwear; midi dresses/knits, boots/sneakers; modest to contemporary looks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Sea swimming at the Forty Foot, parkruns in St. Anne’s, and climbing walls like Awesome Walls fit our routines alongside the ever-present pub quiz circuit.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Gamers World, The Clockwork Door, and meetup-led RPG nights in Smithfield give Trey instant playtest tables and English-friendly campaigns any night of the week.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Whelan’s, Tradfest, and late pub gigs keep live music thriving, with comedy basements and queer club nights ensuring Sarah still gets adult evenings after bedtime routines.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech, parenting, LGBTQ+, and poly meetups pop up nightly around Dublin’s coworking hubs, so integrating into new circles mostly means choosing which Slack invite to accept.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "DART, Luas, and GoCar make it easy to bounce from city center to Howth headlands or Wicklow trails, but slots book up fast on sunny weekends.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Parliamentary republic; PR‑STV voting; multiparty coalition governance common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Generally secular governance; residual church influence in education/health.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "EU standards; unions present; termination processes regulated; non‑competes limited/enforceability varies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Market‑friendly with social supports; strong MNC presence.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Low; independent media/judiciary; EU member checks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Open economy; corporate tax reforms ongoing per OECD.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "High political and economic stability; protest risk low‑moderate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Low systemic propaganda; normal political messaging.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Focus on economy, services, housing; standard partisan frames.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Robust anti‑discrimination; LGBTQ+ legal recognition; reproductive rights.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Moderate; varies with housing/health outcomes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Low by EU standards; transparency relatively strong.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "More administrative/planning than overt; enforcement present.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Three-bedroom rentals in family-friendly neighborhoods like Ranelagh or Clontarf routinely top €3,200 monthly and trigger bidding wars, so landing a lease means compromises on space or commute.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Central Dublin feels safe by US standards, though teen antisocial behavior near O’Connell Street and occasional protests mean we stay alert on late DART rides.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Public system with long queues for some services; many carry private insurance.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Private insurance often required; access to public services depends on residency status—verify specifics.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "National subsidies help, but popular Dublin creches have year-long waitlists and charge €1,100–€1,400 for infants even after the NCS credit, so backup carers are essential.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Supports for families; verify benefits by status and income.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Dublin’s primary schools deliver strong literacy and coding clubs, but denominational patronage and oversubscribed Educate Together campuses require early applications.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The DART, Luas, and dense bus network cover our daily needs, yet BusConnects construction and evening gaps still mean the family keeps Leap cards and occasional car-share credits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Open market economy with EU social protections.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "PAYE with USC and PRSI; yearly self‑assessment if needed; credits for couples.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Progressive bands; mid‑to‑high effective rates when including USC/PRSI—model scenarios.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Opening accounts generally requires photo ID and proof of Irish address; a PPSN is helpful but not always mandatory. Retail banks plus fintechs support widespread contactless payments.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Dublin stacks Dublin Airport convenience against €6 lattes, €1,600 infant creche fees, and high energy bills, leaving limited room for savings unless we command top-tier pay.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "State Pension (Contributory) from about 66 with sufficient PRSI; occupational/private pillars common; EU portability good.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Eligibility depends on PRSI contributions and residence; private/occupational schemes portable; state benefits require contributions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Critical Skills Employment Permit (CSEP), General Employment Permit (GEP), intra‑company transfer, student, family routes; Startup programmes via Enterprise Ireland.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Generally positive; high presence of US companies; straightforward processes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Stamps (1/1G/4 etc.); CSEP can lead to Stamp 4 after a period; GEP longer path.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalisation typically after ~5 years of reckonable residence (with continuity requirements); dual citizenship allowed.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Partner work authorization often available (e.g., Stamp 1G with CSEP spouse); confirm current policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing times vary by route; expect weeks to months; fees apply.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Track tax residency days; keep GNIB/IRP renewals current; maintain health insurance as required.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes - dual nationality permitted; subject to other country rules.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "GNIB/IRP registration, PPSN, address proof; track tax residence days; private health cover early on; rights vary by stamp.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Keywords Studios, Vela Games, Riot’s support teams, and indie collectives around The Digital Hub make Dublin the country’s densest game-dev scene, though roles still cycle in bursts.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "[Keywords Studios](https://www.keywordsstudios.com) (HQ Dublin), [Vela Games](https://velagames.com) (Dublin), [WarDucks](https://warducks.com) (AR/VR); plus indies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "[Imirt — Irish Game Makers](https://www.imirt.ie) (national association/network).",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Enterprise Ireland grants, Dogpatch Labs accelerators, and easy networking with ex-Riot or EA staff give a Dublin studio launch a credible funding and mentorship path.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber, 5G, and a resilient power grid backed by hyperscale data centers keep downtime rare even in older terraces.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/ireland_galway_report.json
+++ b/reports/ireland_galway_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "IE",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "We get a compact harbor city edged by Lough Corrib wetlands, trading urban amenities for quick access to wild landscapes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Rising precipitation and storm intensity; coastal flooding risk; less extreme heat than continental Europe.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Oceanic—cool summers, mild winters, frequent rain/overcast; long summer daylight, short winter days.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Atlantic winds and low traffic keep PM2.5 near 7 µg/m³, with only peat smoke in rural pockets nudging AQI alerts.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Low seismic risk; Atlantic storms possible; robust building standards.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 8-15 C (46-59 F); frequent light rain; humidity moderate; longer daylight Mar-May.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 15-20 C (59-68 F); occasional 22-25 C (72-77 F); generally low to moderate humidity; cool evenings.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 9-14 C (48-57 F); increasing rain/wind from October; daylight shortens steadily.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Typical daytime 4-8 C (39-46 F); rare deep freezes; damp cold with occasional frost/sleet; snow uncommon outside uplands.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Salthill Prom and Silverstrand deliver easy swims and kid-friendly promenades, but cold water and frequent rain shorten beach windows.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Roughly warmest Jul–Sep; otherwise chilly; wetsuits common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Connemara, the Burren, and the Aran Islands sit on Galway’s doorstep, giving us cinematic landscapes without long drives.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.70 minimum wage is well-enforced, yet it trails the Living Wage (~€14) and can’t comfortably cover Dublin housing or childcare, so entry-level families feel squeezed.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Galway senior developer salaries hover around €70–85k, stretching well with two incomes but feeling tight if we rely on a single salary and face high rents.",
+      "alignmentValue": 6
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Medtech anchors like Boston Scientific and analog industries hire .NET talent in Galway, but openings ebb once big projects ship, so Trey may pair local contracts with remote clients.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Niche demand concentrated in startups and some fintech/SaaS firms; roles appear irregularly and often expect polyglot skills.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Common for ICT roles via Critical Skills; reliable processes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Low unemployment; GDP volatile due to multinationals; high cost of living.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "PorterShed’s coworking space, SIRO fiber, and a remote-friendly talent pool make hybrid work straightforward.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "EU norms for leave and hours; team culture varies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Legal max 48; typical around 39–40 in many sectors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "At least 4 weeks annually (plus public holidays).",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech often 23–25+ days, varies by employer.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Traffic backs up on the Quincentenary Bridge, but otherwise Galway’s rhythm is strolls along the Prom and manageable commutes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "School starts near 09:00 and many employers embrace 09:00–17:00 schedules, with after-school clubs at Leisureland or community centers covering late afternoons.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends mix Galway Market runs, Salthill walks, and quick drives to Connemara; we mostly watch the forecast rather than tickets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Leisureland, Salthill playgrounds, and the Explorium-style Galway Atlantaquaria offer solid kid venues, though weather keeps us scheduling indoor backups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Poly Galway meetups and overlapping queer networks exist, but discretion remains wise when dealing with schools or rural relatives.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Balanced; extracurriculars common; independence encouraged; verify school‑home load.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Compact neighborhoods and school walking buses help, yet narrow footpaths and limited indoor play spaces require planning with strollers.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "English‑medium public schools; many with Catholic patronage; limited international schools; Irish taught.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "ECCE slots are dependable, while full-day infant care requires joining waitlists well before relocation and considering childminders.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "National Childcare Scheme hourly subsidies; Child Benefit monthly; paid maternity benefit (PRSI-based), paternity and parents leave.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "NCS available to legally resident families with PPSN; supports generally residency/PRSI-based; documentation and status checks apply.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens usually place kids locally, but popular Educate Together and Gaelscoil campuses rely on waitlists and lotteries.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Visa holders can enroll once paperwork is sorted, yet high demand may route newcomers to temporary or suburban schools until places free up.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Galway offers few private or international school options, so alternatives beyond the public system are limited.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "26+ weeks maternity benefit (PRSI-based), paternity leave, about 9 weeks parents leave; child benefit; flexible work practices rising.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Many supports tied to residence and PRSI contributions; some benefits require Habitual Residence Condition; check specific status.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Free Fees Initiative for eligible undergrads; SUSI grants based on income; wide HE options in Dublin/Cork/Galway/Limerick.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU often pay international fees; scholarships limited; pathways improve after longer residence or PR/EU status.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Increasingly egalitarian; traditional norms persist in pockets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Visible in urban areas; acceptance growing.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Strong legal protections; parental leave improving; confirm details.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Broadly flexible; safety relatively high.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Evolving; caregiving more normalized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Galway Arts Festival, Gaeltacht immersion, and weekend escapes to Connemara give the city an endlessly creative, outdoorsy edge.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominant; Irish is co‑official; high English proficiency.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Significant liberal shifts (e.g., marriage equality, reproductive rights) alongside some conservative currents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Niche in discourse; mainstream politics centrist/center‑left/right mix.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secularization advanced; Church influence diminished but present in schools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Generally moderate‑liberal; sex‑ed improving; verify local norms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Galway Pride, Teach Solais community center, and inclusive arts spaces make queer life visible despite the city’s size.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighborhood markets, Gaeltacht connections, and schools that know families by name create a welcoming, small-town feel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Friendly, resilient, proud of heritage; outward-looking and pragmatic.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Positive toward EU partners; close but complex relationship with the UK.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Often seen as friendly, welcoming, and culturally rich.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "The Latin Quarter stays lively with trad bars and late cafés, though night buses are sparse so we plan taxis home.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart-casual layers and waterproof outerwear; clean sneakers/boots; understated tailoring for nights out.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Smart-casual with practical outerwear; midi dresses/knits, boots/sneakers; modest to contemporary looks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Sea swimming clubs, trad music circles, and climbing at Ballybrit keep both adults and kids active despite rainy spells.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Dungeons & Donuts café, Itsa Trap events, and NUIG societies keep tabletop nights lively for both adults and kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Buskers fill Shop Street, Trad sessions hum in Tig Coili, and Galway International Arts Festival packs the calendar even if venues close earlier than Dublin.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "PorterShed, Galway Tech Meetup, and vibrant arts collectives make it easy to plug into tech, creative, and family circles.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "A 20–40 minute drive or Bus Éireann ride gets us to Connemara hikes, bog boardwalks, or the River Corrib, so outdoor resets stay spontaneous.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Parliamentary republic; PR‑STV voting; multiparty coalition governance common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Generally secular governance; residual church influence in education/health.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "EU standards; unions present; termination processes regulated; non‑competes limited/enforceability varies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Market‑friendly with social supports; strong MNC presence.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Low; independent media/judiciary; EU member checks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Open economy; corporate tax reforms ongoing per OECD.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "High political and economic stability; protest risk low‑moderate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Low systemic propaganda; normal political messaging.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Focus on economy, services, housing; standard partisan frames.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Robust anti‑discrimination; LGBTQ+ legal recognition; reproductive rights.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Moderate; varies with housing/health outcomes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Low by EU standards; transparency relatively strong.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "More administrative/planning than overt; enforcement present.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "University demand and short-term lets keep three-bed rentals above €2,200 and scarce, forcing families to expand searches to suburbs like Oranmore or Moycullen.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Galway feels safe day and night, with occasional rowdy student nights downtown the main watchout.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Public system with long queues for some services; many carry private insurance.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Private insurance often required; access to public services depends on residency status—verify specifics.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Galway creches leverage NCS subsidies, yet limited infant spots and teacher shortages push many families toward part-time childminders.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Supports for families; verify benefits by status and income.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Galway primary schools deliver strong academics with Irish-language immersion options, though enrollment pressure from university families means planning ahead.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "City buses and regional coaches cover main corridors, yet irregular timetables and limited evening service mean a car or cargo bike remains handy.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Open market economy with EU social protections.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "PAYE with USC and PRSI; yearly self‑assessment if needed; credits for couples.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Progressive bands; mid‑to‑high effective rates when including USC/PRSI—model scenarios.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Opening accounts generally requires photo ID and proof of Irish address; a PPSN is helpful but not always mandatory. Retail banks plus fintechs support widespread contactless payments.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Everyday costs are moderate, but high rents, childcare waitlists, and fuel for regular West Coast drives soak up savings quickly.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "State Pension (Contributory) from about 66 with sufficient PRSI; occupational/private pillars common; EU portability good.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Eligibility depends on PRSI contributions and residence; private/occupational schemes portable; state benefits require contributions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Critical Skills Employment Permit (CSEP), General Employment Permit (GEP), intra‑company transfer, student, family routes; Startup programmes via Enterprise Ireland.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Generally positive; high presence of US companies; straightforward processes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Stamps (1/1G/4 etc.); CSEP can lead to Stamp 4 after a period; GEP longer path.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalisation typically after ~5 years of reckonable residence (with continuity requirements); dual citizenship allowed.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Partner work authorization often available (e.g., Stamp 1G with CSEP spouse); confirm current policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing times vary by route; expect weeks to months; fees apply.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Track tax residency days; keep GNIB/IRP renewals current; maintain health insurance as required.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes - dual nationality permitted; subject to other country rules.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "GNIB/IRP registration, PPSN, address proof; track tax residence days; private health cover early on; rights vary by stamp.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Romero Games, Nine Dots, and Ardán-backed indies keep a scrappy game-dev scene alive, yet roles are limited enough that networking at game jams is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "[Keywords Studios](https://www.keywordsstudios.com) (HQ Dublin), [Vela Games](https://velagames.com) (Dublin), [WarDucks](https://warducks.com) (AR/VR); plus indies.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "[Imirt — Irish Game Makers](https://www.imirt.ie) (national association/network).",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "PorterShed, Ardán’s ScreenWest hub, and ATU game incubators provide mentorship and space, though we still chase national grants for sizable funding.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber reaches much of the city, yet storm drains and occasional outages remind us the infrastructure still catches up to growth.",
+      "alignmentValue": 7
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Dublin city report with revised alignment scores for housing pressure, public transport, childcare access, and tech ecosystems
- add a Cork city report capturing family-friendly pace, coastal recreation, and available childcare and schooling options
- add a Galway city report highlighting creative culture, nature access, and the medtech-driven job market, and register all three cities under Ireland in the index

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e33239c68083218a8043cb649659aa