### PR TITLE
Add Denmark city reports for Copenhagen, Aarhus, and Odense

### DIFF
--- a/main.json
+++ b/main.json
@@ -728,7 +728,21 @@
     },
     {
       "name": "Denmark",
-      "file": "reports/denmark_report.json"
+      "file": "reports/denmark_report.json",
+      "cities": [
+        {
+          "name": "Copenhagen",
+          "file": "reports/denmark_copenhagen_report.json"
+        },
+        {
+          "name": "Aarhus",
+          "file": "reports/denmark_aarhus_report.json"
+        },
+        {
+          "name": "Odense",
+          "file": "reports/denmark_odense_report.json"
+        }
+      ]
     },
     {
       "name": "Greece",

--- a/reports/denmark_aarhus_report.json
+++ b/reports/denmark_aarhus_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "DK",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Aarhus wraps its compact downtown with Marselisborg forest, harbor baths, and climate-friendly street design, so the family can enjoy fresh air with only light port emissions near the docks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "The city faces rising sea levels along the bay, yet terraced neighborhoods and new stormwater tunnels blunt the threat for families who avoid low-lying harborfront rentals.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Weather mirrors Denmark’s maritime norm: breezy, grey stretches balanced by mild temps, which is still a solid mid-tier trade versus Kansas City’s extremes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Traffic is light, cycling is mainstream, and only occasional woodsmoke or grain-dust pulses near the port nudge monitors, letting the kids play outside confidently.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Serious quakes and storms are absent; the main watch item is bay flooding during cloudbursts, and municipal warning systems handle those well.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March and April bounce between 5–13°C (41–55°F) with gusty showers, but by May the woods around Moesgaard invite bike picnics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Highs near 22°C (72°F) and cool evenings keep apartments comfortable without AC while giving the family long beach days.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn drops quickly into the 8–12°C (46–54°F) range with North Sea winds, so layers and rain pants stay in constant rotation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters hover a few degrees above freezing with sleet and windchill off the bay—tolerable, but the kids will need waterproof gear for playground runs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Den Permanente and Bellevue beaches are a short bike ride away with clean water and saunas, yet chilly breezes mean quick dips more than full swim days.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Water temps only reach about 18°C (64°F) in midsummer, so wetsuits or sauna warm-ups keep the family comfortable.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Aarhus backs onto forested hills, Mols Bjerge National Park, and rolling coastal trails, giving the family easy weekend adventures despite the lack of mountains.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "There is still no statutory minimum, but regional tech unions negotiate solid pay floors, so the adults should join bargaining agreements to lock them in.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers usually earn 520,000–600,000 DKK plus pension—lower than Copenhagen yet enough to live well in Aarhus’s cheaper market.",
+      "alignmentValue": 6
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Companies like Systematic, banking IT hubs, and public digital teams hire .NET talent, so Trey sees a healthy but smaller scene.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles are sparse outside a handful of SaaS firms, so Sarah will rely on remote teams or broader web stacks.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Major employers use Denmark’s fast-track schemes, but medium companies sponsor less often, making proactive outreach important.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Aarhus anchors Jutland’s economy with low unemployment, a large university sector, and logistics jobs that keep growth steady.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Coworking spaces like The Kitchen and Dokk1’s study zones support hybrid work, and employers stay flexible on time zones.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Offices clear out by 16:00 and respect vacation, so Sarah’s calmer work rhythm fits right in.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Collective agreements keep weeks near 37 hours with real overtime compensation, protecting evenings for the kids.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Five paid weeks plus public holidays remain standard, matching Denmark’s top-tier time-off baseline.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech teams often add sixth weeks or flex days, and colleagues genuinely disconnect, reinforcing the 9-tier generosity.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Traffic is light, commutes are short, and the waterfront promenade encourages slow evenings—a calmer pace than the capital.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "School runs 8:00–14:00, after-school clubs bridge pickups, and most offices mirror 8:30–16:30 so both parents can be present.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends rotate between forest hikes, harbor festivals, and visits to ARoS or the Moesgaard museum before cozy nights in.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Cargo bikes, playgrounds, and kid-friendly cultural events dominate the city core, making family logistics easy.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Queer-friendly bars and student groups provide discreet support for consensual non-monogamy, but visibility is thinner than in Copenhagen.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Parents share drop-offs and leave, and teachers promote independence, though communities still expect you to respect routines and trust the system.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Traffic-calmed neighborhoods, free museums for kids, and well-maintained playgrounds keep Aarhus welcoming for a stroller family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Neighborhood folkeskoler perform well and bilingual streams exist, but there are fewer international schools, so Danish integration is the norm.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Municipal vuggestue and børnehave spots emphasize outdoor play, though popular districts require early registration.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Fees are capped and heavily subsidized, and municipal family houses offer parenting courses and support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once CPR registration clears, expats pay the same subsidized rates, but paperwork and Danish-language portals take persistence.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Local schools are free, include outdoor classrooms, and provide special-needs support with low teacher-student ratios.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Non-EU families enroll after municipal intake sessions; initial Danish language classes may precede a permanent placement.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Aarhus offers a few friskoler and the International School, but seats are limited and pricey, so they serve as backup options.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "The same 52-week parental leave and generous child benefits apply, backed by engaged municipal social workers.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Work-permit holders qualify for leave and benefits once they meet employment length rules, but proving residency can take a few months.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Aarhus University, VIA University College, and specialty academies deliver tuition-free degrees with stipends.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students pay full tuition unless they secure scholarships or permanent residency.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Men take parental leave, women lead companies, and gender equality offices are visible across the university and city hall.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Student groups and Pride events support gender-diverse residents, though everyday exposure is less common than in the capital.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "National protections extend here, and local authorities respond quickly to discrimination cases.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Low-key style and competence matter more than traditional femininity expectations, easing pressure on Sarah.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Fathers are expected to push strollers and take leave, balancing Jante modesty with hands-on parenting.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "ARoS’s rainbow panorama, new waterfront architecture, and culinary festivals keep culture lovers busy without big-city crowds.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Most residents speak excellent English, though municipal offices assume some Danish and encourage enrollment in language classes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Local elections favor Social Democrats and Socialist People’s Party, and climate policy drives city planning.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "University debates and housing co-ops keep leftist ideas visible, yet daily politics remain pragmatic.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church attendance is low, but cultural events still nod to Lutheran traditions during holidays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex ed and a sizeable student population normalize frank conversations, though the scene is less experimental than Copenhagen.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Rainbow families are accepted in schools, Pride events fill the streets each summer, and queer nightlife, while small, feels safe.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Locals are friendlier and more approachable than in the capital, and volunteer associations provide quick inroads for newcomers.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Aarhusians balance pride in their cultural rise with Jante-style modesty, jokingly calling the city the nation’s ‘second capital’.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Residents collaborate with German and Norwegian partners through the port and university networks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Nordic partners view Aarhus as Denmark’s innovation hub and a reliable cultural ally.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Student bars in Latinerkvarteret, waterfront clubs, and concert halls keep nightlife lively without big-city edge.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward relaxed Scandinavian streetwear—wool layers and sneakers—making Trey’s wardrobe easy to align.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women favor minimalist outfits with pops of design from local boutiques, keeping expectations approachable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Cycling, sailing, and community potlucks are popular; hobby clubs often welcome English speakers.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Shops like Dragon’s Lair host regular board-game nights, and Aarhus Boardgame Association runs events in English-friendly settings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "SPOT Festival, Train nightclub, and VoxHall bring steady live music without overwhelming crowds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "TechBBQ satellite events, Game Hub meetups, and family playgroups make community-building straightforward.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Within 20 minutes the family reaches forests, beaches, or Mols Bjerge hikes, offering richer scenery than many cities this size.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Local governance mirrors Denmark’s transparent parliamentary system with open council meetings and responsive citizen portals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Policy debates stay secular, with religion appearing mainly during cultural festivals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Union coverage remains strong, ensuring predictable contracts and parental protections.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Social democratic pragmatism pairs business-friendly development with inclusive welfare investments.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Independent courts, active media, and civic engagement keep the risk low despite global pressures.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Entrepreneurship hubs like The Kitchen coexist with high taxes and worker protections, balancing markets with welfare.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Political transitions are calm, and public services run reliably, allowing long-term planning.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters dominate media with fact-based coverage, and civic campaigns stress sustainability rather than nationalism.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government messaging emphasizes community resilience and climate action, aligning with the guide’s positive tier.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, childcare caps, and affordable housing cooperatives reflect the family’s progressive priorities.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Residents report high trust in municipal digital services, although debates on property tax tweaks surface occasionally.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency remains high; even minor procurement issues trigger public reviews.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "When issues arise they involve minor favoritism rather than systemic bribery, and ombudsmen respond quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family apartments cost less than Copenhagen but still require planning—co-ops and new waterfront builds help, yet demand keeps prices firm.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Serious crime is rare; the biggest nuisance is occasional bike theft, so kids can roam confidently.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Regional hospitals and the new super-hospital deliver quality care, though specialist queues can stretch a few months.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "After CPR registration, expats share the same clinics, but initial paperwork can delay assignment to a general practitioner.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidized daycare and after-school clubs keep costs predictable, provided the family registers early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Parental leave, universal child benefits, and flexible work hours support this two-child household well.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Schools emphasize project-based learning, arts, and STEM partnerships with Aarhus University.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The light rail (Letbanen), dense bus network, and regional trains make car-free living realistic, though late-night frequencies thin out.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "High taxes fund strong services while the city invests heavily in startups and green industries.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "NemID/MitID access and pre-filled SKAT returns keep compliance simple despite the tax burden.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Combined municipal and national taxes sit around 40–44%, a predictable trade-off for the welfare state.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "MobilePay, contactless cards, and instant transfers are ubiquitous even in small shops.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Housing and groceries cost less than in Copenhagen but remain high by global standards, so budgeting still matters.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "National pensions, occupational plans, and municipal elder services provide dependable coverage.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Long-term residents accrue ATP and employer pensions, but portability rules require planning if the family leaves Denmark.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Fast-track, Pay Limit, and Positive List permits apply, though fewer local employers meet salary thresholds than in the capital.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Locals are friendly and English-speaking, yet immigration policy remains selective and expects integration into Danish culture.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Initial work permits last two years with renewals tied to employment; permanent residency still requires eight years or strong Danish skills.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization demands nine years’ residence, Danish exams, and a civic test—achievable but long.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and children join through family reunification once income, housing, and insurance requirements are met.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Expect 1–3 months for permit processing plus translation fees and biometric appointments.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Authorities verify salary thresholds and address registration; lapses can trigger permit reviews, so paperwork must stay current.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Denmark allows dual citizenship, so the family can retain U.S. passports after naturalization.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Registering for CPR numbers, MitID, and Danish lessons is mandatory to access services—delays slow benefit access.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Kiloo, Funday Factory, and Trifork’s game teams provide options, though the scene is smaller than Copenhagen’s.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Kiloo, Funday Factory, and DADIU-linked student teams keep Aarhus on the game map.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Game Hub Scandinavia, DADIU cohorts, and meetups at The Kitchen foster collaboration in English.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Incubators, public grants, and university labs exist, but founders must plan for a smaller investor pool and recruiting pipeline.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber, 5G coverage, smart city pilots, and a renovated harborfront make infrastructure strong for a mid-size city.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/denmark_copenhagen_report.json
+++ b/reports/denmark_copenhagen_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "DK",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Copenhagen wraps dense blocks with harbor baths, parks, and wind-buffered bike corridors, so the family can stay outdoors without worrying about serious pollution. Minor shipping emissions near Nordhavn keep it just short of the 9-tier perfection.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "The city sits barely above sea level, but floodgates, cloudburst boulevards, and new harbor barriers mean daily life stays calm so long as the family keeps an eye on long-term sea-rise plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Expect long grey stretches and wind-driven drizzle between bright spells; the parents trade Midwestern temperature extremes for steady but damp seasons that fit the guide’s mid-tier.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Air sensors usually show PM2.5 well under EU limits, and cycling lanes keep tailpipes away from the kids; we just watch short ammonia or woodstove spikes in winter.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Storm surges from the Øresund and occasional winter gales are the main threats, yet strong seawalls, drainage plans, and alerts keep risk low for a cautious family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March and April linger between 5–12°C (41–54°F), so playgrounds need windbreakers, but by May the city hits the mild range the family wants for biking season.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Typical highs sit around 21–24°C (70–75°F) with light breezes, giving the family festival weather without relying on AC even during long daylight stretches.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September holds around 15°C (59°F) before sliding into 8–10°C (46–50°F) with steady rain, so outdoor plans give way to indoor hygge by late October.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winter hovers near freezing with damp winds that bite harder than the number suggests, which matches the guide’s chilly-but-manageable tier for bundled school runs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Amager Strandpark and city harbor baths offer clean sand and lifeguards, yet chilly breezes keep swims short, so it is a pleasant outing rather than a warm-water lifestyle.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Water barely reaches 18°C (64°F) in August, meaning hardy dips or wetsuits; the family mostly uses the shoreline for walks and play structures.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Design-forward canals, deer parks, and quick S-train rides to Dyrehaven or the Øresund coast give solid weekend nature, even if dramatic mountains are missing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Like the rest of Denmark there is no statutory floor, but Copenhagen tech unions usually secure 115–130 DKK/hour equivalents, so Trey and Sarah need collective agreements to lock in pay.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers routinely clear 600,000–700,000 DKK plus pension, enough to handle city taxes though not the very top of Europe’s pay scale.",
+      "alignmentValue": 7
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Banks, Maersk, public digitalization teams, and consultancies all hire .NET talent, letting Trey choose between enterprise gigs and modern product shops.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in a few SaaS outfits and agencies; Sarah will find opportunities by networking, but the stack remains niche compared with Java or .NET.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Fast-track and Pay Limit schemes are common among Copenhagen tech employers, yet they demand high salaries, relocation budgets, and meticulous paperwork.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "As the capital, Copenhagen mirrors Denmark’s low 3% unemployment and diversified economy, though growth remains steady rather than explosive.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid schedules are default in tech, co-working hubs like Talent Garden stay busy, and time zones align with late-afternoon calls to the U.S.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Managers expect parents to leave by 16:00 and respect holidays, matching Sarah’s low-stress priorities and the guide’s near-top boundary keeping.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Standard agreements keep weeks around 37 hours with strong overtime caps, so evenings stay family-focused.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Five statutory weeks plus local holidays are guaranteed, giving plenty of time for U.S. visits without begging for extra leave.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech teams often add flex Fridays or sixth weeks of PTO, and colleagues actually disconnect, reinforcing the 9-tier generosity.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Rush hour is brisk but not frantic; dedicated bike lanes and compact neighborhoods keep daily rhythms efficient without big-city chaos.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run roughly 8:00–14:00 and offices mirror 8:30–16:30, with after-school SFO programs bridging pickup so both parents can work humane hours.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends center on park picnics, museums, and kids’ sports before hygge evenings; shops stay open but social pressure favors family downtime.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Family-friendly cafes, pram lanes, and public changing rooms are everywhere, and employers rarely question leaving for school pickup.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "The city has visible queer and consensual non-monogamy meetups around Nørrebro and Vesterbro, yet bureaucracy and mainstream norms still assume dyads.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools, health nurses, and employers promote egalitarian parenting, though parents are expected to trust kids with independence early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Wide sidewalks, cargo bikes, and traffic-calmed streets make city roaming easy, even if housing size limits giant playrooms.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Neighborhood folkeskoler are strong, bilingual tracks exist, and several international schools (CIS, Rygaards) serve expat transitions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Municipal vuggestuer and børnehaver are plentiful with outdoor-focused pedagogy, though popular districts still require early applications.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Fees are heavily subsidized and capped, and parents can get sibling discounts plus municipal leave top-ups.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once CPR numbers arrive, expat families pay the same subsidized rates, but waitlists and documentation can delay the first placement.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Catchment schools are free and well-funded, with special-needs support and English reinforcement when needed.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Non-EU families can enroll once municipal registration is complete, yet late arrivals may get interim Danish language classes before a permanent seat.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Private friskoler and internationals exist but require fees and early deposits, so they are a fallback rather than the default.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "New parents receive 52 weeks of shared leave with generous wage replacement and strong job protection.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Work-permit holders access parental leave and child benefits after a few months of contributions, but eligibility depends on residence length and job type.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Universities like KU and ITU are tuition-free and provide stipends, giving the kids future options without debt.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students face €10k–15k annual tuition unless they secure scholarships or long-term residency first.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Copenhagen’s workplaces expect men to take parental leave and share domestic labor, aligning with the family’s egalitarian norms.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Nonbinary recognition, gender-neutral bathrooms, and inclusive school policies are visible, even if social familiarity still trails activists’ hopes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Legal protections cover equal pay, parental leave, and anti-discrimination, and enforcement agencies act quickly on complaints.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Women face minimal pressure to present traditionally; minimalism and competence matter more than performative femininity.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Danish men are expected to be caring, emotionally open parents, though stoic Jante-style restraint remains.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Design museums, Michelin smørrebrød, and world-class cycling culture give the family constant creative fuel.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Nearly every Dane in Copenhagen switches to fluent English, and municipal offices provide English guidance while the family learns Danish.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "The metro votes overwhelmingly for Social Democrats, Socialist People’s Party, and Red-Green Alliance, reinforcing progressive social policy.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas are mainstream in debates on housing and climate, but most residents still favor pragmatic social democracy over radical collectivism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church attendance is tiny, and secular norms dominate schools and politics.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, open conversations about consent, and visible kink-friendly venues show a relaxed, informed culture.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Pride Week takes over City Hall Square, legal protections are robust, and rainbow families are normalized in schools.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Danes remain private at first, so the family leans on international clubs and hobby meetups to build deeper ties.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Locals embrace Jante Law modesty—proud of livability yet wary of sounding boastful.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Copenhageners joke about Swedes and Norwegians but cooperate closely through Øresund and Nordic councils.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Copenhagen as a reliable partner in green tech and diplomacy, even if they tease the high costs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Late-night bars in Meatpacking, jazz clubs, and canal parties offer variety while still feeling safe for adults.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Minimalist tailoring, technical rainwear, and sneakers dominate—a practical yet stylish look Trey can blend into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women favor layered neutrals, quality fabrics, and bikes-ready outfits, keeping expectations comfortable for Sarah.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Cycling, cold-water dips, and hygge dinners fill calendars; the family can join local associations quickly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Shops like Bastard Café host nightly board-game sessions, and role-playing meetups run in English.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Venues such as Vega, DR Koncerthuset, and myriad festivals keep live music accessible without overwhelming crowds.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech meetups, expat networks, and family-friendly hobby groups flourish, giving newcomers many entry points.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Within 30 minutes you reach Dyrehaven forests, beaches, and island getaways, though there are no mountains or deep wilderness.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "The capital hosts a transparent parliamentary system with strong checks, and protests stay peaceful.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Policy debates are overwhelmingly secular; religion rarely surfaces outside ceremonial roles.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "High union density, collective bargaining, and strong safety nets support both salaried and freelance work.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Social democratic pragmatism shapes city planning—pro-market entrepreneurship inside a generous welfare state.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Independent courts, free media, and active civil society keep erosion risks low despite the global climate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Entrepreneurship coexists with high taxes and regulation; business support is strong but deliberately balanced by worker protections.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Government transitions are orderly, strikes are negotiated quickly, and crime stays low, so long-term planning feels safe.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters are independent and transparent, though state campaigns promote cycling, green energy, and social cohesion.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Messaging focuses on communal responsibility and sustainability rather than personality cults, matching the guide’s positive tier.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, child benefits, and inclusive housing programs align tightly with the family’s progressive priorities.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show high trust and easy digital contact with agencies, even if tax scandals occasionally spark debate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Denmark at the top, and city tenders are public, giving residents confidence in clean governance.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "When scandals emerge they involve minor expense-account misuse, not systemic bribery, so oversight feels real.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Rents surpass 2,000€ for family-sized flats, cooperative waitlists stretch years, and bidding wars are common, straining the budget.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime is rare and kids bike independently, but bike theft and the occasional gang incident keep it shy of a perfect score.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Local doctors offer efficient preventive care, yet specialist queues can reach months without private insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Once CPR and yellow cards arrive, expats access the same system, but enrollment delays can leave a short coverage gap.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Municipal subsidies cover most daycare costs, though families need to register early to secure nearby spots.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Generous parental leave, child benefits, and flexible work protections directly support this two-parent, two-child household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Schools emphasize project-based learning, English proficiency, and inclusive classrooms, matching the family’s priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The driverless metro, S-trains, regional rails, and integrated ticketing let the family skip car ownership entirely.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "High taxes fund strong services, while the city still nurtures startups through accelerators and public grants.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "SKAT pre-fills returns, NemID/MitID handle secure logins, and withholding makes compliance painless albeit expensive.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Combined municipal and national rates push effective taxation near 42–45%, which is the trade-off for rich benefits.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Digital payments dominate—MobilePay, contactless cards, and instant transfers keep finances effortless.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries, utilities, and especially housing sit among Europe’s highest, demanding careful budgeting despite high wages.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Folkepension, ATP supplements, and employer pensions provide secure elder support with predictable indexing.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Long-term residents can earn ATP and private pension rights, but portability rules require planning if the family relocates later.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Options include Pay Limit, Positive List, and startup visas, all viable for tech workers but document-heavy with salary thresholds.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Danes are polite and English-speaking, yet immigration rules remain selective and expect quick integration efforts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Work permits usually start at two years with renewal up to four; permanent residency requires eight years or accelerated Danish proficiency.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization needs nine years’ residence, Danish exams, and a citizenship test, making it a long but clear path.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and children join under family reunification once income and housing requirements are met, and permits track the main applicant.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Expect 1–3 months for visa processing and notable fees for translations, biometrics, and required documentation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Authorities audit salary levels and housing; falling below thresholds can jeopardize status, so record-keeping matters.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Denmark now permits dual citizenship, so the family can keep U.S. passports after naturalization.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "CPR registration, NemID, and Danish language classes are mandatory steps; missing deadlines can disrupt benefits access.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like IO Interactive, SYBO, and Tactile have deep teams, offering Trey strong AAA and mobile options.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "IO Interactive, SYBO (Subway Surfers), Tactile Games, and NapNok all operate here, anchoring Denmark’s scene.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Meetups such as Spilbar, Game Hub Denmark, and ITU game incubators foster collaboration in English.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Nordic Game Jam, public grants, and EU funding help founders, but high burn rates demand careful financial planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fiber broadband, 5G coverage, smart-city services, and world-class cycling infrastructure keep daily life seamless.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/denmark_odense_report.json
+++ b/reports/denmark_odense_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "DK",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Odense’s riverfront parks, community gardens, and traffic-calmed center keep air and noise low, though surrounding farmland brings seasonal manure smells that keep it at a solid 7.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "The city sits slightly inland, so sea-level rise is less direct, yet heavy rains can swell the Odense River and call for attention to local flood maps.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Weather mirrors Denmark’s maritime mix: mild temperatures, frequent clouds, and steady wind, which is easier on the family than Midwestern extremes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Industry is light, cycling is popular, and breezes disperse emissions quickly, so PM readings stay comfortably low for outdoor play.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major disasters are rare; the main concern is localized flooding during cloudbursts, which municipal pumps handle well.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March and April sit around 5–12°C (41–54°F) with budding orchards and light rain, so jackets stay handy until May warms things up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Typical highs around 21–23°C (70–73°F) give comfortable park weather without AC, aligning with the family’s mild-summer goal.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn brings 8–12°C (46–54°F) days with drizzle and early dusk, shifting playground time indoors by late October.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters hover near freezing with damp winds; snow is light but slush and chill require waterproof layers for the kids.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Odense residents drive 25–30 minutes to Fyn’s beaches like Hasmark or Kerteminde; they’re clean and family-friendly but not right on the doorstep.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Summer water peaks near 18°C (64°F), fine for quick dips or with wetsuits but not for extended swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Gentle forests, the Odense River trail, and Fyn’s rolling countryside offer charming outings even if dramatic vistas are limited.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "No statutory minimum exists, yet unions secure reliable pay floors, so collective agreements remain important for salary security.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers typically earn 480,000–560,000 DKK plus pension—lower than Aarhus but balanced by cheaper housing.",
+      "alignmentValue": 5
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Robotics firms, health-tech companies, and the municipal IT department use .NET, giving Trey steady but smaller-market options.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby jobs are rare; Sarah will likely rely on remote roles or broader JavaScript/full-stack positions.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Only larger employers handle fast-track visas, so securing sponsorship requires targeted outreach and possibly remote-first arrangements.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Odense is diversifying from industry to robotics and health tech; unemployment stays low but the ecosystem is smaller than in bigger metros.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Coworking hubs like Coworking Plus support remote work, but many firms still prefer hybrid schedules anchored in the city.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Workdays end around 16:00, leave is respected, and supervisors expect family priorities to come first.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Collective agreements keep the 37-hour week intact with real overtime compensation.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "The national five-week paid leave baseline applies here as well, covering long family visits back to the U.S.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Employers often add flex days or shut down during school holidays, so taking six weeks off is commonplace.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Commutes are short, errands are calm, and neighborhoods feel village-like—ideal for Sarah’s slower lifestyle preference.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run about 8:00–14:00 with after-school clubs, and offices mirror 8:30–16:30, so both parents can manage pickup rotations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends focus on zoo visits, river walks, and trips to Egeskov Castle or nearby beaches before cozy evenings in.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Playgrounds, family festivals, and accessible childcare make Odense one of Denmark’s most kid-oriented cities.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "LGBTQ+ spaces are welcoming but smaller; consensual non-monogamy groups exist quietly, so community takes extra effort to find.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Parents share responsibilities, and schools encourage independence, though neighbors expect punctuality and participation in community events.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Car-lite streets, extensive bike paths, and family programs at the library keep the city easy for stroller living.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public folkeskoler perform well, but international school options are limited, so Danish immersion is the default.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Vuggestue and børnehave places emphasize outdoor play and are generally available with moderate waiting times.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Municipal subsidies cap fees, and family counseling centers provide extra support when needed.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once CPR numbers are issued, expats pay the same subsidized rates, though some paperwork is still Danish-only.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Neighborhood schools are free and inclusive, offering special-needs resources and modern facilities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "After municipal registration, non-EU kids join local schools with extra Danish language support during the first year.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "A couple of friskoler and international programs exist but have limited seats and tuition costs, so they’re niche solutions.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Generous parental leave, child benefits, and flex work policies mirror national standards and are easy to access locally.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Visa holders qualify for benefits after a few months of employment, provided paperwork stays current.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "The University of Southern Denmark offers tuition-free degrees and applied sciences programs, giving the kids future options close to home.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students must pay tuition unless they gain residency or scholarships.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Men taking leave and women in leadership are normalized; civic campaigns reinforce equal parenting expectations.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Gender-diverse residents find support through LGBTQ+ groups at the university, though everyday visibility is modest.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "National protections and proactive municipal services keep equality enforcement strong.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Practical clothing and competence matter more than traditional femininity cues, matching Sarah’s style.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Fathers are expected to push prams and share chores, with little tolerance for macho posturing.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Hans Christian Andersen heritage, robotics labs, and new cultural hubs keep life interesting without big-city overload.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Most locals speak strong English, but municipal offices sometimes default to Danish, nudging newcomers into language classes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Odense votes center-left, backing social welfare and green mobility, though it is slightly more moderate than the capital.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist debates exist on campus and in co-ops, but daily politics focus on pragmatic social democracy.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church attendance is low, and schools remain secular, aligning with the family’s preferences.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Sex education is frank and inclusive, yet nightlife is quieter and kink spaces are limited.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Pride events and youth groups offer support, but the scene is smaller, so community requires proactive outreach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors greet each other, volunteer clubs welcome newcomers, and the city feels intimate and supportive.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Residents take pride in Odense’s revival while keeping the modesty expected by Jante Law.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Odense’s port history keeps ties to Germany and Norway friendly and pragmatic.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Nordic partners see Odense as Denmark’s robotics hub and a reliable midsize collaborator.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Bars and music venues cluster around Brandts and the riverfront, but nights wind down earlier than in bigger cities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men favor casual Scandinavian basics—knitwear, jeans, and sneakers—so Trey can dress down comfortably.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women balance minimalist outfits with local boutique touches, keeping expectations relaxed.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Cycling, rowing, choir singing, and community gardening dominate, all welcoming to families.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Cafés like Papas Papbar host regular board-game nights, and English-friendly tabletop groups meet at the library.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Musikhuset and Brandts Klædefabrik deliver concerts and festivals, though options are fewer than in Aarhus.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech Odense, robotics clusters, and parent groups exist but run fewer events, so building networks takes initiative.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Within 30 minutes you reach beaches, forests, and bike-friendly countryside, giving easy weekend escapes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Local governance is transparent with participatory budgeting pilots and responsive digital services.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Politics stay secular; religion appears mainly in cultural festivals and heritage tourism.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Union protections, collective agreements, and parental leave norms are as strong here as in the rest of Denmark.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Social democratic policies drive investments in robotics, transit, and affordable housing alongside market growth.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Independent courts, free media, and active civic groups keep backsliding risks low.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Startup incubators and Odense Robotics coexist with high taxes and strong labor protections, balancing markets with welfare.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Political transitions are orderly, and essential services run smoothly, giving confidence in long-term plans.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Media is independent and fact-focused, with civic campaigns pushing cycling and sustainability rather than ideology.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public messaging emphasizes community care, green living, and social trust, aligning with the positive tier.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, child benefits, and inclusive housing cooperatives meet the family’s progressive priorities.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Residents rely on efficient digital services and generally trust city hall, though debates surface around budget priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International scores remain top-tier, and even minor procurement questions trigger audits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "When issues arise they involve occasional favoritism rather than bribery, and ombudsmen address them quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family apartments average far less than Copenhagen, co-op waitlists are shorter, and new developments keep supply healthy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime is rare; bike theft is the main nuisance, so kids can bike to school safely.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "New hospital facilities and strong primary care ensure reliable treatment, though specialists can have moderate waits.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Once CPR and the yellow card arrive, expats receive the same care, but initial registration can take a few weeks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidized daycare and after-school clubs keep costs manageable; early registration secures nearby spots.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Parental leave flexibility, child benefits, and predictable work hours support this two-child household well.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Schools deliver solid academics with emphasis on creativity and STEM, though specialized international programs are limited.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The Odense Letbane light rail, buses, and regional trains cover core routes, but frequencies drop at night and in suburbs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "High taxes fund extensive services while the city invests in robotics clusters and entrepreneurial hubs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "SKAT pre-populates returns, and MitID logins keep compliance straightforward despite the high rates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Effective tax rates hover around 40–43%, the standard trade-off for Denmark’s safety net.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "MobilePay, contactless cards, and instant bank transfers are standard even in small shops.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Housing and childcare cost less than Copenhagen but still reflect Denmark’s high price level, so budgeting remains important.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "National pensions, ATP, and municipal elder services give long-term security.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Long-term residents accrue pension rights, but portability and vesting schedules require planning if they move away.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "The same national permits apply—Pay Limit, Positive List, and startups—but fewer local employers qualify, so applications hinge on specific offers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Residents are warm and English-friendly, yet immigration rules expect serious integration efforts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Initial work permits run two years with renewals; permanent residence still requires long stays and Danish proficiency.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization needs nine years’ residence plus language and civics exams, so it’s a long-term project.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and kids join under family reunification once income and housing criteria are met, with municipal support during integration.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Expect 1–3 months for permit decisions plus translation, biometrics, and application fees.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Maintaining salary thresholds, Danish lessons, and address registration is critical to avoid permit reviews.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Denmark allows dual citizenship, so the family can retain U.S. passports after naturalization.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "CPR registration, MitID setup, and Danish classes are mandatory steps that unlock healthcare and childcare subsidies.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "A few studios like Set Snail and Gears for Breakfast operate here, plus robotics-adjacent serious game firms, but roles are limited.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Set Snail, Gears for Breakfast (A Hat in Time), and educational game teams tied to SDU keep a modest local scene alive.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Fyn Game Dev meetups and SDU game labs host regular events, though the network is smaller than in Aarhus or Copenhagen.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Odense Robotics and local incubators offer grants and mentorship, but talent pools and investors are limited, so remote collaboration is key.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "The new light rail, widespread fiber, and smart-city pilots support modern living without big-city hassles.",
+      "alignmentValue": 8
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Copenhagen city report detailing environment, housing, transit, and tech ecosystem trade-offs
- add Aarhus city report covering family supports, tech employment landscape, and transport access
- add Odense city report emphasizing livability, affordability, and regional tech opportunities
- register the three cities under Denmark in main.json

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e33a04b888832190f33a50cf021575