### PR TITLE
Add Barcelona, Valencia, and San Sebastián city reports

### DIFF
--- a/main.json
+++ b/main.json
@@ -540,7 +540,21 @@
     },
     {
       "name": "Spain",
-      "file": "reports/spain_report.json"
+      "file": "reports/spain_report.json",
+      "cities": [
+        {
+          "name": "Barcelona",
+          "file": "reports/spain_barcelona_report.json"
+        },
+        {
+          "name": "San Sebastián",
+          "file": "reports/spain_san_sebastian_report.json"
+        },
+        {
+          "name": "Valencia",
+          "file": "reports/spain_valencia_report.json"
+        }
+      ]
     },
     {
       "name": "Northern Ireland",

--- a/reports/spain_barcelona_report.json
+++ b/reports/spain_barcelona_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "ES",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Barcelona’s 22@ tech district hosts Microsoft, HP, and fast-growing consultancies that post senior .NET roles monthly, yet Spanish-language teams and €55–70k salaries mean Trey still leans on networking or remote EU clients for top-tier compensation.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Dense traffic corridors and Saharan dust pushes leave Barcelona’s PM2.5 hovering around 13 µg/m³, so we track daily AQI and run filters for the kids on the frequent ‘unhealthy for sensitive groups’ afternoons.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Urban Spain is largely secular with legal separation of church and state, though Catholic holidays and school traditions still expect nominal participation in some regions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Democratic institutions, courts, and a free press remain robust, but Catalan independence disputes and periodic far-right surges keep us watching reforms that shore up checks and balances.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Bizum instant transfers, SEPA access, and contactless payments are ubiquitous once we secure NIE/TIE numbers, yet opening the first account still requires in-person paperwork and patience.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Seven urban Blue Flag beaches sit on the T4 tram line with lifeguards, ramps, and family showers, but midsummer crowds and pickpocketing nudge us toward Castelldefels or the Costa Brava on peak weekends.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Game stores like Kaburi, Club Kritik meetups, and English-friendly events at Mecatol Rex keep tabletop nights packed, giving Trey plenty of playtest groups within a 20-minute metro ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Municipal Escoles Bressol cap fees on a sliding scale, yet Barcelona waitlists open each spring and many families bridge gaps with canguro sitters or shared nannies until a spot opens.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Superilla superblocks, shaded plazas, and playground-dense Eixample blocks let Anduin scoot safely, though we still dodge scooters on shared paths after work hours.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Catalonia now funds the P2 year and offers income-based Escoles Bressol tuition, but citizens still plan ahead to secure bilingual slots near home.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we have NIE numbers and social security registration, the city extends subsidies, yet digital nomad families often cover full fees the first year while paperwork clears.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Climbing gyms in Poblenou, board-game cafés, and year-round coastal cycling mirror our interests, and English-language RPG tables meet weekly across the city.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighborhood casteller teams, AMPA parent associations, and cooperative markets help newcomers plug in, but we invest in Catalan classes to build trust beyond the expat bubble.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Residency rules expect physical presence, timely empadronamiento, and tax filings; missing appointments or travel days can trigger denials even when we follow the published steps.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Three-bedroom rentals in Gràcia or Poblenou now average €1,800–€2,200 and capped tourist rentals squeeze supply, so we balance proximity to schools against higher housing costs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Spain generally requires US nationals to renounce prior citizenship at naturalization, with limited exceptions for Ibero-American ties.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Barcelona’s metro economy rebounded with biotech, logistics, and tourism, keeping unemployment near 8%, yet reliance on visitors and seasonal hospitality still makes downturns hit service workers first.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A social market model blends EU competition rules with active welfare programs, even as labor-market rigidity and bureaucracy slow business formation.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Catalonia’s public schools deliver solid PISA math scores and bilingual Catalan-Spanish instruction, though families often supplement with English academies to keep kids trilingual.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Large employers like Amazon, Glovo, and NTT Data sponsor highly skilled visas, but many Barcelona startups still prefer EU talent unless a candidate brings rare cloud architecture experience.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Barcelona expands low-emission zones and green corridors, yet port emissions and limited tree cover mean we still plan park days around heat and smog advisories.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Progressive national and regional income taxes plus social security push combined effective rates into the mid-30s for dual tech incomes, even after family deductions.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September starts around 24 °C/75 °F with warm swims, tapering to 14 °C/57 °F by November as Mediterranean storms bring short, intense downpours.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Child-friendly plazas, Sunday family rituals, and multigenerational housing norms create supportive communities, though we still navigate late dining customs for little kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and dependent children attach to most residence permits without quotas, with only adult dependents needing extra financial proof.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Child allowances, universal healthcare, and longer paid leave have expanded recently, yet benefits remain modest compared with Nordic benchmarks and vary by region.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical households access healthcare, preschool, and tax deductions, but navigating means-tested housing or large-family perks demands persistent paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Visa families can enroll in healthcare and schooling once registered, yet some cash benefits and housing aid require permanent residency status.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Cities embrace eclectic street style and size-inclusive brands, while smaller towns still favor classic Mediterranean looks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Tailored casual wear and creative sneaker culture thrive in metros, though conservative offices still expect polished business attire.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Feminist movements have shifted norms toward autonomy and professional ambition, even if older generations still comment on appearance or parenting choices.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios in Barcelona, Madrid, and Málaga recruit steadily for Unity and Unreal roles, but senior openings cluster in a few firms or require hybrid Spanish-English teams.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Self-ID legislation, public healthcare coverage for transition care, and active Pride organizations make major cities affirming for gender-diverse friends and family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal pay laws, gender-violence courts, and strong representation policies exist, yet executive leadership remains male-dominated and enforcement varies regionally.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-earner households are the norm, but machismo lingering in some workplaces means Sarah may still shoulder expectation to manage school logistics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Residence cards grant healthcare, schooling, and banking access, yet employment changes and extended travel still require notifying authorities to stay compliant.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Spain faces hotter, longer summers, Mediterranean droughts, and wildfire seasons that already strain water supplies, so we would plan around rising adaptation costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Universal coverage delivers strong primary care and pediatric services, with specialist waits of a few months in busy metro hospitals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "After registering and contributing to social security, residents join the public system, but newcomers must bridge the first year with comprehensive private insurance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Public universities charge €1–2k per year with robust scholarship programs, though selective degrees hinge on competitive entrance exams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students access most public programs but pay higher tuition bands and juggle residency paperwork for internships.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Barcelona’s rent caps and 7% yearly renewals favor tenants once a lease is signed, but scarce inventory and multi-month deposits make landing a family flat a stressful sprint.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "The tax agency offers online filing and pre-filled drafts, yet autonomous-community surcharges, wealth tax rules, and dual-reporting for US citizens keep accountants on speed dial.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Zoned public schools guarantee placement, but quality varies and families often queue for bilingual or concertado slots to secure smaller classes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children can enroll in public schools after empadronamiento, though language support and bilingual seats depend heavily on the district.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Tourism and tech mean we hear English in Ciutat Vella and 22@, yet school meetings, pediatricians, and government counters default to Catalan or Spanish.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, trans-inclusive laws, and vibrant Pride scenes in Madrid and Barcelona foster a welcoming environment for a queer-affirming, polyamory-positive family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist parties like Sumar and regional movements shape debate, yet national politics still balances socialist ideas with centrist economics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Younger men embrace caregiving and emotional openness, while traditional machismo comments persist in some workplaces and extended families.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "BarcelonaJS, IndieDevDay, SheCodes, and polyam meetup groups fill the calendar, making it easy to blend professional networking with social life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The 2024 SMI sits at €1,134/month across 14 payments, covering basics outside the big two metros but still tight for single-income households.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fiber broadband, T-Mobilitat smartcards, and extensive bike lanes keep daily logistics smooth, though aging water pipes still deliver occasional brown tap alerts after heavy rains.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Weekend trains reach Costa Brava coves, Montserrat’s trails, and Collserola’s forests, giving us easy escapes from the urban core.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Serious hazards are limited to Mediterranean flash floods and heat waves; earthquake and wildfire risks stay low compared with inland Spain.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Collserola’s trailheads and the Besòs river park sit on the metro map, so spur-of-the-moment hikes or bike rides are practical without a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Festivals like Primavera Sound, neighborhood festa majors, and late-night jazz venues offer constant live music with safe late-night transit home.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Evenings run late with 22:00 dinners and 02:00 club closings, so we plan babysitters and quiet Sundays to balance the city’s nocturnal energy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Barcelona Game Dev, GameBCN, and the yearly IndieDevDay expo anchor a collaborative scene where Trey can swap feedback or find contractors.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Ubisoft Barcelona, King, Socialpoint, Tripledot, and local VR shops keep hundreds of developers employed, supporting both AAA and mobile pipelines.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Accelerators like GameBCN, ENISA soft loans, and Catalonia’s ACCIÓ grants help founders, but high payroll taxes still push us to budget carefully for a studio launch.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Barcelona’s creative hustle means jammed metros at rush hour and dense appointment schedules, even if Mediterranean lunches stretch longer than in the US.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools expect active AMPA participation and Catalan-language story times, yet teachers respect dual-income households and after-school care fills gaps.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization takes 10 years of legal residency, language and civics exams, and a formal renunciation ceremony, with approval timelines stretching beyond a year.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International places Spain mid-table in the EU, and recurring municipal and housing scandals keep public skepticism alive.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A parliamentary monarchy with proportional representation delivers coalition governance, albeit with occasional deadlocks during contentious reforms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Barcelona’s queer and kink scenes host openly polyam networks and legal protections cover consensual non-monogamy, though discretion is still wise in older Catalan circles.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Escoles Bressol offer 8:00–17:00 schedules with hot meals, but applications close early and many expat families bridge with private nurseries that cost €600–€900 monthly.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International schools like ASB, Benjamin Franklin, and SEK-Catalunya provide IB or US curricula, yet entrance exams and €10k+ tuition demand planning.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Barcelona city hall champions feminist, pro-LGBTQ+ policies and sanctuary-city stances, aligning with the family’s progressive priorities.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government communications emphasize social cohesion and EU solidarity, yet national parties spin narratives sharply during election cycles.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters and independent press offer plural perspectives, but partisan tabloids and political disinformation spikes near elections demand media literacy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "An integrated metro, FGC commuter lines, trams, and night buses cover most neighborhoods every 5–10 minutes, so a car is optional except for rural excursions.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Policy debates remain largely secular, even if Catholic holidays and concordat funding periodically re-enter national conversations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Coworking hubs like Aticco and OneCoWork, plus plentiful expat remote workers, normalize hybrid schedules even if some legacy firms still prefer office presence.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Digital nomad, entrepreneur, and non-lucrative visas offer multi-year renewals, but each renewal cycle re-checks income, insurance, and local registration.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Spain's contributory pension replaces roughly 70% of wages and pairs with universal healthcare, even as reforms slowly raise the retirement age.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Permanent residents who contribute for 15+ years qualify for state pensions, but fragmented work histories reduce payouts and require supplemental savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Temporary residents can pay into the system, yet long vesting periods and portability rules mean we would rely on private or US-based retirement accounts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Barcelona hosts Rails shops in fintech and SaaS niches, but the bulk of new postings skew toward JavaScript or Java, so Sarah may lean on remote US clients for top pay.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime stays low, yet pickpocketing on Las Ramblas and metro lines requires constant vigilance and anti-theft bags.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public, concertada, and international schools operate within a 30-minute commute, but placement lotteries mean we list multiple choices to secure a seat.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Mediterranean waters warm to 25–26 °C (77–79 °F) in July–August and stay swimmable from late May through September, dropping to 14 °C (57 °F) in winter.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Barcelona offers mild, sunny winters and warm, humid summers; spring and fall bring brief rain bursts but few weather extremes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Sex-positive clubs, inclusive sex education, and normalized public affection make Barcelona comfortable for an openly polyamorous family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, minimum income programs, and expanding parental leave form a solid safety net even if benefit administration can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March mornings start near 10 °C/50 °F and afternoons climb to 18 °C/64 °F by May, with light breezes off the Mediterranean.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Institutions are steady, yet Catalan independence debates and fragmented parliaments periodically trigger snap elections and protests.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Mainstream politics emphasizes social democracy and EU integration, accommodating regional identities even when rhetoric turns sharp.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Competitive markets and EU oversight balance with strategic state intervention in energy and transport to protect consumers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs reach 28–31 °C (82–88 °F) with humid nights around 23 °C (73 °F), so siestas and air-conditioning help the kids rest.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Digital nomad and non-lucrative visas typically take 4–8 months with translation, apostille, and legal fees pushing total costs into the mid-four figures.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Survey data shows only about a third of Spaniards trust national institutions, reflecting fatigue with corruption scandals despite ongoing transparency reforms.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Urban development and party financing scandals remain the main risks, prompting audits when dealing with permitting or large contracts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers see €50–65k offers, with remote-friendly unicorns like Glovo nudging into the low €70s when candidates bring cloud leadership.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays start with boqueria markets, beach mornings, or Tibidabo hikes; Sundays shift to museum visits or neighborhood festa major events before relaxed tapas dinners.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run roughly 09:00–16:30 with comedor lunch, while tech offices expect 09:30–18:30; flex hours and teletrabajo days help cover pickup.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law mandates 30 paid calendar days plus 14 public holidays, and unions enforce taking the full allotment.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Many firms close in August and add bridge days around holidays, yielding 32–35 days off once seniority perks kick in.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Relations with Portugal, France, and Morocco are cooperative, even as occasional Gibraltar or fishing disputes flare up.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Spaniards balance pride in regional identities with enthusiasm for modern, multicultural cities and EU citizenship.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors generally see Spain as friendly and culturally rich, while noting persistent economic and Catalan debates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Digital nomad, non-lucrative, entrepreneur, and golden visas fit our profile, but each demands proof of income, insurance, and in-person appointments.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "A sizable US and UK expat base, municipal welcome centers, and bilingual services ease onboarding, though landlords still favor long-term references.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Modernist architecture, indie game jams, and beach-to-mountain weekends deliver the creative, cosmopolitan lifestyle the family craves.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters hover between 7–15 °C (45–59 °F); chilly spells are damp but brief, and snow is essentially nonexistent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "The statutory 40-hour week persists, yet many firms pilot 37.5-hour schedules or flexible Fridays, leaving room to prioritize family.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Generous vacation policies and midweek cultural events support balance, yet late meeting schedules and August shutdowns require planning to sync with US clients.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong unions, collective bargaining, and recent platform-worker reforms provide solid protections, though enforcement can lag for freelancers.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/spain_san_sebastian_report.json
+++ b/reports/spain_san_sebastian_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "ES",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Donostia’s tech scene clusters around Gipuzkoa’s manufacturing firms and research centers; .NET roles exist at companies like Ikor or Ibermática, but openings are fewer and often bilingual in Spanish and Basque.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Atlantic winds keep annual PM2.5 around 8 µg/m³, with only occasional spikes from port traffic or wood-burning stoves in winter.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Urban Spain is largely secular with legal separation of church and state, though Catholic holidays and school traditions still expect nominal participation in some regions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Democratic institutions, courts, and a free press remain robust, but Catalan independence disputes and periodic far-right surges keep us watching reforms that shore up checks and balances.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Bizum instant transfers, SEPA access, and contactless payments are ubiquitous once we secure NIE/TIE numbers, yet opening the first account still requires in-person paperwork and patience.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "La Concha and Zurriola beaches sit within a 10-minute walk, offering lifeguards, calm family coves, and a dedicated surf zone for year-round seaside routines.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Local shops like Joker and associations such as Donostirol keep weekly tabletop nights alive, though English-language campaigns require a bit more organizing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "The Basque Haurreskolak network offers subsidized nurseries with long hours, but high demand in city-center schools means we apply early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Wide promenades, low traffic, and plentiful playgrounds—from Alderdi Eder to Amara—make the compact city easy to navigate with kids.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Basque citizens receive income-based childcare fees, generous birth grants, and extended parental leave top-ups, creating one of Spain’s strongest family support systems.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Resident visa holders access the same Haurreskolak subsidies after registering with Osakidetza and the municipal padrón, though paperwork often requires Basque translations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Surfing, trail running on Monte Igueldo, and pintxo crawls align with our outdoor and foodie interests, while board-game groups meet weekly in the old town.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighborhood sociedades gastronómicas and school-wide Basque festivals build tight-knit circles; learning Euskara helps us move beyond an expat niche.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Residency rules expect physical presence, timely empadronamiento, and tax filings; missing appointments or travel days can trigger denials even when we follow the published steps.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "San Sebastián rivals Madrid for housing costs—three-bedroom flats often exceed €1,800 and tourist demand keeps prices high even off-season.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Spain generally requires US nationals to renounce prior citizenship at naturalization, with limited exceptions for Ibero-American ties.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Gipuzkoa enjoys low unemployment near 7% thanks to advanced manufacturing and research funding, though the economy is smaller and more specialized than Spain’s major metros.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A social market model blends EU competition rules with active welfare programs, even as labor-market rigidity and bureaucracy slow business formation.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Basque schools score above national averages and offer strong immersion tracks, yet parents choose between Basque-dominant or trilingual models to maintain English exposure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Larger Basque firms sponsor skilled visas, but the city’s SME-heavy market hires slowly and expects regional language proficiency.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected green belts, clean rivers, and aggressive recycling keep environmental quality high, even if winter humidity and salt air demand extra home maintenance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Progressive national and regional income taxes plus social security push combined effective rates into the mid-30s for dual tech incomes, even after family deductions.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September stays around 21 °C/70 °F with warm seas, cooling to 13 °C/55 °F by November as Atlantic showers become frequent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Child-friendly plazas, Sunday family rituals, and multigenerational housing norms create supportive communities, though we still navigate late dining customs for little kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and dependent children attach to most residence permits without quotas, with only adult dependents needing extra financial proof.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Child allowances, universal healthcare, and longer paid leave have expanded recently, yet benefits remain modest compared with Nordic benchmarks and vary by region.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical households access healthcare, preschool, and tax deductions, but navigating means-tested housing or large-family perks demands persistent paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Visa families can enroll in healthcare and schooling once registered, yet some cash benefits and housing aid require permanent residency status.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Cities embrace eclectic street style and size-inclusive brands, while smaller towns still favor classic Mediterranean looks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Tailored casual wear and creative sneaker culture thrive in metros, though conservative offices still expect polished business attire.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Feminist movements have shifted norms toward autonomy and professional ambition, even if older generations still comment on appearance or parenting choices.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios in Barcelona, Madrid, and Málaga recruit steadily for Unity and Unreal roles, but senior openings cluster in a few firms or require hybrid Spanish-English teams.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Self-ID legislation, public healthcare coverage for transition care, and active Pride organizations make major cities affirming for gender-diverse friends and family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal pay laws, gender-violence courts, and strong representation policies exist, yet executive leadership remains male-dominated and enforcement varies regionally.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-earner households are the norm, but machismo lingering in some workplaces means Sarah may still shoulder expectation to manage school logistics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Residence cards grant healthcare, schooling, and banking access, yet employment changes and extended travel still require notifying authorities to stay compliant.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Spain faces hotter, longer summers, Mediterranean droughts, and wildfire seasons that already strain water supplies, so we would plan around rising adaptation costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Universal coverage delivers strong primary care and pediatric services, with specialist waits of a few months in busy metro hospitals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "After registering and contributing to social security, residents join the public system, but newcomers must bridge the first year with comprehensive private insurance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Public universities charge €1–2k per year with robust scholarship programs, though selective degrees hinge on competitive entrance exams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students access most public programs but pay higher tuition bands and juggle residency paperwork for internships.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Limited housing stock and strict vacation-rental limits make finding a family flat competitive; owners often request multi-month deposits and local co-signers.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "The tax agency offers online filing and pre-filled drafts, yet autonomous-community surcharges, wealth tax rules, and dual-reporting for US citizens keep accountants on speed dial.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Zoned public schools guarantee placement, but quality varies and families often queue for bilingual or concertado slots to secure smaller classes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children can enroll in public schools after empadronamiento, though language support and bilingual seats depend heavily on the district.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Tourism workers speak English, but public services default to Spanish and Basque, so everyday errands require solid Spanish and a willingness to pick up Euskara basics.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, trans-inclusive laws, and vibrant Pride scenes in Madrid and Barcelona foster a welcoming environment for a queer-affirming, polyamory-positive family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist parties like Sumar and regional movements shape debate, yet national politics still balances socialist ideas with centrist economics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Younger men embrace caregiving and emotional openness, while traditional machismo comments persist in some workplaces and extended families.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Coworkings like Talent House and Impact Hub host remote worker events, while international parents gather through Goazen or Meetup, albeit less frequently than in big cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The 2024 SMI sits at €1,134/month across 14 payments, covering basics outside the big two metros but still tight for single-income households.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fiber broadband, the Euskotren Topo line, and frequent regional buses connect neighborhoods smoothly, though flights still route via Bilbao for long-haul trips.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Coastal cliffs, lush hills, and nearby Basque villages deliver postcard scenery, all within 30 minutes by bus or funicular.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major hazards are limited to heavy Atlantic storms and occasional localized flooding; earthquakes and wildfires are rare.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Monte Urgull hikes, Urumea river paths, and nearby Parque Natural Pagoeta make spontaneous outdoor adventures easy without a car.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Pintxo bars, jazz festivals, and Kursaal concerts keep nights lively, even if venues close earlier than in Barcelona.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Locals favor pintxo crawls and social clubs over mega-clubs, so evenings wrap by 01:00—great for parents balancing sleep.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "BasqueGame meetups and the Tecnalia research cluster provide networking, but gatherings are quarterly and smaller than Spain’s big-city scenes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Small studios like Relevo, Virtualware satellite teams, and indie outfits collaborate locally, offering boutique rather than large-scale opportunities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "BEAZ grants, Basque Industry 4.0 programs, and provincial innovation funds support creative tech startups, though talent recruiting may require remote hires.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Compact geography, short commutes, and a culture of long lunches create a relaxed pace that matches Sarah’s need for slower rhythms.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools encourage family involvement in Basque cultural events and expect kids to pick up Euskara, but schedules respect dual-working parents with after-school activities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization takes 10 years of legal residency, language and civics exams, and a formal renunciation ceremony, with approval timelines stretching beyond a year.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International places Spain mid-table in the EU, and recurring municipal and housing scandals keep public skepticism alive.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A parliamentary monarchy with proportional representation delivers coalition governance, albeit with occasional deadlocks during contentious reforms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Basque cities lean progressive, and LGBTQ+ centers host occasional poly meetups, though the scene is smaller and more discreet than in Barcelona.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Haurreskolak nurseries operate extended hours with hot meals, and private guarderías fill remaining demand at €500–€700 per month.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "A handful of concertada and international schools—like Mary Ward or the French Lycée—offer alternatives, but seats are limited and tuition is higher than the national average.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Basque institutions pair strong social services with pluralistic politics, and Donostia regularly backs feminist and LGBTQ+ initiatives.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government communications emphasize social cohesion and EU solidarity, yet national parties spin narratives sharply during election cycles.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters and independent press offer plural perspectives, but partisan tabloids and political disinformation spikes near elections demand media literacy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "DBus, Euskotren, and bike lanes cover the compact city well, with 10-minute headways through most of the day; only late-night service thins out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Policy debates remain largely secular, even if Catholic holidays and concordat funding periodically re-enter national conversations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Co-working hubs cater to remote professionals and time zones align well with the UK, but some Basque employers still prefer on-site collaboration.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Digital nomad, entrepreneur, and non-lucrative visas offer multi-year renewals, but each renewal cycle re-checks income, insurance, and local registration.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Spain's contributory pension replaces roughly 70% of wages and pairs with universal healthcare, even as reforms slowly raise the retirement age.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Permanent residents who contribute for 15+ years qualify for state pensions, but fragmented work histories reduce payouts and require supplemental savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Temporary residents can pay into the system, yet long vesting periods and portability rules mean we would rely on private or US-based retirement accounts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles are rare locally; Sarah would likely combine remote contracts with occasional Bilbao meetups to stay connected.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "San Sebastián posts some of Spain’s lowest crime rates, so kids can explore plazas with minimal worry beyond standard tourist pickpocket awareness.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public models A, B, and D let families choose the mix of Basque and Spanish instruction, but English-heavy curricula require private or concertada seats.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Bay waters warm to 21–22 °C (70–72 °F) in August—refreshing but cooler than the Mediterranean—and drop to 12 °C (54 °F) in winter.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Winters are mild and damp, summers rarely top 26 °C (79 °F), and frequent showers keep the landscape green but require good rain gear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Basque society is broadly liberal, Pride events are well-supported, and sex education is comprehensive, even if nightlife is more low-key.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, minimum income programs, and expanding parental leave form a solid safety net even if benefit administration can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Spring runs 9–17 °C (48–63 °F) with alternating sun and showers, making layers essential for playground time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Institutions are steady, yet Catalan independence debates and fragmented parliaments periodically trigger snap elections and protests.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Mainstream politics emphasizes social democracy and EU integration, accommodating regional identities even when rhetoric turns sharp.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Competitive markets and EU oversight balance with strategic state intervention in energy and transport to protect consumers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summer highs stay around 22–25 °C (72–77 °F) with cool evenings near 18 °C (64 °F), keeping heat manageable without heavy AC use.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Digital nomad and non-lucrative visas typically take 4–8 months with translation, apostille, and legal fees pushing total costs into the mid-four figures.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Survey data shows only about a third of Spaniards trust national institutions, reflecting fatigue with corruption scandals despite ongoing transparency reforms.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Urban development and party financing scandals remain the main risks, prompting audits when dealing with permitting or large contracts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers earn €45–55k, with larger Basque industrial firms paying a bit more when roles involve cloud or IoT modernization.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays start with mercados and pintxo crawls before afternoon surf or hikes; Sundays lean toward family bike rides along the Urumea and film screenings at Tabakalera.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools usually run 09:00–16:30 with lunch, and many companies embrace jornada intensiva or 08:00–15:00 summer hours, freeing late afternoons for family time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law mandates 30 paid calendar days plus 14 public holidays, and unions enforce taking the full allotment.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Many firms close in August and add bridge days around holidays, yielding 32–35 days off once seniority perks kick in.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Relations with Portugal, France, and Morocco are cooperative, even as occasional Gibraltar or fishing disputes flare up.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Spaniards balance pride in regional identities with enthusiasm for modern, multicultural cities and EU citizenship.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors generally see Spain as friendly and culturally rich, while noting persistent economic and Catalan debates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Digital nomad, non-lucrative, entrepreneur, and golden visas fit our profile, but each demands proof of income, insurance, and in-person appointments.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Municipal support offices and an international community around Talent House help newcomers settle, though Basque-language paperwork can slow the first few months.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "World-class gastronomy, immediate access to surf and mountains, and a laid-back Basque culture make Donostia an appealing lifestyle upgrade.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters average 6–13 °C (43–55 °F); frost is rare but Atlantic storms bring frequent rain and wind.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "The statutory 40-hour week persists, yet many firms pilot 37.5-hour schedules or flexible Fridays, leaving room to prioritize family.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Basque labor norms emphasize reasonable hours, five-plus weeks of vacation, and strong worker councils, aligning well with Sarah’s work-life goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong unions, collective bargaining, and recent platform-worker reforms provide solid protections, though enforcement can lag for freelancers.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/spain_valencia_report.json
+++ b/reports/spain_valencia_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "ES",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Valencia’s Parc Tecnològic and 22@-style innovation hubs keep .NET roles flowing in fintech, logistics, and outsourcing shops, though many offers land in the €40–55k range and expect conversational Spanish.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Sea breezes and low-rise sprawl keep annual PM2.5 near 9–10 µg/m³; we only monitor for Saharan dust events or Fallas fireworks spikes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Urban Spain is largely secular with legal separation of church and state, though Catholic holidays and school traditions still expect nominal participation in some regions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Democratic institutions, courts, and a free press remain robust, but Catalan independence disputes and periodic far-right surges keep us watching reforms that shore up checks and balances.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Bizum instant transfers, SEPA access, and contactless payments are ubiquitous once we secure NIE/TIE numbers, yet opening the first account still requires in-person paperwork and patience.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Malvarrosa and Patacona beaches run wide with fine sand, lifeguards, and boardwalk paella spots, while quieter dunes at El Saler sit 20 minutes south in Albufera Natural Park.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Clubs like Homoludicus, Rol Valencia, and Freakmonkey host weekly Spanish- and English-language sessions, though the scene is cozier than Barcelona’s.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "City-run Escoletes Municipals and the Generalitat’s free P2 classrooms reduce fees, yet we still register early to secure extended-hour spots near work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Turia Gardens, bikeable avenidas, and traffic-calmed plazas let the kids roam, though midday heat in July pushes playground time to mornings and evenings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Valencian families benefit from 0–3 subsidies, free P2, and comedor meal aid, making public nursery coverage fairly generous.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once padrón registration and social security numbers are in place, resident visa holders tap the same subsidies, with only minor translation hurdles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Beach volleyball leagues, climbing gyms like Sharma Valencia, and year-round cycling align with our interests, though niche tabletop meetups skew Spanish-first.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Fallas casal groups, neighborhood orchards, and school AMPA meetings make it easy to know neighbors if we embrace Valencian traditions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Residency rules expect physical presence, timely empadronamiento, and tax filings; missing appointments or travel days can trigger denials even when we follow the published steps.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Family apartments near the beach or Ruzafa list around €1,200–€1,400, and groceries stay 15–20% cheaper than Barcelona, letting us save without compromising lifestyle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Spain generally requires US nationals to renounce prior citizenship at naturalization, with limited exceptions for Ibero-American ties.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "The metro area mixes logistics, ceramics, and tourism with unemployment near 10%; growth is steady but less diversified than Madrid or Barcelona.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A social market model blends EU competition rules with active welfare programs, even as labor-market rigidity and bureaucracy slow business formation.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Valencian public schools meet national averages with bilingual Valencian-Spanish tracks, yet English immersion often requires concertada or private options.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Larger firms like Edicom or Ford Almussafes sponsor blue cards, but many local SMEs expect EU status, so Trey may rely on remote contracts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Turia Park, urban gardens, and regional recycling programs keep daily life green, though port expansion and fertilizer runoff in Albufera still need watchdog attention.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Progressive national and regional income taxes plus social security push combined effective rates into the mid-30s for dual tech incomes, even after family deductions.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "October days hover around 24 °C/75 °F before sliding to 15 °C/59 °F in November, with occasional gota fría storms dumping intense rain.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Child-friendly plazas, Sunday family rituals, and multigenerational housing norms create supportive communities, though we still navigate late dining customs for little kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and dependent children attach to most residence permits without quotas, with only adult dependents needing extra financial proof.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Child allowances, universal healthcare, and longer paid leave have expanded recently, yet benefits remain modest compared with Nordic benchmarks and vary by region.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical households access healthcare, preschool, and tax deductions, but navigating means-tested housing or large-family perks demands persistent paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Visa families can enroll in healthcare and schooling once registered, yet some cash benefits and housing aid require permanent residency status.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Cities embrace eclectic street style and size-inclusive brands, while smaller towns still favor classic Mediterranean looks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Tailored casual wear and creative sneaker culture thrive in metros, though conservative offices still expect polished business attire.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Feminist movements have shifted norms toward autonomy and professional ambition, even if older generations still comment on appearance or parenting choices.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios in Barcelona, Madrid, and Málaga recruit steadily for Unity and Unreal roles, but senior openings cluster in a few firms or require hybrid Spanish-English teams.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Self-ID legislation, public healthcare coverage for transition care, and active Pride organizations make major cities affirming for gender-diverse friends and family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal pay laws, gender-violence courts, and strong representation policies exist, yet executive leadership remains male-dominated and enforcement varies regionally.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-earner households are the norm, but machismo lingering in some workplaces means Sarah may still shoulder expectation to manage school logistics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Residence cards grant healthcare, schooling, and banking access, yet employment changes and extended travel still require notifying authorities to stay compliant.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Spain faces hotter, longer summers, Mediterranean droughts, and wildfire seasons that already strain water supplies, so we would plan around rising adaptation costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Universal coverage delivers strong primary care and pediatric services, with specialist waits of a few months in busy metro hospitals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "After registering and contributing to social security, residents join the public system, but newcomers must bridge the first year with comprehensive private insurance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Public universities charge €1–2k per year with robust scholarship programs, though selective degrees hinge on competitive entrance exams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students access most public programs but pay higher tuition bands and juggle residency paperwork for internships.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Inventory is healthier than in Madrid, yet desirable barrios like Ruzafa or El Carmen still ask two-month deposits and guarantors for international tenants.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "The tax agency offers online filing and pre-filled drafts, yet autonomous-community surcharges, wealth tax rules, and dual-reporting for US citizens keep accountants on speed dial.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Zoned public schools guarantee placement, but quality varies and families often queue for bilingual or concertado slots to secure smaller classes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children can enroll in public schools after empadronamiento, though language support and bilingual seats depend heavily on the district.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Tourism keeps English serviceable downtown, but schools, clinics, and Ayuntamiento desks expect Spanish or Valencian; learning both opens social doors.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, trans-inclusive laws, and vibrant Pride scenes in Madrid and Barcelona foster a welcoming environment for a queer-affirming, polyamory-positive family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist parties like Sumar and regional movements shape debate, yet national politics still balances socialist ideas with centrist economics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Younger men embrace caregiving and emotional openness, while traditional machismo comments persist in some workplaces and extended families.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Remote workers gather at Vortex and Wayco, tech meetups fill Marina de Empresas, and poly-friendly socials pop up monthly though they’re smaller than Barcelona’s.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The 2024 SMI sits at €1,134/month across 14 payments, covering basics outside the big two metros but still tight for single-income households.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fiber internet and the metro-tram network cover the core, yet regional trains run less frequently and bike lanes still show a few gaps toward the periphery.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Albufera wetlands, orange groves, and the nearby Calderona mountains give us quick access to nature without leaving the province.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Coastal flooding from gota fría storms and periodic droughts are the main risks; wildfires stay inland but remain a seasonal concern.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "The drained Turia riverbed is now an 8-km park for biking and play, and commuter trains reach mountains or coves within an hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Fallas fire parades, Les Arts festival, and live music in Ruzafa keep nights lively, albeit on a smaller scale than Madrid.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Dinner still lands around 21:00, but nightlife feels more relaxed—wine bars, beachfront chiringuitos, and early-closing clubs suit parents balancing sleep.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Events like Valencia Indie Summit, professional groups at Lanzadera, and university labs provide networking, though gatherings are monthly rather than weekly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Codigames, Elite3D (now part of 2K), and digital health studios anchor the local scene, offering mid-sized teams for Trey to tap.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Lanzadera incubator seats, IVF grants, and lower salaries help stretch a runway, but venture capital still gravitates toward Madrid and Barcelona.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Valencia keeps Mediterranean rhythms—bike commutes, long lunches, and shorter queues—making daily life calmer than Spain’s largest metros.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools lean on family involvement for Fallas crafts and festivals, yet administrators respect dual-income households and offer comedor and extra-curricular care.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization takes 10 years of legal residency, language and civics exams, and a formal renunciation ceremony, with approval timelines stretching beyond a year.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International places Spain mid-table in the EU, and recurring municipal and housing scandals keep public skepticism alive.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A parliamentary monarchy with proportional representation delivers coalition governance, albeit with occasional deadlocks during contentious reforms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "LGTBI+ centers and occasional poly meetups foster acceptance, though public displays still draw curiosity outside progressive neighborhoods.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public escoletes run 09:00–17:00 with meal service, and private nurseries cost €400–€600, giving us workable coverage once placement is secured.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "British School of Valencia, Caxton College, and French Lycée offer international curricula, but admissions require planning and annual tuition near €7k–€10k.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Valencia’s city hall champions green mobility, feminist policies, and inclusive festivals, aligning well with progressive values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government communications emphasize social cohesion and EU solidarity, yet national parties spin narratives sharply during election cycles.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters and independent press offer plural perspectives, but partisan tabloids and political disinformation spikes near elections demand media literacy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Metrovalencia, EMT buses, and new bike lanes cover most districts every 10–15 minutes, though late-night service is thinner than in Barcelona.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Policy debates remain largely secular, even if Catholic holidays and concordat funding periodically re-enter national conversations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Coworkings near Russafa and the marina host distributed teams, yet some traditional employers still want hybrid schedules anchored to the office.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Digital nomad, entrepreneur, and non-lucrative visas offer multi-year renewals, but each renewal cycle re-checks income, insurance, and local registration.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Spain's contributory pension replaces roughly 70% of wages and pairs with universal healthcare, even as reforms slowly raise the retirement age.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Permanent residents who contribute for 15+ years qualify for state pensions, but fragmented work histories reduce payouts and require supplemental savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Temporary residents can pay into the system, yet long vesting periods and portability rules mean we would rely on private or US-based retirement accounts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles surface sporadically in SaaS firms like Edicom; Sarah may mix Spanish clients with remote contracts to maintain income.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Street crime rates are low and neighborhoods feel safe, with only occasional petty theft in tourist strips during Fallas.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Concertada bilingual schools and a few international campuses give us choice, though Valencian-language immersion is standard in public primaries.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Water hits 25–27 °C (77–81 °F) in July–August and stays swimmable May through October, cooling to about 14 °C (57 °F) in winter.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers are sunny and humid with highs above 32 °C (90 °F), while winters stay mild and breezy; autumn storms bring brief flooding.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Liberal attitudes toward sexuality show up in Pride, kink-friendly venues, and sex education campaigns, though it’s slightly more conservative than Barcelona.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, minimum income programs, and expanding parental leave form a solid safety net even if benefit administration can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March averages 12 °C/54 °F mornings with afternoons reaching 20 °C/68 °F by May, perfect for park play before the summer heat.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Institutions are steady, yet Catalan independence debates and fragmented parliaments periodically trigger snap elections and protests.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Mainstream politics emphasizes social democracy and EU integration, accommodating regional identities even when rhetoric turns sharp.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Competitive markets and EU oversight balance with strategic state intervention in energy and transport to protect consumers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs push 30–33 °C (86–91 °F) with humid nights around 23 °C (73 °F); siesta breaks and fans become essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Digital nomad and non-lucrative visas typically take 4–8 months with translation, apostille, and legal fees pushing total costs into the mid-four figures.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Survey data shows only about a third of Spaniards trust national institutions, reflecting fatigue with corruption scandals despite ongoing transparency reforms.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Urban development and party financing scandals remain the main risks, prompting audits when dealing with permitting or large contracts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers usually see €42–55k offers, with remote-friendly startups edging a bit higher for cloud or gaming expertise.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends mix Turia bike rides, paella with friends, and late-night Fallas events; Sunday afternoons lean toward beach walks or kids’ activities in the park.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run 09:00–17:00 with comedor lunch, and many offices embrace 08:00–16:00 split shifts, giving parents time for pickups or seaside strolls.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law mandates 30 paid calendar days plus 14 public holidays, and unions enforce taking the full allotment.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Many firms close in August and add bridge days around holidays, yielding 32–35 days off once seniority perks kick in.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Relations with Portugal, France, and Morocco are cooperative, even as occasional Gibraltar or fishing disputes flare up.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Spaniards balance pride in regional identities with enthusiasm for modern, multicultural cities and EU citizenship.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors generally see Spain as friendly and culturally rich, while noting persistent economic and Catalan debates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Digital nomad, non-lucrative, entrepreneur, and golden visas fit our profile, but each demands proof of income, insurance, and in-person appointments.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Valencia Activa’s welcome programs and a growing US expat community make integration friendly, even if some landlords still prefer Spanish guarantors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Fallas pyrotechnics, futuristic City of Arts architecture, and easy beach access deliver a uniquely Valencian mix of creativity and calm.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winter days stay around 12–18 °C (54–64 °F) with cool nights near 6 °C (43 °F); frost is rare.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "The statutory 40-hour week persists, yet many firms pilot 37.5-hour schedules or flexible Fridays, leaving room to prioritize family.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Shorter commutes, plentiful public holidays, and employers open to jornada intensiva schedules help protect evenings for family time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong unions, collective bargaining, and recent platform-worker reforms provide solid protections, though enforcement can lag for freelancers.",
+      "alignmentValue": 8
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Barcelona city report with updated scores for the tech job market, childcare access, environment, and transit connectivity
- capture Valencia-specific alignment values covering affordability, coastal climate, and childcare coverage in a new city report
- add a San Sebastián report reflecting Basque family supports, housing pressure, nature access, and slower-paced living
- register the three cities under Spain in `main.json`

## Testing
- python -m json.tool reports/spain_barcelona_report.json
- python -m json.tool reports/spain_valencia_report.json
- python -m json.tool reports/spain_san_sebastian_report.json

------
https://chatgpt.com/codex/tasks/task_e_68e3326da5748321a96f034d80c396ed