### PR TITLE
Add New Zealand city reports for Auckland, Wellington, and Christchurch

### DIFF
--- a/main.json
+++ b/main.json
@@ -524,7 +524,21 @@
     },
     {
       "name": "New Zealand",
-      "file": "reports/new_zealand_report.json"
+      "file": "reports/new_zealand_report.json",
+      "cities": [
+        {
+          "name": "Auckland",
+          "file": "reports/new_zealand_auckland_report.json"
+        },
+        {
+          "name": "Christchurch",
+          "file": "reports/new_zealand_christchurch_report.json"
+        },
+        {
+          "name": "Wellington",
+          "file": "reports/new_zealand_wellington_report.json"
+        }
+      ]
     },
     {
       "name": "United States",

--- a/reports/new_zealand_auckland_report.json
+++ b/reports/new_zealand_auckland_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "NZ",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Auckland’s finance, logistics, and SaaS companies hire senior .NET engineers year-round, giving Trey a thicker pipeline while he builds remote U.S. work on the side.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Port emissions and motorway traffic push Auckland’s annual PM2.5 toward 7–8 µg/m³, so we’d keep air purifiers for winter inversions even though sea breezes clear most days.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Auckland’s multicultural schools stay largely secular, though Christian special-character schools are common enough that we’d confirm each zone’s ethos.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Local media, Ombudsman oversight, and active civic groups maintain the same strong democratic guardrails the family expects.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Tap-to-pay dominates Auckland’s retail and ferry network, but we’d still lean on U.S. fintech accounts for cross-border transfers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Thirty minutes unlocks both calm Hauraki Gulf beaches and rugged West Coast surf, so weekends can rotate between family swims and coastal hikes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Stores like Dice & Fork, Vagabond, and hobby clubs across the North Shore give Trey ample groups without leaving the metro.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Auckland centre fees often exceed NZ$400 per week and waitlists run long, so we’d combine part-time care with trusted sitters to cover work hours.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Neighborhoods like Devonport and Mt Albert offer playgrounds and safe streets, but heavy traffic in central suburbs means close supervision for independent travel.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizen households can stack 20 Hours ECE with Best Start, yet Auckland premiums erode savings until the boys hit primary school.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Temporary residents rely almost entirely on private pay, so we’d budget for top-tier costs until residency unlocks subsidies.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Climbing gyms, esports lounges, yacht clubs, and indie dev meetups across the CBD keep both adults engaged without exhausting commutes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Auckland’s scale makes neighbour bonds slower to form, but school whānau groups and community centres in suburbs like Pt Chev foster belonging once we commit.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Most Accredited Employer sponsors sit in Auckland, yet shifting salary bands and health screenings still require vigilant documentation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Auckland’s housing, groceries, and childcare sit 25–35% above U.S. midwest prices, so we’d trade square footage or live further out to protect savings.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Living in Auckland doesn’t alter New Zealand’s dual citizenship allowance, so we can naturalise without surrendering U.S. passports.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Auckland concentrates the country’s GDP, with logistics, film, and tech sectors rebounding faster than national averages despite higher interest rates.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "The metro showcases New Zealand’s mix of open markets and social programmes—startup incubators sit next to strong public health services.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "High-decile schools on the North Shore and Central Auckland deliver student-centred learning, though we’d bolster maths at home to counter national dips.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Auckland hosts the largest pool of accredited tech employers, yet Trey still must meet NZ$95k+ salary thresholds and job-check requirements.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Island sanctuaries and Waitākere ranges show Auckland’s biodiversity, but urban sprawl and harbour pollution keep the score below pristine.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual tech incomes in Auckland still face the 33% marginal rate plus GST, mirroring Wellington tax obligations.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn stays around 13–20 °C with gentle rains, offering plenty of comfortable outdoor afternoons for the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "City-fringe suburbs deliver playgrounds and ferry-accessible adventures, but longer commutes can squeeze weekday family time if we work downtown.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Each family member can find niche communities—from tech meetups to inclusive playgroups—though cross-town travel adds planning overhead.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families access parental leave, Working for Families credits, and subsidised GP visits, softening Auckland’s higher baseline costs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Middle-income households benefit from targeted tax credits and public schooling, though rising mortgages still demand budgeting discipline.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Visa holders miss out on the richer tax credits but can still access public schools and vaccination programmes once resident visas arrive.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Auckland’s creative scene blends Pacific prints with urban streetwear, letting Sarah mix professional looks with casual weekend style.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart casual wardrobes—blazers with sneakers—fit Auckland’s tech offices, so Trey can stay comfortable while client-ready.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Dual-career households and visible women leaders set expectations that mothers balance work and family without stigma.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Grinding Gear Games and RocketWerkz hire in Auckland, giving Trey contract and networking options alongside remote clients.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Auckland Pride, queer youth centres, and inclusive school policies keep gender-diverse residents visible and supported.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Human Rights Commission enforcement and an active queer community ensure anti-discrimination protections feel real in daily Auckland life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Shared parental leave is common among professional couples, though some older suburbs still carry traditional expectations.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Most landlords and schools accept visa paperwork, but high demand rentals require extra documentation and guarantors.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Sea-level rise threatens low-lying suburbs and more intense rainfall strains stormwater, yet council adaptation plans and higher ground housing provide options.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Auckland City Hospital offers advanced care, but high demand lengthens some waitlists, so we’d pair with private insurance for elective needs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Resident visa holders access the same GP network, yet temporary visa families must self-insure until their status shifts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Auckland University, AUT, and Unitec provide broad tertiary choices with citizen discounts and scholarships.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International fees remain high until residency, so the boys would need domestic status before considering local degrees.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Median Auckland house prices exceed NZ$1 million, forcing newcomers toward outer suburbs or townhouse living to stay within budget.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Inland Revenue’s online services make PAYE and GST straightforward, though limited deductions mean we’d coordinate with a cross-border accountant.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens secure spots in strong zoned schools like Epsom and Takapuna, though competition for high-decile zones boosts housing costs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident visas bring domestic fees, but temporary visas pay international rates—manageable only short-term.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominates civic life while widespread bilingual signage encourages Te Reo learning without creating language barriers.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Rainbow Auckland events and inclusive employers make the metro broadly queer-friendly, though rural fringes can feel more conservative.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Progressive circles debate equity, yet Auckland’s business-first culture keeps overt socialist movements relatively niche.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Diverse workplaces normalize dads taking parental leave, though machismo lingers in certain sports communities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech, gaming, parenting, and poly-friendly meetups run weekly across the CBD and North Shore, so social calendars can stay full.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The national NZ$23.15 minimum wage applies, but Auckland’s higher living wage campaigns nudge employers toward better pay for service staff.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Ultra-fast fibre, electrified rail expansions, and frequent ferries keep Auckland’s infrastructure modern despite congestion challenges.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Volcanic cones, native bush, and island day trips put dramatic landscapes within easy reach of the city centre.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Auckland faces lower earthquake risk than Wellington, though volcanic monitoring and cyclone-driven flooding remain considerations.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Regional parks and gulf islands are a short ferry or car ride away, though weekend traffic can slow spontaneous getaways.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Aotea Centre shows, Karangahape Road gigs, and Britomart bars keep nightlife vibrant for occasional date nights.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Late-night dining and live music run well past midnight downtown, offering options when grandparents visit to watch the kids.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Grinding Gear Games, RocketWerkz, and NZGDA meetups create a dense network for Trey to plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Global successes like Grinding Gear and Ninpo Game Studio highlight Auckland’s deep talent pool for potential hires.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Callaghan Innovation grants, GridAKL coworking, and proximity to investors make Auckland the strongest launchpad for Trey’s studio in New Zealand.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Auckland’s traffic and long commutes create a faster pace than Wellington, so we’d target inner suburbs to protect downtime.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools encourage parent involvement, but full calendars mean we must intentionally carve out volunteer time to stay connected.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Residency plus 1,350 days in-country still leads to citizenship, with Auckland ceremonies held regularly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Aucklanders share the national view that corruption is rare and handled swiftly when uncovered.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Local government participation and national proportional representation keep democratic engagement strong throughout the metro.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Poly-friendly meetups and relationship counsellors exist, though suburban stigma still pops up in more conservative communities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Quality centres exist across the isthmus, yet demand for full-day care exceeds supply, so we’d register early and maintain backup carers.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Auckland offers IB and secular private schools, but tuition rivals U.S. rates, so we’d reserve them for specific needs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Central Auckland votes progressive and champions climate action, while outer suburbs lean moderate, keeping the overall tone aligned with the family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Council communication emphasizes evidence-based updates, and multiple newsrooms challenge spin quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "State messaging is visible but balanced by independent outlets like The Spinoff and Newshub, so narratives stay pluralistic.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "AT buses, ferries, and commuter rail cover the region, yet service gaps on evenings and weekends mean we’d keep a car for cross-town trips.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Faith groups contribute to social services, but policy debates remain largely secular, aligning with the family’s expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Many Auckland tech firms now run hybrid weeks, and coworking hubs like GridAKL and Generator support remote specialists.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Accredited Employer and Skilled Migrant pathways are well supported in Auckland, yet application queues still run 6–9 months.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Citizens enjoy NZ Super and KiwiSaver matching, though living costs encourage continued part-time work.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who gain residency can access KiwiSaver and eventually NZ Super after 10 years, supporting long-term plans.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Temporary visa holders cannot tap NZ Super and have limited KiwiSaver access, so savings rely on private accounts until residency.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Auckland’s SaaS companies and consultancies maintain Ruby teams, giving Sarah more on-site roles plus remote U.S. options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime remains low, but car break-ins and retail theft are more common in the CBD, so we’d choose suburbs with active community patrols.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "The metro offers IB, Montessori, and bilingual programmes alongside strong public schools, giving the boys varied paths.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Hauraki Gulf waters warm to 20–22 °C in late summer, letting the kids swim comfortably several months per year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Auckland’s subtropical climate brings mild winters and warm, humid summers, so we manage rain showers and the occasional tropical storm.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education and diverse media representation keep conversations open for sex-positive parenting.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "National reforms on marriage equality, healthcare, and Māori partnership manifest strongly in Auckland’s social services.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Spring sits around 12–19 °C with blooming parks, making shoulder-season outdoor time easy for the family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Auckland’s economic heft keeps employment steady even during national political transitions, reinforcing long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Local politics swing between progressive and centrist coalitions, but both support social safety nets and competitive markets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Auckland’s entrepreneurial culture, venture scene, and access to Asia-Pacific markets keep capitalism dynamic yet regulated.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summer highs of 23–27 °C deliver warm beach days, though humidity and UV require sun-smart routines.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Visa fees, medical checks, and relocation costs mirror national figures, so we’d reserve funds for six months of rent and application expenses.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Local surveys show high trust in public institutions, though transport delays occasionally test patience.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Issues typically involve minor council procurement errors, not systemic bribery, aligning with the family’s tolerance.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers earn NZ$125k–150k in Auckland—better than elsewhere in NZ but still below U.S. packages, encouraging side contracts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends mix farmers’ markets, ferry rides to Waiheke, and sports at the Domain, keeping the kids engaged outdoors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run roughly 8:55–3:05 and tech offices 8:30–5, but commute traffic means we’d lean on before/after-school care for smoother evenings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Four weeks of statutory leave plus Auckland Anniversary Day deliver reliable downtime if we stagger with school holidays.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Most Auckland employers offer the 20-day baseline with occasional company shutdowns around Christmas.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Residents maintain close business and family ties with Australia and the Pacific, reinforcing a cooperative regional view.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Aucklanders see themselves as diverse, ambitious, and outward-looking—traits that mesh with the family’s goals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Australia and Pacific partners regard Auckland as New Zealand’s global city, reflecting positively on residents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Skilled Migrant, Accredited Employer, and Investor visas are administered locally but still require meeting strict wage, points, and health criteria.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Auckland’s expat community makes cultural integration easy, yet border caps and biosecurity rules keep entry selective.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Auckland’s blend of career opportunities, island escapes, and multicultural food scene checks nearly every box on the family’s wish list.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winter lows hover around 7–10 °C, keeping things damp but rarely freezing, so we focus on dehumidifiers rather than snow gear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "A 40-hour week is standard, though startups sometimes expect longer hours during product pushes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Hybrid policies are growing, yet commute times can eat into evenings unless we choose employers with flexible hours.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Collective bargaining coverage and strong labour inspectors support employees, and grievances get resolved through the Employment Relations Authority when needed.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/new_zealand_christchurch_report.json
+++ b/reports/new_zealand_christchurch_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "NZ",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Christchurch’s tech park and engineering firms offer occasional .NET roles, but Trey would rely on remote contracts or travel to Auckland for bigger projects.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Winter inversions trap wood-smoke in Christchurch’s basin, pushing PM2.5 above 12 µg/m³ on cold nights, so we’d run purifiers and monitor air-quality alerts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Christchurch is broadly secular with Anglican heritage still visible, meaning public schools stay neutral but some community events retain light Christian overtones.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Even from the South Island, strong national institutions and active local journalism keep democratic safeguards high.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Tap-and-go EFTPOS is ubiquitous from Riccarton Mall to farmers’ markets, with only the occasional rural vendor requesting cash.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Sumner, New Brighton, and Taylor’s Mistake give the family quick beach escapes, though chilly Pacific water and strong easterlies limit swim season.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Clubs at Dice & Slice and the Christchurch Board Gamers meetup keep regular tables, but the scene is smaller so Trey may host games at home more often.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Fees are lower than Auckland’s, yet quality centres still have waitlists, so we’d combine ECE hours with part-time sitters.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Flat bike paths, new playgrounds in the rebuild, and light traffic give the boys independence once we teach them to handle occasional tram crossings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens can stack 20 Hours ECE with Best Start payments, and lower South Island rents stretch those subsidies further than in the north.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Temporary residents cover most childcare costs out of pocket, though lower rates than Auckland soften the hit until residency.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Port Hills mountain biking, bouldering gyms, and the strong indie dev scene around Christchurch Game Developers keep both adults engaged.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Post-quake neighbourhood groups foster tight-knit support networks, so newcomers who volunteer quickly build lasting friendships.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Immigration NZ runs outreach in Christchurch, yet visa thresholds still shift annually, requiring careful paperwork despite the smaller city pace.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Housing and childcare cost 15–20% less than Auckland, letting the family afford a larger home while still budgeting for imported groceries.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Settling in Christchurch still allows dual passports once residency time requirements are met.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Construction and ag-tech keep the local economy steady, but growth lags Auckland, so job searches may take longer.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Canterbury combines export agriculture with cooperative enterprises, reflecting New Zealand’s balanced market-social model.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Christchurch Boys’ and Girls’ High plus innovative rebuild schools offer strong academics, though we’d supplement maths to offset national declines.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Fewer Christchurch employers hold accreditation, so Trey would target engineering consultancies or plan to stay remote-first until residency.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Regreened river corridors, Port Hills reserves, and proximity to Banks Peninsula deliver daily access to nature despite agricultural runoff upstream.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Earnings still fall into the 33% bracket plus GST, though lower housing costs help balance the effective rate.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn days range 10–18 °C with crisp evenings, so we plan for layers and earlier sunsets than in the North Island.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Short commutes, weekend access to ski fields, and community events around the Avon River support a balanced family rhythm.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Each family member finds outlets—from Code Clubs for the kids to inclusive social groups for the parents—without major travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen households in Christchurch benefit from national parental leave, tax credits, and subsidised healthcare, stretching further thanks to lower living costs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Middle-income families enjoy affordable extracurriculars and rebuilt community centres, though wages remain lower than in Auckland.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Visa holders lack tax credits but still gain access to public schooling and community health services once residency is secured.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Christchurch leans toward practical layers and outdoor wear, so Sarah can focus on comfort over high fashion.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart-casual with merino layers suits local offices, letting Trey stay low-key while client-ready.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women juggle careers and family in Christchurch, though traditional expectations linger in some suburbs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like CerebralFix and Digital Confectioners provide local gigs, but Trey would still supplement with remote contracts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Queer advocacy groups like Qtopia ensure visible support, even if smaller-town attitudes mean we pick schools carefully.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "National anti-discrimination laws protect LGBTQ+ residents, and Christchurch City Council backs inclusive policies.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are common, and dads at playgrounds are increasingly visible, aligning with Trey’s caregiving role.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Services understand temporary visas, but we’d still need strong references to secure rentals in sought-after school zones.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Sea-level rise threatens coastal suburbs like Southshore, and heavier rain events test flood defences, though relocation inland is straightforward.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Christchurch Hospital delivers quality care, yet specialist waitlists can stretch months, so citizens often add private insurance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Resident visas unlock the public system; until then we’d maintain comprehensive private cover for the family.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "University of Canterbury and Ara Institute offer strong tertiary options with fees-free first year for citizens.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International fees at UC remain steep, so the boys would need residency before enrolling locally.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Earthquake rebuilds created modern, insulated homes at prices below Auckland, though insurance premiums remain higher.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "IRD’s digital services make returns simple, but we’d still coordinate cross-border filings with a specialist.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens access rebuilt, high-quality state schools with modern facilities, and zoning is less competitive than in Auckland.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Temporary visas pay international fees, but once residency lands the boys join local schools at domestic rates without long waitlists.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominates daily life, and growing Te Reo programmes provide optional language learning without creating barriers.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "The city is welcoming at Pride events and in rebuilt downtown, but we’d vet suburban communities for consistent acceptance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Social justice groups are active, yet the broader culture remains pragmatic and business-friendly.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Rugby culture still shapes norms, but younger families embrace more flexible gender roles.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech meetups and poly-friendly socials run monthly; participation means driving a bit farther than in Wellington but staying connected is doable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The NZ$23.15 minimum wage applies, and Canterbury’s lower living costs help service staff stretch their pay.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Post-quake rebuilds delivered modern public buildings and fibre broadband, though some suburban roads remain under construction.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Banks Peninsula, Southern Alps day trips, and restored wetlands put breathtaking scenery within an hour’s drive.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Christchurch still faces earthquake risk and liquefaction zones, so we’d prioritise strengthened housing and maintain robust emergency kits.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "From the Port Hills to nearby ski fields, outdoor adventures are minutes away, aligning with the family’s love of nature.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "The rebuild revived a modest bar and music scene, but offerings are thinner than Auckland’s, making nights out more occasional.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Downtown winds down early, which suits parents but limits late-night variety when sitters are available.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Christchurch Game Developers meetups and shared spaces at GreenHouse provide support, albeit on a smaller scale than Auckland.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like CerebralFix, Digital Confectioners, and Metia Interactive operate locally, offering partnership options for Trey.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Callaghan Innovation grants and the EPIC Innovation Hub lower barriers, yet local investor pools are thin so Trey would court national funds.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "A slower, garden-city pace keeps commutes short and weekends relaxed, aligning with Sarah’s desire for a calmer rhythm.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools encourage parent participation, and community sport clubs make it easy to stay involved in the boys’ activities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "After securing residence and meeting the in-country days, Christchurch families naturalise through local ceremonies without added hurdles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Residents share the national perception that corruption is rare and swiftly addressed.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Local council reforms and national proportional representation keep governance transparent even far from Wellington.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Poly-friendly counselling exists, but smaller social circles mean we’d build discretion and choose communities carefully.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Quality centres like Kidsfirst are accessible if we enrol early; otherwise we’d mix ECE hours with in-home carers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Private options exist but are limited compared to Auckland, so we’d lean on strong public schools unless the boys need specialized programmes.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Christchurch votes slightly more centrist, yet post-quake planning emphasises sustainability and inclusion, aligning reasonably with the family’s values.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Council communications focus on rebuild updates and hazard preparedness, with independent media providing oversight.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Government messaging is visible but balanced by outlets like The Press and community radio, keeping information pluralistic.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Metro buses cover core suburbs, yet limited frequency and no commuter rail mean we’d keep a car for most errands.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Faith-based voices appear in council debates occasionally, but policy remains largely secular.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Coworking spaces like EPIC and Saltworks host remote workers, though some employers still prefer onsite presence.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Visa pathways mirror the national process, with regional talent visas sometimes easing Trey’s case if he supports local tech growth.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "NZ Super combined with KiwiSaver gives Christchurch citizens a stable retirement, and lower housing costs help savings last.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who gain residency can contribute to KiwiSaver and access NZ Super after ten years, supporting long-term security.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Temporary visa holders must self-fund retirement until residency, similar to other New Zealand cities.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Few Christchurch companies hire Ruby specialists, so Sarah would cultivate remote clients or contract work to maintain steady income.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime remains low, and while petty theft occurs in the CBD, suburban streets feel safe for kids biking to friends’ houses.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "A mix of state-integrated schools and a few IB programmes offer choice, though specialized secular private options are limited.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Pegasus Bay waters rarely exceed 17 °C, so beach days focus on sand play and surfing rather than long swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Christchurch’s oceanic climate brings cool, dry summers and frosty winters, matching the family’s mild preference if we manage nor’west winds.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Health classes cover consent and sexuality, though conversations may be slightly more reserved than in Wellington.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "National protections for LGBTQ+ rights, reproductive care, and Māori partnership apply equally in Christchurch services.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Spring swings between 8–17 °C with gusty nor’westers, so we balance outdoor plans with backup indoor options.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Despite seismic history, civic institutions and budgeting remain steady, giving the family confidence in long-term plans.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Regional politics lean centre-right but respect social programmes, keeping policy within the family’s comfort zone.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Entrepreneurial co-ops, agritech start-ups, and community trusts balance open markets with social investment.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summer highs reach 22–26 °C with low humidity, ideal for outdoor play aside from occasional hot nor’west winds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Visa fees and processing times mirror the national norm, so we’d reserve funds and patience for a six-month timeline.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Local surveys report high trust in councils and national agencies, especially after transparent quake recovery efforts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption cases are rare and typically minor procurement issues quickly addressed by oversight bodies.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers earn around NZ$110k–125k, so remote U.S. contracts help match the family’s income goals.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends mix farmers’ markets, Port Hills hikes, and quick trips to Hanmer Springs or ski fields, keeping the kids active outdoors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run roughly 8:55–3 p.m. and offices 8:30–5, with manageable commutes letting both parents handle pickups without stress.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Four weeks of statutory leave plus Canterbury Anniversary Day provide predictable downtime for alpine or coastal getaways.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Most employers stick near the 20-day baseline, though some engineering firms offer extra days during summer shutdowns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Canterbury maintains friendly ties with Australia and the Pacific through tourism and agriculture, reinforcing cooperative attitudes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Christchurch residents see themselves as resilient, community-minded, and close to nature—traits that resonate with the family.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "International visitors view Christchurch as a rebuilt, eco-focused city, giving residents a positive regional reputation.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Skilled Migrant, Accredited Employer, and Entrepreneur visas follow national criteria; regional skill shortages may offer minor leverage but still require strong credentials.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Locals appreciate international talent, though the smaller community expects newcomers to engage actively in neighbourhood life.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Christchurch’s blend of garden-city calm, alpine access, and collaborative rebuild projects offers an adventurous yet grounded lifestyle.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winter lows dip to 0–8 °C with frosts and occasional snow flurries, so we’d invest in double glazing and heat pumps.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "A standard 40-hour week applies, with many firms embracing flexible schedules to retain talent in a smaller market.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Short commutes and family-friendly employers let evenings stay free for community events and kid activities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Employment law protections and active unions in construction ensure workers can advocate for safe, flexible conditions.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/new_zealand_wellington_report.json
+++ b/reports/new_zealand_wellington_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "NZ",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "In Wellington, government digital teams and consultancies like Datacom and Xero keep .NET projects in play, so Trey can rotate between public-sector contracts and remote U.S. clients to stay fully booked.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Wellington’s constant Cook Strait winds flush PM2.5 levels down near 5–6 µg/m³, so the boys can play outside daily with little need for purifiers even in winter.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular culture dominates Wellington’s public life, and state schools stay religion-neutral, letting Sarah and Trey raise the kids without navigating faith-based defaults.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "National integrity bodies, MMP coalition politics, and an active press gallery anchored in Wellington keep checks on executive power strong enough for the family’s comfort.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Contactless EFTPOS works everywhere from Cuba Street cafes to suburban markets, yet we’d keep a U.S. fintech account to dodge fees on international transfers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Lyall Bay, Oriental Bay, and Kapiti Coast beaches sit within 30–45 minutes, giving breezy weekend outings even though cold water and strong winds shorten swimming season.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Cuba Street game cafes, Victoria University clubs, and Kapcon conventions keep tabletop calendars full, so Trey can find regular campaigns without much travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "City-run childcare centers and 20 Hours ECE subsidies help, but limited CBD slots mean we’d still juggle waitlists or in-home carers to cover both workdays.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Compact suburbs like Karori and Island Bay mix playgrounds, low crime, and strong school walksheds, matching the family’s preference for independent kid mobility.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizen families layer 20 Hours ECE with Best Start payments, but Wellington center fees still hit NZ$360 per week for infants until school begins.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Temporary residents can claim the 20 Hours ECE allocation, yet income-tested subsidies stay off-limits, so newcomers pay near full freight for under-fives.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Zealandia hikes and waterfront bouldering gyms to indie game jams at Creative HQ, both adults find plenty of like-minded communities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbourhood Facebook groups, marae events, and school whānau nights make it easy to plug into Wellington’s civic-minded community once we show up consistently.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Living near Immigration New Zealand’s head offices simplifies paperwork questions, but shifting wage thresholds and medical screenings still demand careful tracking.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Wellington rents and power bills mirror Auckland’s, so we’d budget for a smaller hillside home or consider Hutt Valley commutes to stay within savings targets.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Settling in the capital still lets us retain U.S. passports while naturalising after residency, keeping family travel options open.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Wellington’s public-sector employment cushions national slowdowns, yet high interest rates have cooled tech hiring and venture funding.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "The capital showcases New Zealand’s mixed economy—state services alongside startup grants—matching the family’s taste for regulated markets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Decile-10 schools like Wellington Girls’ and high-ranked primaries support the boys, though math scores lag OECD leaders so we’d supplement at home.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Wellington’s accredited ministries and consultancies sponsor skilled migrants more readily than smaller towns, yet Trey must meet salary bands above NZ$95k.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "The city backs onto native bush, Zealandia sanctuary, and a protected harbour, though invasive possums and runoff still demand ongoing restoration work.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual professional incomes in Wellington land near the 33% bracket plus 15% GST, comparable to Seattle without U.S. deductions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn days run 12–18 °C with frequent southerlies, so we plan layered school runs and backup indoor activities when gales roll through.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Parent-friendly work cultures, weekend markets, and short drives to regional parks give the family balanced routines close to home.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "A strong expat network and inclusive schools help each family member find peers quickly, though distant U.S. relatives still require long-haul visits.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families access paid parental leave, Working for Families tax credits, and subsidised healthcare, easing long-term planning in the capital.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Wellington employers often top up national leave schemes, yet high costs mean middle-income households still watch budgets closely.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Visa holders miss tax credits but still tap public schooling and subsidised GP visits once resident visas are approved.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Wellington leans toward practical layers, raincoats, and boutique Kiwi designers, letting Sarah blend professional and casual looks without pressure to chase high fashion.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart-casual jackets and merino layers dominate Wellington offices, so Trey can stay comfortable while still fitting into client meetings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Public-sector leadership and flexible work policies normalise professional women balancing family life, supporting Sarah’s expectations.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Wētā Workshop Game Studio and PikPok anchor Wellington’s scene, giving Trey contract options alongside remote collaborations.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Queer-friendly events and inclusive school policies in Wellington normalize gender diversity, matching the family’s progressive values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "The capital hosts national LGBTQ+ advocacy groups and strong anti-discrimination enforcement, so rights protections feel robust day to day.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Shared parental leave norms and dual-career households mean dads at school pickups are common, supporting Trey’s caregiving goals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Most services accept temporary visas, yet proving income for rentals and school enrollment still requires organized paperwork.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Wellington faces sea-level rise and more frequent southerly storms, but aggressive resilience planning and hillside housing mitigate near-term risk.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Capital & Coast DHB hospitals and community clinics keep wait times reasonable, though specialist queues still require patience.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Resident visa holders tap the same GP network after the stand-down period, but newcomers on temporary visas should budget for private insurance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Victoria University and WelTec give Wellington teens strong tertiary pathways with fees-free first-year options for citizens.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International tuition is steep until the boys gain residency, so we’d rely on scholarships or delay enrollment if they pursue local degrees.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Steep terrain and quake-strengthening costs keep Wellington family homes pricey, pushing many newcomers toward Hutt Valley or Porirua rentals.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "IRD’s myIR portal handles filings smoothly, though limited deductions mean we still track U.S. obligations carefully.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens enjoy guaranteed spots in zoned schools with modern facilities, and Wellington’s decile mix offers strong state options.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident visas unlock domestic status, but temporary visas pay international fees—manageable if we shift to residency before long-term enrollment.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominates workplaces and schools, while Te Reo Māori signage encourages the family to learn basics without impacting daily navigation.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Wellington Pride, inclusive school boards, and visible queer leadership make the city welcoming for polyamory-friendly parents.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Left-leaning arts communities debate redistribution, but mainstream politics remains pragmatic social democracy rather than radical.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Wellington dads split caregiving and office duties, so Trey’s nurturing role fits local expectations.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech meetups, poly-friendly socials, and multicultural festivals cluster downtown, offering regular in-person networking.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The NZ$23.15 minimum wage applies citywide, supporting service workers the family depends on even if it trails Wellington’s living wage.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fibre broadband, reliable power, and quake-strengthened civic buildings keep daily life smooth, aside from occasional southerly outages on the rail line.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "The city sits between bush-clad hills and a sheltered harbour, giving weekend access to Zealandia, Cape Palliser, and Rimutaka Forest Park.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Wellington’s quake risk is real—strengthened buildings and regular drills help, but we’d retrofit rentals and store supplies for the next big one.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Public transport reaches beaches, hill walks, and Zealandia within 30 minutes, so spontaneous nature breaks are easy for the family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Cuba Street venues, the Opera House, and indie gigs keep nightlife varied, though the scene winds down earlier than Auckland’s.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Bars close around midnight and the vibe stays relaxed, which suits parents balancing childcare with the occasional date night.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Wellington hosts NZGDA meetups, Level Up events, and shared studios in Miramar, giving Trey consistent peer support.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "PikPok, A44, and Wētā Workshop anchor Wellington’s industry, offering benchmarks and potential collaborators for Trey’s studio.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Creative HQ accelerators and the government’s screen rebates lower early costs, yet local venture capital still requires persistent pitching.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Downtown runs on public-sector schedules, but hillside suburbs stay calm, giving Sarah a manageable rhythm with manageable commutes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools encourage whānau involvement and flexible work, so active parenting is celebrated rather than penalized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "After securing residence and spending 1,350 days in New Zealand, Wellington families transition to citizenship smoothly with local ceremonies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International still ranks New Zealand among the least corrupt, and Wellington’s watchdog agencies quickly surface any lapses.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Living near Parliament highlights proportional representation and active select committees, reassuring the family about democratic resilience.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Queer-friendly social clubs and progressive relationship therapists make non-monogamous families feel seen, even if legal recognition remains limited.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Quality centers exist across the city, but demand outstrips supply, so we’d register early and line up backup nannies.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Private options like Scots College exist but command high fees, so we’d rely on zoned public schools unless the boys need specialized programs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Wellington votes strongly for progressive parties, supports climate action, and celebrates Pride, aligning tightly with the family’s politics.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public service campaigns emphasize evidence-based messaging, and the press gallery scrutinizes spin, keeping civic communication transparent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "State broadcasters provide balanced coverage, and while government announcements are frequent, independent media offer immediate fact-checks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Metlink trains and buses cover most suburbs, but wind disruptions and aging rolling stock mean we’d keep a car for backups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Parliament debates focus on policy rather than faith, and Wellington council meetings rarely invoke religion, matching the family’s secular priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Government agencies and tech firms now support hybrid rosters, and coworking hubs like BizDojo keep remote parents plugged in.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Accredited Employer and Skilled Migrant pathways operate from Wellington, but processing still takes 6–9 months before residency is secured.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "NZ Super and KiwiSaver matching make retirement planning straightforward once the family naturalizes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Newcomers who gain residency accumulate KiwiSaver benefits, though they must live in-country for a decade to access full NZ Super.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Temporary visa holders cannot access NZ Super and face limited KiwiSaver participation, so long-term savings stay self-directed until residency.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Wellington hosts Ruby shops in GovTech, Silverstripe, and small SaaS outfits, offering Sarah a modest but steady pool of roles supplemented by remote gigs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime remains low, and while petty theft spikes occasionally downtown, suburban neighborhoods feel safe for independent kid travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Strong state-integrated schools and a handful of IB programs provide variety, though secular private choices remain limited.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Cook Strait waters peak around 17–18 °C, so summer swims are brisk unless the family uses wetsuits.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Wellington’s windy maritime climate keeps temperatures mild but demands year-round rain gear and windbreakers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive health curricula and open public discourse support sex-positive parenting in the capital.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Parliament’s track record on marriage equality, reproductive health, and Māori partnership feels tangible in Wellington’s civic services.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Spring swings between 11–17 °C with gusty showers, so we plan layered outfits and flexible weekend plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Being close to the civil service underscores how smoothly budget cycles and elections transition, reassuring long-term planners.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Coalition shifts between Labour and National play out visibly in Wellington, yet both respect social safety nets and market economics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Small business grants, co-ops, and open markets coexist, giving Trey room to experiment with his studio without heavy-handed regulation.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summer highs hover around 20–24 °C with strong UV, so we chase beach days while managing wind and midday sun.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Skilled Migrant fees plus medical exams run several thousand dollars, and processing still averages six months, so we’d budget time and cash reserves.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Proximity to ministries shows transparent policy consultations, keeping public trust in institutions relatively high.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Any corruption tends to be minor procurement missteps quickly investigated by Wellington’s oversight agencies, not systemic bribery.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers in Wellington pull NZ$120k–135k; comfortable but below U.S. compensation, so remote contracts remain valuable.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends revolve around waterfront markets, Zealandia, and short drives to Kapiti walks, giving the kids consistent outdoor adventures.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run 9 a.m.–3 p.m., government offices 8:30–5, and after-school care to 6 p.m., letting both parents finish work without stress.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Four weeks of statutory leave plus Wellington Anniversary Day anchor reliable downtime if we plan around Christmas closures.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Most Wellington tech employers stick close to the 20-day baseline, so extra rest requires tenure or salary trade-offs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Locals maintain friendly rivalry with Australia while collaborating on climate and defense, fostering a positive regional outlook.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Wellingtonians prize creativity, public service, and outdoor access—values the family shares.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Australia and Pacific partners view Wellington as a reliable, eco-minded capital, supporting a stable reputation abroad.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Skilled Migrant, Accredited Employer, and Entrepreneur visas are accessible from the capital but still hinge on points, salary, and health checks.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Cultural fit is easy, yet strict biosecurity and limited visa caps mean Americans still navigate a selective process.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "The blend of public-sector stability, creative tech, and access to wild coastlines makes Wellington a compelling long-term base.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters hover around 8–12 °C with damp southerlies, so we’d prioritize insulation and dehumidifiers over snow gear.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "A 40-hour week is standard, with most public-sector teams discouraging overtime except during budget cycles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Hybrid policies and early-finish Fridays in many agencies give Sarah the calmer rhythm she’s seeking.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Collective agreements, strong health-and-safety enforcement, and ready access to mediation back employees who need flexibility.",
+      "alignmentValue": 8
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add city-specific reports for Wellington, Auckland, and Christchurch with alignment scores tailored to the family profile and rating guides
- register the new city reports under New Zealand in `main.json` so the UI can surface them

## Testing
- jq '.values | length' reports/new_zealand_wellington_report.json
- jq '.values | length' reports/new_zealand_auckland_report.json
- jq '.values | length' reports/new_zealand_christchurch_report.json

------
https://chatgpt.com/codex/tasks/task_e_68e339ec944c8321871ef1d1ef5c3bdb