### PR TITLE
Add Amsterdam, Utrecht, and Eindhoven city reports

### DIFF
--- a/main.json
+++ b/main.json
@@ -608,7 +608,21 @@
     },
     {
       "name": "Netherlands",
-      "file": "reports/netherlands_report.json"
+      "file": "reports/netherlands_report.json",
+      "cities": [
+        {
+          "name": "Amsterdam",
+          "file": "reports/netherlands_amsterdam_report.json"
+        },
+        {
+          "name": "Utrecht",
+          "file": "reports/netherlands_utrecht_report.json"
+        },
+        {
+          "name": "Eindhoven",
+          "file": "reports/netherlands_eindhoven_report.json"
+        }
+      ]
     },
     {
       "name": "Ecuador",

--- a/reports/netherlands_amsterdam_report.json
+++ b/reports/netherlands_amsterdam_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "NL",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "In Amsterdam, Dutch spatial planning lets this park-seeking family bike to clean canals, urban forests, and well-managed green belts even in dense metros. Nitrogen-intensive farming belts still strain biodiversity, so weekend outings sometimes shift toward protected dunes and wetlands.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "In Amsterdam, Sea-level rise remains the headline risk for a below-sea-level home, yet the fully funded Delta Programme and constant dike upgrades keep near-term danger manageable for the family. We would still budget for flood insurance and monitor adaptation policies before buying property in reclaimed polders.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "In Amsterdam, the marine climate hits the family's mild-temperature preference, but long stretches of drizzle and grey skies each shoulder season limit spontaneous outdoor plans. Reliable rain gear and indoor kid activities are essential half the year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "In Amsterdam, EU emission rules keep daily PM2.5 low enough for the kids' outdoor play and parents' cycling commutes. We only watch for occasional nitrogen spikes near ports or dairy clusters before planning long rides.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "In Amsterdam, there is virtually no quake or wildfire threat, and world-class flood controls align with the family's low-risk tolerance. Storm surges are rare but we would follow municipal alerts when renting near rivers or the North Sea.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "In Amsterdam, March and April swing between jacket weather and cold rain, so the family alternates playground days with museum trips. By May the 6-16°C range turns pleasant, matching their bike-friendly goals.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "In Amsterdam, typical highs sit around 21-24°C, letting the family enjoy parks and festivals without AC. Brief humid heatwaves over 30°C pop up, so we plan cooling breaks during rare continental air masses.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "In Amsterdam, September starts crisp, but by October steady rain and 8-16°C temps mean we juggle layered clothing for school runs. The family's preference for predictable outdoor time requires flexible weekend plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "In Amsterdam, winters hover 0-6°C with damp winds, so the family needs solid rain gear more than snow shovels. Occasional freezing rain can snarl transit, but long deep freezes are rare compared with the US Midwest.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Zandvoort and Bloemendaal aan Zee sit 30 minutes away by train, giving the family breezy dune walks, cafes, and kid-friendly beach clubs. Water stays chilly most of the year, so swimsuits come out mainly during rare August heat spikes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "North Sea temperatures near Amsterdam peak around 17–19 °C in late summer, which keeps swims short for the kids. The rest of the year the shoreline serves more for kite flying and beach playgrounds than long dips.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Amsterdam balances canal vistas, the leafy Amsterdamse Bos, and quick access to Waterland's wetlands for birding weekends. Serious hikes still mean a train to Veluwezoom or Belgium, so the family leans on cycling for nature fixes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "A €2,070 monthly minimum (2024) indexed twice a year gives the family confidence in service-sector stability, though Amsterdam rents still demand dual professional incomes. It supports Sarah seeking lower-stress roles without fearing exploitative pay scales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers in Amsterdam regularly clear €75k–€95k, and top fintech or gaming roles push past €100k with the 30% ruling. That keeps the family's budget workable even after premium rents and childcare fees.",
+      "alignmentValue": 8
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Amsterdam's finance, travel, and media HQs keep senior .NET squads hiring, from ING and Adyen to Booking's platform teams. The mix of English-first companies and hybrid schedules lets Trey land a high-salary role while still building his indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby shops cluster around SaaS outfits in Amsterdam Science Park and De Pijp, giving Sarah a handful of English-language teams to court. Competition is real, so she may blend remote U.S. clients with local contracts while she networks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "In Amsterdam, hundreds of IND-recognized sponsors hire internationals under the Highly Skilled Migrant scheme, matching the family's desire for predictable processing. Recruiters are familiar with US applicants and handle much of the paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "In Amsterdam, the diversified Dutch economy—logistics, agri-tech, and creative sectors—keeps unemployment low and inflation trending down. That resilience reassures the family as they weigh launching a studio during global uncertainty.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Coworking chains like Spaces, TQ, and A-Lab stay busy with remote product teams, and most Amsterdam tech firms support 2–3 home days per week. CET mornings sync smoothly with U.S. partners, so both parents can keep American clients without burnout.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "In Amsterdam, Dutch managers expect people to leave on time and respect part-time parenting schedules, which aligns with Sarah's search for calm teams. Wednesday afternoon school breaks dovetail with family-focused routines.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "In Amsterdam, a standard full-time contract is 36-40 hours and four-day weeks are common, letting the parents alternate caregiving without risking careers. Mandatory overtime is rare and usually compensated.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "In Amsterdam, labor law guarantees four weeks plus 8% holiday allowance and public holidays, giving the family reliable downtime. Planning around staggered school breaks is still necessary to avoid peak travel prices.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "In Amsterdam, tech employers often top up to 25-30 days plus flexible bridge days, so Trey can travel for conferences while the kids enjoy extended holidays. Teams plan collectively, minimizing burnout.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Tourist surges, startup energy, and dense calendars keep Amsterdam's core moving fast; staying sane means blocking downtime and choosing calmer boroughs like Oost or Noord. With deliberate scheduling, the family can still protect slow evenings for board games.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Amsterdam basisscholen run roughly 8:30–15:00 with free Wednesday afternoons, and most offices start near 9:00. After-school opvang and neighborhood grandparents' networks bridge the gap so Trey and Sarah can wrap calls before dinner.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays often start at the Noordermarkt or Dappermarkt before bike rides through Vondelpark or the NEMO science museum with the kids. Sundays stay relaxed with canal walks or short trains to Haarlem beaches, keeping bedtime routines steady.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Compact canal houses demand smart storage, yet every district layers in playgrounds, libraries, and community centers that welcome queer and poly families. Expect to apply early for sports clubs or music lessons because spots fill quickly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "In Amsterdam, Dutch society is broadly tolerant of non-traditional relationships, yet legal recognition remains limited to one registered partner. The family can live openly in progressive cities but should expect paperwork to center a primary dyad.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "In Amsterdam, parents are encouraged to balance work and caregiving, matching Sarah's desire for supportive communities. Schools expect active involvement but not intensive helicoptering, easing pressure on busy tech parents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Protected cycle tracks, car-free school streets, and plentiful pocket parks let Anduin and Alasdair roam with confidence, though touristy Damrak zones require extra vigilance. Municipal playworkers keep neighborhood clubs inclusive even for newcomers.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Amsterdam offers bilingual public tracks, Montessori experiments, and several international schools, but lotteries and waiting lists require planning a year ahead. The family can secure a good fit by aligning with a school's pedagogy and neighborhood early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Daycare centers such as Partou and KinderRijk offer bilingual groups yet often demand 6–12 month waitlists, especially for infants. Budget €10–€11 per hour before subsidies and consider in-home gastouder care as a backup.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "In Amsterdam, native families receive income-tested childcare allowances covering up to 96% for lower earners, and municipal playgroups add socialization. The generosity fits the family's desire for institutional support.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "In Amsterdam, highly skilled migrants qualify for childcare subsidies once they secure a BSN and tax number, but reimbursements arrive after paying invoices. Cash-flow planning is necessary during the first year.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "In Amsterdam, citizen children enjoy tuition-free primary and secondary schooling with strong inclusion services and after-school BSO. National inspections keep quality consistent across municipalities.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "In Amsterdam, residence permit holders access the same public schools, though oversubscribed bilingual programs may prioritize long-term residents. The family can still find English support via newcomer classes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "In Amsterdam, international schools and denominational options are available but expensive (~€15k-25k) and wait-listed. They serve as a backup if Dutch-language immersion proves too abrupt.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "In Amsterdam, parents receive child benefits, parental leave top-ups, and tax credits that make raising two kids manageable. The ecosystem aligns with the family's priority on supportive community infrastructure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "In Amsterdam, most benefits extend once registered, though some allowances require permanent residency or Dutch taxable income. The family should expect a short administrative ramp-up after arrival.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "In Amsterdam, citizens pay low statutory tuition and can tap DUO loans and grants, giving the kids affordable university pathways. Strong English-taught bachelor's programs broaden future options.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "In Amsterdam, non-EU families pay higher tuition but still gain entry to research universities and HBO programs if they meet integration requirements. Scholarships exist, yet the family must budget more than citizens.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "In Amsterdam, gender equality is mainstream, with men taking parental leave and part-time arrangements normalized. The family's progressive values will fit, though women still shoulder more part-time work statistically.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "In Amsterdam, legal recognition of gender diversity is strong and schools include inclusive curricula, yet rural pockets can lag. The family will find affirming communities in major cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "In Amsterdam, anti-discrimination laws, reproductive rights, and LGBTQ+ protections are robust, matching the family's non-negotiables. Advocacy groups remain vigilant against occasional conservative backlash.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "In Amsterdam, women lead in politics and tech, and casual fashion emphasizes practicality over rigid gender coding. Social pressure to scale back careers after kids persists but continues to soften.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "In Amsterdam, involved fatherhood and emotional openness are encouraged, letting Trey model caregiving without stigma. Some traditional expectations linger in older generations, especially outside the Randstad.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "UNESCO canal heritage sits beside cutting-edge media labs, giving the family endless curiosity fuel between festivals and indie showcases. Amsterdam's international openness keeps their progressive politics welcome.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "In Amsterdam, over 90% of residents speak fluent English and government services provide English portals, easing the family's transition. Dutch remains necessary for deeper bureaucracy and long-term integration.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "In Amsterdam, coalition politics lean liberal on social policy and climate action, aligning with the family's progressive priorities. Fiscal debates can still introduce centrist compromises that temper reforms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "In Amsterdam, left-wing parties and unions remain active, yet the mainstream prefers pragmatic social democracy over radical rhetoric. The family will find Marxist discourse in academic and activist circles more than daily life.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "In Amsterdam, secularism dominates public life; schools and offices rarely center religion, supporting the family's preference for pluralistic spaces. Faith communities exist but do not drive policy.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "In Amsterdam, comprehensive sex education, normalized discussions, and legal protections make open dialogue easy for this sex-positive household. Respect for consent is woven into public campaigns and health services.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "In Amsterdam, marriage equality, anti-discrimination enforcement, and visible Pride events create a welcoming environment for the family's polyamory-positive network. Rural municipalities may be quieter but still legally supportive.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "In Amsterdam, neighborhood associations, expat meetups, and parent-led school councils make it easy to plug in. Direct Dutch communication can feel blunt at first but fosters dependable relationships.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "In Amsterdam, Dutch identity blends pragmatism and pride in consensus-building, which meshes with the family's collaborative ethos. Modesty norms can make overt ambition seem out of place until relationships deepen.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "In Amsterdam, most residents hold friendly, practical views of Belgium and Germany while critiquing UK or US politics with candor. The family should expect honest conversations rather than diplomatic small talk.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "In Amsterdam, neighbors respect Dutch competence and infrastructure but sometimes tease the Netherlands for moralizing on climate and finance. This reputation rarely affects day-to-day life for migrants.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Paradiso, Shelter, and cultural hubs along the IJ keep nightlife vibrant without forcing 4 a.m. nights. Reliable night buses and ferries mean the couple can plan occasional dates without scrambling for rides.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Menswear leans toward tailored streetwear—think rainproof overshirts, sneakers, and sustainable denim—so Trey can blend in while biking to meetings. Boutique brands in the Nine Streets make upgrading wardrobes easy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women mix minimalist silhouettes with statement coats and Dutch-designed accessories, a look Sarah can adopt without chasing runway extremes. Ethical labels and inclusive salons cater well to progressive families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Canal boating, climbing gyms like Monk, and maker labs at Waag Society give the parents creative outlets while the kids join sailing or coding clubs. English-language board game nights pop up weekly in cafés across Jordaan and Oost.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Gamekeeper, Het Spellenhuis, and the Amsterdam Board Games Meetup host regular English-friendly sessions that let Trey test prototypes. Family cafes such as TonTon Club mix arcades and tabletop titles for low-stress socializing.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "The city hosts world-class jazz at Bimhuis, orchestral nights at the Concertgebouw, and gaming-friendly chip-tune shows at Melkweg. Planning babysitters ahead is the only hurdle when headline acts roll through.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "AmsterdamJS, Women in Tech NL, and the Amsterdam Game Dev meetup gather weekly across coworking hubs, so the adults can plug into supportive professional circles quickly. Parent WhatsApp groups make it easy to line up playdates in each neighborhood.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Within 20 minutes the family can cycle into Amsterdamse Bos or take a ferry to Waterland's meadows; longer train rides unlock Texel or Utrechtse Heuvelrug. Urban density means booking campsites early for summer weekends.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "In Amsterdam, a multi-party parliamentary system with proportional representation rewards coalition building, matching the family's preference for pluralistic governance. Fragmentation can slow legislation but keeps extremes in check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "In Amsterdam, religious parties hold seats yet rarely impose doctrine on policy, so secular families like this one rarely encounter faith-based legislation. Debates around education funding are the main area where faith still matters.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "In Amsterdam, collective bargaining, works councils, and strict dismissal protections empower employees while still allowing flexible schedules. This safeguards Sarah if she opts for part-time or remote roles.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "In Amsterdam, the national ethos blends social liberalism with pro-business pragmatism, which fits the family's progressive-but-entrepreneurial stance. Populist voices occasionally push harder on migration or cultural issues.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "In Amsterdam, institutions are resilient and courts independent, yet recent far-right gains demand vigilance—exactly the concern highlighted in the family profile. Civil society remains active in defending democratic norms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "In Amsterdam, a regulated market economy balances startup support with social safety nets, ideal for launching an indie studio without sacrificing healthcare. High taxes and compliance requirements still add overhead.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "In Amsterdam, long-term NATO membership, low crime, and steady institutions give the family confidence in long-horizon planning. Coalition reshuffles rarely disrupt daily life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "In Amsterdam, independent media and public broadcasters provide diverse viewpoints, satisfying the family's desire for pluralistic information. Government messaging exists but faces strong journalistic scrutiny.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "In Amsterdam, public campaigns focus on health, climate, and civic cohesion rather than nationalist narratives, aligning with the family's expectations. Spin becomes noticeable mainly during sensitive tax or benefits scandals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "In Amsterdam, housing, education, and welfare supports are generous compared to the US, supporting the family's work-life balance goals. Policy trade-offs occasionally prioritize budget discipline over rapid expansion.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "In Amsterdam, confidence dipped after the childcare benefits scandal, so newcomers should expect candid skepticism in local conversations. Transparency measures are improving but trust has not fully rebounded.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "In Amsterdam, transparency International ranks the Netherlands among the least corrupt, reinforcing the family's need for predictable bureaucracy. Isolated procurement controversies rarely touch daily life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "In Amsterdam, when issues arise they usually involve lobbying or housing development favoritism rather than petty bribery. Staying informed through local news helps the family navigate zoning or permit decisions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Three-bedroom rentals routinely top €2,400 and often require income three to four times rent plus lotteries, making safe family housing the toughest hurdle. The family should budget months of search time and lean on relocation brokers to avoid exploitative offers.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime remains rare, but pickpockets and bike theft around Centraal and nightlife strips like Leidseplein demand vigilance. Choosing quieter neighborhoods and investing in secure bike parking keeps risks manageable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "In Amsterdam, universal coverage, strong primary care, and maternity support meet the family's standards for accessible healthcare. Waiting lists for specialists exist but are usually manageable with referrals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "In Amsterdam, once insured through a Dutch policy, migrants receive the same GP-led care, though English-speaking specialists can book out quickly. The family should register with a huisarts immediately after arrival.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "In Amsterdam, generous parental leave, child benefits, and school-based aftercare give the household multiple supports. Administrative delays can occur but usually resolve with municipal help.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "In Amsterdam, mainstream policies assume dual working parents with government-backed care, aligning with this family's structure. Navigating Dutch-language portals is the main adjustment.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "In Amsterdam, Dutch schools rank well internationally and emphasize project-based learning that suits curious kids. We would monitor capacity issues in fast-growing suburbs to secure preferred tracks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "GVB trams, the North–South metro, and dense bus routes tie every neighborhood to Amsterdam Centraal, while frequent intercity trains reach Utrecht or Schiphol in under 30 minutes. Ferries and bike lanes fill any gaps, leaving car ownership optional.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "In Amsterdam, a coordinated market economy with strong social partners supports entrepreneurship while cushioning shocks. Regulations are thorough, so Trey will need a bookkeeper for any studio venture.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "In Amsterdam, payroll withholding covers most obligations and MijnBelastingdienst offers digital filings, yet forms remain Dutch-first. Hiring a tax advisor early will help the family leverage deductions and avoid surprises.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "In Amsterdam, dual tech incomes land in the 36.97% and 49.5% brackets, but the 30% ruling can shield a chunk of Trey's salary for five years. Planning around pension contributions and childcare deductions keeps net pay comfortable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "In Amsterdam, opening accounts with a BSN is straightforward, and instant SEPA transfers, iDEAL, and contactless payments simplify daily life. Some niche US cards may still require backup options.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, yet housing, childcare, and dining in Amsterdam's center devour salaries quickly. The budget works only if Trey lands a top-tier package or the 30% ruling to offset premium expenses.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "In Amsterdam, the AOW public pension plus mandatory employer schemes provide solid old-age income for lifelong residents. Voluntary savings still matter as demographics age.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "In Amsterdam, expats accrue AOW only for years lived in the Netherlands and rely heavily on employer pensions or third-pillar savings. The family would need disciplined private investing if they relocate mid-career.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "In Amsterdam, highly Skilled Migrant, EU Blue Card, startup, and self-employed visas give the family multiple entry routes. Each path has clear salary thresholds or business plans, so preparation is key but outcomes are predictable.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "In Amsterdam, IND officers regularly process US applications, and the Dutch-American Friendship Treaty offers an entrepreneurial fallback. Bureaucracy can feel impersonal, so patient follow-up is essential.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "In Amsterdam, permits typically run two to five years and convert to permanent residency after five years of legal stay. The family must track renewal deadlines but the pathway is well-trodden.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "In Amsterdam, naturalization after five years is feasible with integration exams, yet dual nationality is restricted. The family would weigh renouncing US citizenship against the benefits of Dutch passports.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "In Amsterdam, spouses and minor children join easily, but polyamorous partners beyond one registered relationship lack recognition. Planning documents should focus on the legally acknowledged couple.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "In Amsterdam, once an employer submits, highly skilled migrant approvals arrive in two to four weeks; fees hover around €350-400 per person. Delays mostly stem from housing registration or biometrics appointments.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "In Amsterdam, maintaining salary thresholds, municipal registration, and Dutch health insurance keeps the family in good standing. Audits are structured but missing paperwork can trigger costly reviews.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "In Amsterdam, the Netherlands generally requires renouncing previous citizenships, so the family would need a treaty-based exemption or Dutch spouse to keep US passports. Planning for this constraint is critical.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "In Amsterdam, all adults need a BSN, DigiD, and Dutch-language correspondence to access benefits, making early administrative coaching invaluable. Health insurance enrollment within four months is mandatory.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Guerrilla Games, Rockstar Amsterdam, and HoYoverse's European HQ anchor a dense hiring scene, complemented by dozens of VR and indie studios. Trey can toggle between AAA contracts and indie collaborations without leaving the city.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Flagship teams like Guerrilla Games, Rockstar, and Abstraction Games make Amsterdam a recognizable name in global development. Their presence keeps recruiter pipelines warm for senior engineers and technical artists.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Amsterdam Game Dev Café, Control Conference pop-ups, and Dutch Game Garden events at A-Lab provide monthly English-language meetups. Those spaces make it easy for Trey to share prototypes and for Sarah to meet fellow technologists.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "StartupAmsterdam grants, Creative Industries Fund NL subsidies, and EU Creative Europe calls pair with accelerator desks at A-Lab and Boom Chicago. The ecosystem expects polished pitches, but a well-scoped indie studio can secure mentors and seed money.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "In Amsterdam, nationwide fiber, smart logistics, and digital government services keep daily friction low for a remote-working family. Occasional rail maintenance or housing energy retrofits are the main disruptions.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/netherlands_eindhoven_report.json
+++ b/reports/netherlands_eindhoven_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "NL",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "In Eindhoven, Dutch spatial planning lets this park-seeking family bike to clean canals, urban forests, and well-managed green belts even in dense metros. Nitrogen-intensive farming belts still strain biodiversity, so weekend outings sometimes shift toward protected dunes and wetlands.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "In Eindhoven, Sea-level rise remains the headline risk for a below-sea-level home, yet the fully funded Delta Programme and constant dike upgrades keep near-term danger manageable for the family. We would still budget for flood insurance and monitor adaptation policies before buying property in reclaimed polders.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "In Eindhoven, the marine climate hits the family's mild-temperature preference, but long stretches of drizzle and grey skies each shoulder season limit spontaneous outdoor plans. Reliable rain gear and indoor kid activities are essential half the year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "In Eindhoven, EU emission rules keep daily PM2.5 low enough for the kids' outdoor play and parents' cycling commutes. We only watch for occasional nitrogen spikes near ports or dairy clusters before planning long rides.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "In Eindhoven, there is virtually no quake or wildfire threat, and world-class flood controls align with the family's low-risk tolerance. Storm surges are rare but we would follow municipal alerts when renting near rivers or the North Sea.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "In Eindhoven, March and April swing between jacket weather and cold rain, so the family alternates playground days with museum trips. By May the 6-16°C range turns pleasant, matching their bike-friendly goals.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "In Eindhoven, typical highs sit around 21-24°C, letting the family enjoy parks and festivals without AC. Brief humid heatwaves over 30°C pop up, so we plan cooling breaks during rare continental air masses.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "In Eindhoven, September starts crisp, but by October steady rain and 8-16°C temps mean we juggle layered clothing for school runs. The family's preference for predictable outdoor time requires flexible weekend plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "In Eindhoven, winters hover 0-6°C with damp winds, so the family needs solid rain gear more than snow shovels. Occasional freezing rain can snarl transit, but long deep freezes are rare compared with the US Midwest.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North Sea beaches sit 90 minutes away, so the family leans on inland lakes like E3 Strand or Aquabest for quick swims. These spots are well-equipped but can feel crowded on hot weekends.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Local lakes warm into the low 20s °C by midsummer, offering better swim conditions than the chilly North Sea. Outside July and August, water play shifts to indoor pools or splash parks.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Heathlands at Strabrechtse Heide, the Dommel river valley, and Kempen forests sit a short bike ride or bus away. Weekend trips to De Groote Peel keep the family's nature time varied without long drives.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "In Eindhoven, a €2,070 monthly minimum (2024) indexed twice a year gives the family confidence in service-sector stability, though Amsterdam rents still demand dual professional incomes. It supports Sarah seeking lower-stress roles without fearing exploitative pay scales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Experienced developers earn €60k–€80k in Eindhoven, with Brainport bonuses and 30% ruling perks nudging compensation higher. Lower housing costs keep the family's finances balanced compared to Randstad cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Brainport anchors like ASML, NXP, and Philips rely on .NET for tooling and enterprise systems, so senior engineers stay in demand. Many teams operate in English, giving Trey corporate stability alongside his indie ambitions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles are limited, concentrated in a few e-commerce and agency shops around Strijp-S. Sarah will likely combine local freelance gigs with remote clients to maintain momentum.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "In Eindhoven, hundreds of IND-recognized sponsors hire internationals under the Highly Skilled Migrant scheme, matching the family's desire for predictable processing. Recruiters are familiar with US applicants and handle much of the paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "In Eindhoven, the diversified Dutch economy—logistics, agri-tech, and creative sectors—keeps unemployment low and inflation trending down. That resilience reassures the family as they weigh launching a studio during global uncertainty.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "High Tech Campus tenants embrace hybrid schedules, and coworking spaces like Microlab or Seats2meet Strijp-S offer reliable desks. Teams still expect on-site collaboration a couple of days a week for hardware handoffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "In Eindhoven, Dutch managers expect people to leave on time and respect part-time parenting schedules, which aligns with Sarah's search for calm teams. Wednesday afternoon school breaks dovetail with family-focused routines.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "In Eindhoven, a standard full-time contract is 36-40 hours and four-day weeks are common, letting the parents alternate caregiving without risking careers. Mandatory overtime is rare and usually compensated.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "In Eindhoven, labor law guarantees four weeks plus 8% holiday allowance and public holidays, giving the family reliable downtime. Planning around staggered school breaks is still necessary to avoid peak travel prices.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "In Eindhoven, tech employers often top up to 25-30 days plus flexible bridge days, so Trey can travel for conferences while the kids enjoy extended holidays. Teams plan collectively, minimizing burnout.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Outside of tech conference weeks, Eindhoven moves at a relaxed clip with short commutes and roomy public spaces. That slower rhythm suits Sarah's desire for calmer days while Trey taps into innovation hubs when needed.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools start around 8:30 and finish near 15:15, and many Brainport companies run 9-to-5 with protected overtime policies. BSO programs and High Tech Campus childcare cover late meetings when product launches spike.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends mix Strijp-S design events, Philips Museum visits, and bike trips to Genneper Parken or the DAF Museum. Sunday outings often head to indoor playgrounds or VR arcades when Dutch weather turns wet.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Wide bike lanes, generous green space, and international schools clustered near Brainport make Eindhoven friendly for young families. Community centers welcome LGBTQ+ parents, and neighbors are accustomed to expat households.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "In Eindhoven, Dutch society is broadly tolerant of non-traditional relationships, yet legal recognition remains limited to one registered partner. The family can live openly in progressive cities but should expect paperwork to center a primary dyad.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "In Eindhoven, parents are encouraged to balance work and caregiving, matching Sarah's desire for supportive communities. Schools expect active involvement but not intensive helicoptering, easing pressure on busy tech parents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Traffic-calmed streets, Playgrounds in every wijk, and kid-focused museums give the children independence quickly. We only stay alert around nightlife-heavy Stratumseind during festival weekends.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public basisscholen are solid, and the International School Eindhoven covers IB tracks, but seats fill fast with expat demand. Early enrollment and proximity to campus ease the process.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Kinderopvang at High Tech Campus and providers like Korein offer bilingual groups with shorter waitlists than the Randstad. Costs remain high until subsidies reimburse invoices a few months later.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "In Eindhoven, native families receive income-tested childcare allowances covering up to 96% for lower earners, and municipal playgroups add socialization. The generosity fits the family's desire for institutional support.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "In Eindhoven, highly skilled migrants qualify for childcare subsidies once they secure a BSN and tax number, but reimbursements arrive after paying invoices. Cash-flow planning is necessary during the first year.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "In Eindhoven, citizen children enjoy tuition-free primary and secondary schooling with strong inclusion services and after-school BSO. National inspections keep quality consistent across municipalities.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "In Eindhoven, residence permit holders access the same public schools, though oversubscribed bilingual programs may prioritize long-term residents. The family can still find English support via newcomer classes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "In Eindhoven, international schools and denominational options are available but expensive (~€15k-25k) and wait-listed. They serve as a backup if Dutch-language immersion proves too abrupt.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "In Eindhoven, parents receive child benefits, parental leave top-ups, and tax credits that make raising two kids manageable. The ecosystem aligns with the family's priority on supportive community infrastructure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "In Eindhoven, most benefits extend once registered, though some allowances require permanent residency or Dutch taxable income. The family should expect a short administrative ramp-up after arrival.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "In Eindhoven, citizens pay low statutory tuition and can tap DUO loans and grants, giving the kids affordable university pathways. Strong English-taught bachelor's programs broaden future options.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "In Eindhoven, non-EU families pay higher tuition but still gain entry to research universities and HBO programs if they meet integration requirements. Scholarships exist, yet the family must budget more than citizens.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "In Eindhoven, gender equality is mainstream, with men taking parental leave and part-time arrangements normalized. The family's progressive values will fit, though women still shoulder more part-time work statistically.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "In Eindhoven, legal recognition of gender diversity is strong and schools include inclusive curricula, yet rural pockets can lag. The family will find affirming communities in major cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "In Eindhoven, anti-discrimination laws, reproductive rights, and LGBTQ+ protections are robust, matching the family's non-negotiables. Advocacy groups remain vigilant against occasional conservative backlash.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "In Eindhoven, women lead in politics and tech, and casual fashion emphasizes practicality over rigid gender coding. Social pressure to scale back careers after kids persists but continues to soften.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "In Eindhoven, involved fatherhood and emotional openness are encouraged, letting Trey model caregiving without stigma. Some traditional expectations linger in older generations, especially outside the Randstad.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Dutch Design Week, GLOW light festival, and experimental tech art in Strijp-S give the family plenty to explore between indie showcases. Eindhoven's maker spirit meshes with their curiosity and entrepreneurial goals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "In Eindhoven, over 90% of residents speak fluent English and government services provide English portals, easing the family's transition. Dutch remains necessary for deeper bureaucracy and long-term integration.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "In Eindhoven, coalition politics lean liberal on social policy and climate action, aligning with the family's progressive priorities. Fiscal debates can still introduce centrist compromises that temper reforms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "In Eindhoven, left-wing parties and unions remain active, yet the mainstream prefers pragmatic social democracy over radical rhetoric. The family will find Marxist discourse in academic and activist circles more than daily life.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "In Eindhoven, secularism dominates public life; schools and offices rarely center religion, supporting the family's preference for pluralistic spaces. Faith communities exist but do not drive policy.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "In Eindhoven, comprehensive sex education, normalized discussions, and legal protections make open dialogue easy for this sex-positive household. Respect for consent is woven into public campaigns and health services.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "In Eindhoven, marriage equality, anti-discrimination enforcement, and visible Pride events create a welcoming environment for the family's polyamory-positive network. Rural municipalities may be quieter but still legally supportive.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "In Eindhoven, neighborhood associations, expat meetups, and parent-led school councils make it easy to plug in. Direct Dutch communication can feel blunt at first but fosters dependable relationships.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "In Eindhoven, Dutch identity blends pragmatism and pride in consensus-building, which meshes with the family's collaborative ethos. Modesty norms can make overt ambition seem out of place until relationships deepen.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "In Eindhoven, most residents hold friendly, practical views of Belgium and Germany while critiquing UK or US politics with candor. The family should expect honest conversations rather than diplomatic small talk.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "In Eindhoven, neighbors respect Dutch competence and infrastructure but sometimes tease the Netherlands for moralizing on climate and finance. This reputation rarely affects day-to-day life for migrants.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Stratumseind offers dense nightlife when the couple wants a date night, yet the city winds down earlier than Amsterdam. Reliable night buses and taxis cover the trip home before the kids' bedtime is disrupted.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Menswear skews toward tech-casual outfits with design-forward sneakers and jackets showcased during Dutch Design Week. Trey can keep a polished yet relaxed look that works for both campus meetings and indie showcases.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Sarah can lean into Eindhoven's design culture—structured basics accented by bold accessories from local makers. The scene values creativity over luxury labels, aligning with her practical style.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Design labs, climbing halls like Monk Eindhoven, and maker spaces at Microlab cater to the parents' creative pursuits. Kids rotate between PSV football academies, robotics clubs, and science workshops at Discovery Factory.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Stores like Gameforce and Spellenspektakel events, plus the Eindhoven Board Gamers meetup, keep tabletop nights lively. Sessions regularly welcome English speakers so Trey can demo prototypes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Venues like Effenaar, Muziekgebouw, and Dynamo bring touring acts, esports LANs, and game-music concerts to town. Big-name shows sell out quickly, so booking ahead is part of the routine.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Brainport TechMeetups, High Tech Campus family clubs, and international parents groups provide quick social entry points. Women in Tech Brainport chapters give Sarah a supportive peer network.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Cycle paths lead straight to Genneper Parken, Philips de Jonghpark, and regional forests, so fresh air is always on tap. Renting an electric bakfiets makes longer excursions with the kids easy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "In Eindhoven, a multi-party parliamentary system with proportional representation rewards coalition building, matching the family's preference for pluralistic governance. Fragmentation can slow legislation but keeps extremes in check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "In Eindhoven, religious parties hold seats yet rarely impose doctrine on policy, so secular families like this one rarely encounter faith-based legislation. Debates around education funding are the main area where faith still matters.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "In Eindhoven, collective bargaining, works councils, and strict dismissal protections empower employees while still allowing flexible schedules. This safeguards Sarah if she opts for part-time or remote roles.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "In Eindhoven, the national ethos blends social liberalism with pro-business pragmatism, which fits the family's progressive-but-entrepreneurial stance. Populist voices occasionally push harder on migration or cultural issues.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "In Eindhoven, institutions are resilient and courts independent, yet recent far-right gains demand vigilance—exactly the concern highlighted in the family profile. Civil society remains active in defending democratic norms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "In Eindhoven, a regulated market economy balances startup support with social safety nets, ideal for launching an indie studio without sacrificing healthcare. High taxes and compliance requirements still add overhead.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "In Eindhoven, long-term NATO membership, low crime, and steady institutions give the family confidence in long-horizon planning. Coalition reshuffles rarely disrupt daily life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "In Eindhoven, independent media and public broadcasters provide diverse viewpoints, satisfying the family's desire for pluralistic information. Government messaging exists but faces strong journalistic scrutiny.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "In Eindhoven, public campaigns focus on health, climate, and civic cohesion rather than nationalist narratives, aligning with the family's expectations. Spin becomes noticeable mainly during sensitive tax or benefits scandals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "In Eindhoven, housing, education, and welfare supports are generous compared to the US, supporting the family's work-life balance goals. Policy trade-offs occasionally prioritize budget discipline over rapid expansion.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "In Eindhoven, confidence dipped after the childcare benefits scandal, so newcomers should expect candid skepticism in local conversations. Transparency measures are improving but trust has not fully rebounded.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "In Eindhoven, transparency International ranks the Netherlands among the least corrupt, reinforcing the family's need for predictable bureaucracy. Isolated procurement controversies rarely touch daily life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "In Eindhoven, when issues arise they usually involve lobbying or housing development favoritism rather than petty bribery. Staying informed through local news helps the family navigate zoning or permit decisions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Rental demand is rising, but family homes in wijken like Strijp or Meerhoven remain attainable around €1,600–€1,900 per month. Acting quickly and providing employer guarantees usually secures a lease.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Eindhoven feels safe across most districts, with policing focused on bike theft and nightlife incidents along Stratumseind. Choosing residential neighborhoods keeps the kids' routines low-risk.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "In Eindhoven, universal coverage, strong primary care, and maternity support meet the family's standards for accessible healthcare. Waiting lists for specialists exist but are usually manageable with referrals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "In Eindhoven, once insured through a Dutch policy, migrants receive the same GP-led care, though English-speaking specialists can book out quickly. The family should register with a huisarts immediately after arrival.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "In Eindhoven, generous parental leave, child benefits, and school-based aftercare give the household multiple supports. Administrative delays can occur but usually resolve with municipal help.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "In Eindhoven, mainstream policies assume dual working parents with government-backed care, aligning with this family's structure. Navigating Dutch-language portals is the main adjustment.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "In Eindhoven, Dutch schools rank well internationally and emphasize project-based learning that suits curious kids. We would monitor capacity issues in fast-growing suburbs to secure preferred tracks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Eindhoven's bus rapid transit lines and intercity trains cover major routes, but suburban service thins at night. The family leans on bikes or Greenwheels car share for late events or trips into nature reserves.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "In Eindhoven, a coordinated market economy with strong social partners supports entrepreneurship while cushioning shocks. Regulations are thorough, so Trey will need a bookkeeper for any studio venture.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "In Eindhoven, payroll withholding covers most obligations and MijnBelastingdienst offers digital filings, yet forms remain Dutch-first. Hiring a tax advisor early will help the family leverage deductions and avoid surprises.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "In Eindhoven, dual tech incomes land in the 36.97% and 49.5% brackets, but the 30% ruling can shield a chunk of Trey's salary for five years. Planning around pension contributions and childcare deductions keeps net pay comfortable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "In Eindhoven, opening accounts with a BSN is straightforward, and instant SEPA transfers, iDEAL, and contactless payments simplify daily life. Some niche US cards may still require backup options.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Daily expenses run notably lower than in Amsterdam—housing, childcare, and dining leave more room for savings. The family can direct the difference into studio runway or travel.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "In Eindhoven, the AOW public pension plus mandatory employer schemes provide solid old-age income for lifelong residents. Voluntary savings still matter as demographics age.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "In Eindhoven, expats accrue AOW only for years lived in the Netherlands and rely heavily on employer pensions or third-pillar savings. The family would need disciplined private investing if they relocate mid-career.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "In Eindhoven, highly Skilled Migrant, EU Blue Card, startup, and self-employed visas give the family multiple entry routes. Each path has clear salary thresholds or business plans, so preparation is key but outcomes are predictable.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "In Eindhoven, IND officers regularly process US applications, and the Dutch-American Friendship Treaty offers an entrepreneurial fallback. Bureaucracy can feel impersonal, so patient follow-up is essential.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "In Eindhoven, permits typically run two to five years and convert to permanent residency after five years of legal stay. The family must track renewal deadlines but the pathway is well-trodden.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "In Eindhoven, naturalization after five years is feasible with integration exams, yet dual nationality is restricted. The family would weigh renouncing US citizenship against the benefits of Dutch passports.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "In Eindhoven, spouses and minor children join easily, but polyamorous partners beyond one registered relationship lack recognition. Planning documents should focus on the legally acknowledged couple.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "In Eindhoven, once an employer submits, highly skilled migrant approvals arrive in two to four weeks; fees hover around €350-400 per person. Delays mostly stem from housing registration or biometrics appointments.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "In Eindhoven, maintaining salary thresholds, municipal registration, and Dutch health insurance keeps the family in good standing. Audits are structured but missing paperwork can trigger costly reviews.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "In Eindhoven, the Netherlands generally requires renouncing previous citizenships, so the family would need a treaty-based exemption or Dutch spouse to keep US passports. Planning for this constraint is critical.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "In Eindhoven, all adults need a BSN, DigiD, and Dutch-language correspondence to access benefits, making early administrative coaching invaluable. Health insurance enrollment within four months is mandatory.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "VR specialists like Enversed Studios and serious-game outfits tied to TU/e create a niche hiring scene. Trey can find collaborators, but he may still reach toward Amsterdam or Utrecht for larger teams.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios such as Enversed, GameHouse, and indie teams at Strijp-S keep Eindhoven visible in VR and mobile development. While fewer than in Amsterdam, they form a solid local peer group.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Eindhoven Game Developers Meetup, Lumo Labs demo days, and TU/e game jams provide recurring touchpoints. Events skew smaller than the Randstad but stay welcoming and English-accessible.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Brainport Development, Lumo Labs, and Brabant Startup Fonds supply grants and mentorship for XR and serious-game ventures. Funding is competitive, yet the lower cost base helps the family bootstrap an indie studio.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "In Eindhoven, nationwide fiber, smart logistics, and digital government services keep daily friction low for a remote-working family. Occasional rail maintenance or housing energy retrofits are the main disruptions.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/netherlands_utrecht_report.json
+++ b/reports/netherlands_utrecht_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "NL",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "In Utrecht, Dutch spatial planning lets this park-seeking family bike to clean canals, urban forests, and well-managed green belts even in dense metros. Nitrogen-intensive farming belts still strain biodiversity, so weekend outings sometimes shift toward protected dunes and wetlands.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "In Utrecht, Sea-level rise remains the headline risk for a below-sea-level home, yet the fully funded Delta Programme and constant dike upgrades keep near-term danger manageable for the family. We would still budget for flood insurance and monitor adaptation policies before buying property in reclaimed polders.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "In Utrecht, the marine climate hits the family's mild-temperature preference, but long stretches of drizzle and grey skies each shoulder season limit spontaneous outdoor plans. Reliable rain gear and indoor kid activities are essential half the year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "In Utrecht, EU emission rules keep daily PM2.5 low enough for the kids' outdoor play and parents' cycling commutes. We only watch for occasional nitrogen spikes near ports or dairy clusters before planning long rides.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "In Utrecht, there is virtually no quake or wildfire threat, and world-class flood controls align with the family's low-risk tolerance. Storm surges are rare but we would follow municipal alerts when renting near rivers or the North Sea.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "In Utrecht, March and April swing between jacket weather and cold rain, so the family alternates playground days with museum trips. By May the 6-16°C range turns pleasant, matching their bike-friendly goals.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "In Utrecht, typical highs sit around 21-24°C, letting the family enjoy parks and festivals without AC. Brief humid heatwaves over 30°C pop up, so we plan cooling breaks during rare continental air masses.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "In Utrecht, September starts crisp, but by October steady rain and 8-16°C temps mean we juggle layered clothing for school runs. The family's preference for predictable outdoor time requires flexible weekend plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "In Utrecht, winters hover 0-6°C with damp winds, so the family needs solid rain gear more than snow shovels. Occasional freezing rain can snarl transit, but long deep freezes are rare compared with the US Midwest.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Beaches like Zandvoort or Scheveningen are 40 minutes by train, so seaside days take planning. Closer to home, Haarrijnse Plas and Maarsseveense Plassen give the kids swimming spots during warm weeks.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "North Sea water still peaks around 18 °C in August, making quick dips more realistic than long swims. Lakes near Utrecht warm up faster, offering better options for small children.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "From Oudegracht canals to Utrechtse Heuvelrug forests and the Vecht river estates, nature is a quick bike or train ride away. Weekend camping in Soestduinen or sailing on the Loosdrechtse Plassen keeps the family outdoors year-round.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "In Utrecht, a €2,070 monthly minimum (2024) indexed twice a year gives the family confidence in service-sector stability, though Amsterdam rents still demand dual professional incomes. It supports Sarah seeking lower-stress roles without fearing exploitative pay scales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Experienced developers in Utrecht earn roughly €65k–€85k, with 30% ruling offers near the top end. Settling in Leidsche Rijn or Nieuwegein helps the family stretch those salaries toward childcare and savings goals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Rabobank, bol.com, and Nederlandse Spoorwegen run major tech hubs around Utrecht Centraal, keeping senior .NET engineers in demand. English-friendly product teams give Trey a steady pipeline without leaving the city.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby hiring is thinner, centered on boutique agencies and a few SaaS scale-ups near the canals. Sarah can land roles, but she'll likely pair local contracts with remote clients to keep her workload stable.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "In Utrecht, hundreds of IND-recognized sponsors hire internationals under the Highly Skilled Migrant scheme, matching the family's desire for predictable processing. Recruiters are familiar with US applicants and handle much of the paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "In Utrecht, the diversified Dutch economy—logistics, agri-tech, and creative sectors—keeps unemployment low and inflation trending down. That resilience reassures the family as they weigh launching a studio during global uncertainty.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid weeks are the norm, and coworking spots like Seats2meet and Mindspace make remote collaboration easy. CET overlap lets Trey and Sarah manage U.S. calls without sacrificing the kids' after-school routine.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "In Utrecht, Dutch managers expect people to leave on time and respect part-time parenting schedules, which aligns with Sarah's search for calm teams. Wednesday afternoon school breaks dovetail with family-focused routines.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "In Utrecht, a standard full-time contract is 36-40 hours and four-day weeks are common, letting the parents alternate caregiving without risking careers. Mandatory overtime is rare and usually compensated.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "In Utrecht, labor law guarantees four weeks plus 8% holiday allowance and public holidays, giving the family reliable downtime. Planning around staggered school breaks is still necessary to avoid peak travel prices.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "In Utrecht, tech employers often top up to 25-30 days plus flexible bridge days, so Trey can travel for conferences while the kids enjoy extended holidays. Teams plan collectively, minimizing burnout.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "The medieval core buzzes with students and cyclists, yet within 15 minutes the family can retreat to quieter neighborhoods or riverside paths. That balance lets Sarah enjoy a slower rhythm while Trey taps into city energy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Primary schools open around 8:30 and close near 15:00 with Wednesday half-days, aligning well with 9-to-5 tech schedules. BSO aftercare and neighborhood oppas pools cover late meetings so both parents stay flexible.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends start with market runs at Vredenburg or Twijnstraat before biking to Utrechtse Heuvelrug for forest hikes. Evenings often feature family-friendly shows at TivoliVredenburg or board-game nights at local cafés.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Car-lite streets, plentiful playgrounds, and community centers like Bibliotheek Neude make Utrecht feel purpose-built for young families. Inclusive festivals and parent collectives welcome progressive, poly-friendly households.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "In Utrecht, Dutch society is broadly tolerant of non-traditional relationships, yet legal recognition remains limited to one registered partner. The family can live openly in progressive cities but should expect paperwork to center a primary dyad.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "In Utrecht, parents are encouraged to balance work and caregiving, matching Sarah's desire for supportive communities. Schools expect active involvement but not intensive helicoptering, easing pressure on busy tech parents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Traffic-calmed woonerven, school streets, and safe canal-side paths let the kids bike independently sooner than in the U.S. City hosts and Buurtteams help newcomers plug into playgroups quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Dalton, Montessori, and bilingual public schools sit alongside the International School Utrecht, but popular tracks still use lotteries. Early registration and matching the family's pedagogy keep stress low.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Kinderopvang providers such as Partou and Kind & Co have good reputations, yet infant places need booking six months out. Municipal playgroups and gastouders offer flexible backups while subsidies reimburse a large share.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "In Utrecht, native families receive income-tested childcare allowances covering up to 96% for lower earners, and municipal playgroups add socialization. The generosity fits the family's desire for institutional support.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "In Utrecht, highly skilled migrants qualify for childcare subsidies once they secure a BSN and tax number, but reimbursements arrive after paying invoices. Cash-flow planning is necessary during the first year.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "In Utrecht, citizen children enjoy tuition-free primary and secondary schooling with strong inclusion services and after-school BSO. National inspections keep quality consistent across municipalities.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "In Utrecht, residence permit holders access the same public schools, though oversubscribed bilingual programs may prioritize long-term residents. The family can still find English support via newcomer classes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "In Utrecht, international schools and denominational options are available but expensive (~€15k-25k) and wait-listed. They serve as a backup if Dutch-language immersion proves too abrupt.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "In Utrecht, parents receive child benefits, parental leave top-ups, and tax credits that make raising two kids manageable. The ecosystem aligns with the family's priority on supportive community infrastructure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "In Utrecht, most benefits extend once registered, though some allowances require permanent residency or Dutch taxable income. The family should expect a short administrative ramp-up after arrival.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "In Utrecht, citizens pay low statutory tuition and can tap DUO loans and grants, giving the kids affordable university pathways. Strong English-taught bachelor's programs broaden future options.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "In Utrecht, non-EU families pay higher tuition but still gain entry to research universities and HBO programs if they meet integration requirements. Scholarships exist, yet the family must budget more than citizens.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "In Utrecht, gender equality is mainstream, with men taking parental leave and part-time arrangements normalized. The family's progressive values will fit, though women still shoulder more part-time work statistically.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "In Utrecht, legal recognition of gender diversity is strong and schools include inclusive curricula, yet rural pockets can lag. The family will find affirming communities in major cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "In Utrecht, anti-discrimination laws, reproductive rights, and LGBTQ+ protections are robust, matching the family's non-negotiables. Advocacy groups remain vigilant against occasional conservative backlash.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "In Utrecht, women lead in politics and tech, and casual fashion emphasizes practicality over rigid gender coding. Social pressure to scale back careers after kids persists but continues to soften.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "In Utrecht, involved fatherhood and emotional openness are encouraged, letting Trey model caregiving without stigma. Some traditional expectations linger in older generations, especially outside the Randstad.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "A historic university city with experimental culture, Utrecht offers hidden courtyards, festivals, and game jams in one compact package. That curiosity-friendly mix keeps the family engaged without overwhelming them.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "In Utrecht, over 90% of residents speak fluent English and government services provide English portals, easing the family's transition. Dutch remains necessary for deeper bureaucracy and long-term integration.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "In Utrecht, coalition politics lean liberal on social policy and climate action, aligning with the family's progressive priorities. Fiscal debates can still introduce centrist compromises that temper reforms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "In Utrecht, left-wing parties and unions remain active, yet the mainstream prefers pragmatic social democracy over radical rhetoric. The family will find Marxist discourse in academic and activist circles more than daily life.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "In Utrecht, secularism dominates public life; schools and offices rarely center religion, supporting the family's preference for pluralistic spaces. Faith communities exist but do not drive policy.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "In Utrecht, comprehensive sex education, normalized discussions, and legal protections make open dialogue easy for this sex-positive household. Respect for consent is woven into public campaigns and health services.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "In Utrecht, marriage equality, anti-discrimination enforcement, and visible Pride events create a welcoming environment for the family's polyamory-positive network. Rural municipalities may be quieter but still legally supportive.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "In Utrecht, neighborhood associations, expat meetups, and parent-led school councils make it easy to plug in. Direct Dutch communication can feel blunt at first but fosters dependable relationships.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "In Utrecht, Dutch identity blends pragmatism and pride in consensus-building, which meshes with the family's collaborative ethos. Modesty norms can make overt ambition seem out of place until relationships deepen.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "In Utrecht, most residents hold friendly, practical views of Belgium and Germany while critiquing UK or US politics with candor. The family should expect honest conversations rather than diplomatic small talk.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "In Utrecht, neighbors respect Dutch competence and infrastructure but sometimes tease the Netherlands for moralizing on climate and finance. This reputation rarely affects day-to-day life for migrants.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Student bars, TivoliVredenburg, and late-night cafés keep evenings lively without Amsterdam's crowds. Night buses taper after 2 a.m., so date nights wrap by the last train or rely on bikeshare rides home.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Style skews toward smart-casual layers and rainproof bike gear, so Trey can keep things practical without standing out. Boutiques in the Nine Little Streets offshoots provide upgrades when needed.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women mix Scandinavian minimalism with colorful Dutch accessories, making it easy for Sarah to express herself while staying commuter-friendly. Local designers at Steenweg pop-ups support sustainable wardrobes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Canal paddling, climbing at Energiehaven, and maker workshops at Hooghiemstra support both parents' creative streaks. Kids join music schools or coding clubs clustered around the railway museum district.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Subcultures, NeverNeverLand, and Utrecht Board Game Meetup host weekly English-friendly sessions, perfect for Trey's prototyping nights. Family cafes keep Sunday afternoons relaxed with new releases on tap.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "TivoliVredenburg's five halls, De Helling, and indie venues along the Oudegracht cover everything from orchestral scores to game-music concerts. Babysitters are easier to book here than in Amsterdam's pricier market.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Dutch Game Garden's incubator, UtrechtJS, and Women in Games NL ensure there is always a meetup near Centraal. Parent co-ops in Leidsche Rijn and Lombok make social onboarding straightforward for Sarah.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Bike paths shoot straight to Amelisweerd woods, the Vecht river, and Utrechtse Heuvelrug trails, so fresh air is always close. The family only needs a car when chasing alpine adventures abroad.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "In Utrecht, a multi-party parliamentary system with proportional representation rewards coalition building, matching the family's preference for pluralistic governance. Fragmentation can slow legislation but keeps extremes in check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "In Utrecht, religious parties hold seats yet rarely impose doctrine on policy, so secular families like this one rarely encounter faith-based legislation. Debates around education funding are the main area where faith still matters.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "In Utrecht, collective bargaining, works councils, and strict dismissal protections empower employees while still allowing flexible schedules. This safeguards Sarah if she opts for part-time or remote roles.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "In Utrecht, the national ethos blends social liberalism with pro-business pragmatism, which fits the family's progressive-but-entrepreneurial stance. Populist voices occasionally push harder on migration or cultural issues.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "In Utrecht, institutions are resilient and courts independent, yet recent far-right gains demand vigilance—exactly the concern highlighted in the family profile. Civil society remains active in defending democratic norms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "In Utrecht, a regulated market economy balances startup support with social safety nets, ideal for launching an indie studio without sacrificing healthcare. High taxes and compliance requirements still add overhead.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "In Utrecht, long-term NATO membership, low crime, and steady institutions give the family confidence in long-horizon planning. Coalition reshuffles rarely disrupt daily life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "In Utrecht, independent media and public broadcasters provide diverse viewpoints, satisfying the family's desire for pluralistic information. Government messaging exists but faces strong journalistic scrutiny.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "In Utrecht, public campaigns focus on health, climate, and civic cohesion rather than nationalist narratives, aligning with the family's expectations. Spin becomes noticeable mainly during sensitive tax or benefits scandals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "In Utrecht, housing, education, and welfare supports are generous compared to the US, supporting the family's work-life balance goals. Policy trade-offs occasionally prioritize budget discipline over rapid expansion.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "In Utrecht, confidence dipped after the childcare benefits scandal, so newcomers should expect candid skepticism in local conversations. Transparency measures are improving but trust has not fully rebounded.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "In Utrecht, transparency International ranks the Netherlands among the least corrupt, reinforcing the family's need for predictable bureaucracy. Isolated procurement controversies rarely touch daily life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "In Utrecht, when issues arise they usually involve lobbying or housing development favoritism rather than petty bribery. Staying informed through local news helps the family navigate zoning or permit decisions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family apartments near the historic core trigger bidding wars, yet newer districts like Leidsche Rijn and Kanaleneiland offer modern townhomes if the family moves quickly. Expect to document income carefully for corporate landlords.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Utrecht feels safe even after dark, with police focusing on bike theft and occasional nightlife scuffles near Neude. Choosing residential streets keeps the kids' cycling routes low-stress.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "In Utrecht, universal coverage, strong primary care, and maternity support meet the family's standards for accessible healthcare. Waiting lists for specialists exist but are usually manageable with referrals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "In Utrecht, once insured through a Dutch policy, migrants receive the same GP-led care, though English-speaking specialists can book out quickly. The family should register with a huisarts immediately after arrival.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "In Utrecht, generous parental leave, child benefits, and school-based aftercare give the household multiple supports. Administrative delays can occur but usually resolve with municipal help.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "In Utrecht, mainstream policies assume dual working parents with government-backed care, aligning with this family's structure. Navigating Dutch-language portals is the main adjustment.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "In Utrecht, Dutch schools rank well internationally and emphasize project-based learning that suits curious kids. We would monitor capacity issues in fast-growing suburbs to secure preferred tracks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "U-OV buses, the Uithoflijn tram, and the country's busiest rail hub keep Utrecht exceptionally connected. Late-night service tapers in outer districts, so the family keeps OV-fietsen or Greenwheels memberships as backup.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "In Utrecht, a coordinated market economy with strong social partners supports entrepreneurship while cushioning shocks. Regulations are thorough, so Trey will need a bookkeeper for any studio venture.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "In Utrecht, payroll withholding covers most obligations and MijnBelastingdienst offers digital filings, yet forms remain Dutch-first. Hiring a tax advisor early will help the family leverage deductions and avoid surprises.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "In Utrecht, dual tech incomes land in the 36.97% and 49.5% brackets, but the 30% ruling can shield a chunk of Trey's salary for five years. Planning around pension contributions and childcare deductions keeps net pay comfortable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "In Utrecht, opening accounts with a BSN is straightforward, and instant SEPA transfers, iDEAL, and contactless payments simplify daily life. Some niche US cards may still require backup options.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Housing and childcare remain expensive, but costs run 10–15% below Amsterdam while groceries and transit stay similar. Careful budgeting leaves room for travel and the kids' activities.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "In Utrecht, the AOW public pension plus mandatory employer schemes provide solid old-age income for lifelong residents. Voluntary savings still matter as demographics age.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "In Utrecht, expats accrue AOW only for years lived in the Netherlands and rely heavily on employer pensions or third-pillar savings. The family would need disciplined private investing if they relocate mid-career.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "In Utrecht, highly Skilled Migrant, EU Blue Card, startup, and self-employed visas give the family multiple entry routes. Each path has clear salary thresholds or business plans, so preparation is key but outcomes are predictable.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "In Utrecht, IND officers regularly process US applications, and the Dutch-American Friendship Treaty offers an entrepreneurial fallback. Bureaucracy can feel impersonal, so patient follow-up is essential.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "In Utrecht, permits typically run two to five years and convert to permanent residency after five years of legal stay. The family must track renewal deadlines but the pathway is well-trodden.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "In Utrecht, naturalization after five years is feasible with integration exams, yet dual nationality is restricted. The family would weigh renouncing US citizenship against the benefits of Dutch passports.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "In Utrecht, spouses and minor children join easily, but polyamorous partners beyond one registered relationship lack recognition. Planning documents should focus on the legally acknowledged couple.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "In Utrecht, once an employer submits, highly skilled migrant approvals arrive in two to four weeks; fees hover around €350-400 per person. Delays mostly stem from housing registration or biometrics appointments.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "In Utrecht, maintaining salary thresholds, municipal registration, and Dutch health insurance keeps the family in good standing. Audits are structured but missing paperwork can trigger costly reviews.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "In Utrecht, the Netherlands generally requires renouncing previous citizenships, so the family would need a treaty-based exemption or Dutch spouse to keep US passports. Planning for this constraint is critical.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "In Utrecht, all adults need a BSN, DigiD, and Dutch-language correspondence to access benefits, making early administrative coaching invaluable. Health insurance enrollment within four months is mandatory.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Dutch Game Garden alumni like Ronimo, Abbey Games, and Nixxes keep Utrecht on recruiters' radar. Trey finds steady contract work through the incubator network even if AAA seats are fewer than in Amsterdam.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios such as Ronimo Games, Abbey Games, and Nixxes maintain strong teams in and around Utrecht. Their presence proves the city can sustain ambitious projects despite its smaller size.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Dutch Game Garden's monthly network lunches, Indigo showcase events, and local game jams keep the community tight-knit. English sessions welcome newcomers, so Trey and Sarah can plug in quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Access to Dutch Game Garden mentorship, ROM Utrecht Region funding, and Creative Industries grants makes launching a studio realistic. The family still needs a polished business plan, but support structures are nearby.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "In Utrecht, nationwide fiber, smart logistics, and digital government services keep daily friction low for a remote-working family. Occasional rail maintenance or housing energy retrofits are the main disruptions.",
+      "alignmentValue": 9
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add detailed Amsterdam, Utrecht, and Eindhoven city reports covering all evaluation keys with updated alignment values and justifications tailored to the family profile
- register the new Netherlands city files in `main.json` so they surface alongside the country entry

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e33247cb9c8321bf031e22f7aa444c