### PR TITLE
Add Swedish city reports for Stockholm, Malmö, and Gothenburg

### DIFF
--- a/main.json
+++ b/main.json
@@ -724,7 +724,21 @@
     },
     {
       "name": "Sweden",
-      "file": "reports/sweden_report.json"
+      "file": "reports/sweden_report.json",
+      "cities": [
+        {
+          "name": "Stockholm",
+          "file": "reports/sweden_stockholm_report.json"
+        },
+        {
+          "name": "Malmö",
+          "file": "reports/sweden_malmo_report.json"
+        },
+        {
+          "name": "Gothenburg",
+          "file": "reports/sweden_gothenburg_report.json"
+        }
+      ]
     },
     {
       "name": "Denmark",

--- a/reports/sweden_gothenburg_report.json
+++ b/reports/sweden_gothenburg_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "SE",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "In Gothenburg, forested hills, the Göta älv river, and quick ferry rides to the Bohuslän archipelago keep nature woven into city life while emissions rules curb pollution.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "In Gothenburg, stormier winters and heavier rainfall raise flood risks along the Göta river, yet western sea breezes limit heat extremes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "In Gothenburg, marine climate brings mild summers and wet, windy winters; we'll trade deep cold for frequent drizzle and gusts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "In Gothenburg, ship traffic and port industry add particulates, but strict emissions controls keep annual PM2.5 around 7 µg/m³.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "In Gothenburg, apart from occasional flooding and coastal storms, natural disaster risk stays low with strong infrastructure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "In Gothenburg, April hovers 3–10 °C (37–50 °F) with misty mornings, shifting to 7–15 °C (45–59 °F) by May.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "In Gothenburg, July days average 15–22 °C (59–72 °F) with longer daylight and refreshing breezes off the North Sea.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "In Gothenburg, September averages 10–16 °C (50–61 °F) before sliding to 4–9 °C (39–48 °F) amid steady rain and wind.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "In Gothenburg, December–February typically range −2 to 4 °C (28–39 °F); sleet and wind demand waterproof layers more than heavy parkas.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "In Gothenburg, Saltholmen ferries reach rocky swimming spots and small sandy beaches—scenic but with cold water and short prime season.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "In Gothenburg, Kattegat waters peak near 17 °C (63 °F) in late July, so swims are brisk unless paired with sauna time.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "In Gothenburg, nearby Bohuslän coast, Delsjön lakes, and Vättlefjäll nature reserve deliver rugged scenery minutes from town.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "In Gothenburg, union agreements set solid baselines, though port and service jobs still vary depending on collective coverage.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "In Gothenburg, senior engineers earn roughly 520k–650k SEK with strong benefits, reflecting the city's automotive and tech mix.",
+      "alignmentValue": 7
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "In Gothenburg, Volvo Group, Ericsson, and numerous consultancies drive demand for .NET talent, giving Trey broad options.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "In Gothenburg, startup scene is growing but smaller than Stockholm; expect select opportunities in e-commerce and SaaS firms around Lindholmen.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "In Gothenburg, global companies like Volvo Cars and AstraZeneca sponsor visas, though mid-sized firms may hesitate due to paperwork.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "In Gothenburg, the diversified economy—automotive, maritime, and biotech—keeps growth steady even during national slowdowns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "In Gothenburg, tech campuses embrace hybrid work, and coworking spaces around Lindholmen provide infrastructure for distributed teams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "In Gothenburg, companies value work-life balance with predictable hours, generous parental leave, and respect for vacations.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "In Gothenburg, 37.5–40 hour weeks are typical; overtime requires compensation and is uncommon outside product launches.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "In Gothenburg, employees get 25 days plus red-letter holidays, and summer shutdowns are common in manufacturing and tech.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "In Gothenburg, six weeks off is normal once we combine collective agreement days, parental leave, and July slowdowns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "In Gothenburg, the port city feels relaxed; biking or tram rides take 20–30 minutes, and evenings center on cafes and waterfront walks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "In Gothenburg, schools start around 8:20 a.m., offices run 8:30–4:30, and fritids programs cover childcare until about 5:30 p.m.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "In Gothenburg, families hike around Delsjön, visit Universeum, or ferry to the islands; Sundays remain calm with limited shop hours.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "In Gothenburg, the city is walkable with abundant playgrounds and tram access, so pushing strollers and biking with kids feels safe.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "In Gothenburg, queer-friendly venues and alternative communities exist in areas like Majorna, though scenes are smaller and more relationship-focused than Stockholm.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "In Gothenburg, shared parental leave and child-centered schooling are the norm; parents balance independence with community activities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "In Gothenburg, playgrounds, child cafés, and family cabins on trams make getting around with toddlers straightforward.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "In Gothenburg, municipal schools offer bilingual support, and international schools like ISGR and British International School serve expats with waitlists.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "In Gothenburg, förskola places are guaranteed, though certain central districts require early applications; outdoor pedagogy is standard.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "In Gothenburg, income-capped daycare fees keep monthly costs low, typically under 1,500 SEK per child.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "In Gothenburg, once personnummer arrives, visa holders pay the same capped rates; delays mainly hinge on registration processing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "In Gothenburg, catchment schools guarantee placement with Swedish-English support, while specialized schools use lottery systems.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "In Gothenburg, with residency, we enter the same queue; international schools prioritize diplomats but admit long-term residents when slots free up.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "In Gothenburg, friskolor receive public funding, so tuition remains low; international schools charge modest fees compared with US private schools.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "In Gothenburg, families access 480 days paid leave, child allowance, and vab days to care for sick kids.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "In Gothenburg, residence permits unlock parental leave and allowances proportional to Swedish income contributions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "In Gothenburg, University of Gothenburg and Chalmers University of Technology provide tuition-free degrees and adult learning pathways.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "In Gothenburg, non-EU students pay tuition until permanent residency, but scholarships and employer sponsorships help offset costs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "In Gothenburg, men routinely take parental leave and handle school pickups, and women advance in tech and academia with institutional support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "In Gothenburg, West Pride festival and queer collectives offer visible, safe spaces for exploring gender expression.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "In Gothenburg, legal protections and access to gender-affirming healthcare apply equally, though regional clinic waitlists require patience.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "In Gothenburg, practical, minimalist fashion mixes with outdoor gear; assertiveness and career ambition are expected.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "In Gothenburg, emotional openness and hands-on parenting are accepted, softening traditional masculinity cues.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "In Gothenburg, the city blends maritime industry with indie culture—think craft coffee, music festivals, and DIY art spaces.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "In Gothenburg, English is widely spoken in tech, universities, and services, though learning Swedish eases integration with older neighbors.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "In Gothenburg, the city votes center-left, prioritizing climate-neutral transport, housing inclusion, and social welfare.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "In Gothenburg, leftist politics are influential but pragmatic, focusing on labor rights and climate policy rather than radical nationalization.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "In Gothenburg, secular norms dominate despite Lutheran history; interfaith initiatives exist but public life remains non-religious.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "In Gothenburg, comprehensive sex education, accessible clinics, and open conversations keep attitudes progressive and consent-focused.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "In Gothenburg, rainbow trams, West Pride, and anti-discrimination enforcement make queer families visible and supported.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "In Gothenburg, neighborhood associations, cooperative housing, and shared saunas foster community once we engage beyond initial Swedish reserve.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "In Gothenburg, residents pride themselves on being down-to-earth, creative, and more relaxed than Stockholmers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "In Gothenburg, they maintain close ties with Norway and Denmark and view the North Sea as their broader backyard.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "In Gothenburg, others see Gothenburg as friendly and industrious, with jokes about constant rain but respect for its music scene.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "In Gothenburg, live music venues, craft beer halls, and late-night trams create a social scene that balances affordability with strict alcohol regulations.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "In Gothenburg, men pair minimalist Scandinavian basics with rain-ready outerwear—waxed jackets, sneakers, and knit caps.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "In Gothenburg, women mix functional layers with statement coats and sustainable brands, fitting Sarah's taste for comfort with style.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "In Gothenburg, sailing, cycling, trail running, and attending film or music festivals dominate weekends.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "In Gothenburg, stores like Alphaspel and clubs at Studiefrämjandet host regular board-game nights appealing to Trey.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "In Gothenburg, venues like Pustervik and Gothenburg Concert Hall host indie, metal, and classical performances, while Way Out West festival anchors the calendar.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "In Gothenburg, tech meetups at Lindholmen Science Park, expat parent groups, and maker spaces offer regular social touchpoints.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "In Gothenburg, trams reach Delsjön lakes and Änggårdsbergen nature reserve within 20 minutes, perfect for hiking or skiing.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "In Gothenburg, municipal government mirrors Sweden's parliamentary democracy with coalition leadership and transparent budgeting.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "In Gothenburg, religion stays largely separate from policy debates, maintaining secular governance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "In Gothenburg, strong unions and collective agreements protect workers across ports, factories, and tech firms.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "In Gothenburg, local politics exemplify Sweden's social-democratic model, balancing industrial innovation with welfare investment.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "In Gothenburg, independent media, active unions, and civic engagement keep democratic norms firm despite national polarization.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "In Gothenburg, the city encourages entrepreneurship through incubators while redistributing wealth via taxes and services.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "In Gothenburg, political stability is high; changes emerge through consensus rather than abrupt shifts.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "In Gothenburg, media outlets remain independent, and public information campaigns focus on safety and sustainability rather than ideology.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "In Gothenburg, government messaging emphasizes traffic safety, climate goals, and health initiatives without heavy-handed propaganda.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "In Gothenburg, robust welfare, parental leave, and affordable childcare continue to anchor the local social contract.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "In Gothenburg, residents generally trust municipal services, though they expect responsive handling of infrastructure and transit issues.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "In Gothenburg, corruption is rare; transparency laws and investigative journalism expose missteps quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "In Gothenburg, when issues appear they involve procurement or zoning rather than bribery.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "In Gothenburg, rental queues last several years, but new builds in Frihamnen and suburbs offer options if we budget time and money.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "In Gothenburg, violent crime remains low; occasional gang incidents occur in specific suburbs, while central districts feel safe day and night.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "In Gothenburg, citizens use Västra Götaland clinics with modest co-pays and coordinated specialist care.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "In Gothenburg, visa holders pay the same regulated fees after registration; short-term private insurance may bridge initial weeks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "In Gothenburg, förskola slots, vab leave, and family centers support dual-career households even when waitlists appear.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "In Gothenburg, parents split leave, claim child allowance, and leverage flexible work to attend school events.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Education",
+      "alignmentText": "In Gothenburg, public schools perform solidly with strong English instruction; STEM-focused programs benefit from Chalmers partnerships.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "In Gothenburg, vast tram and bus networks plus commuter rail make car-free living practical, though hills and rain demand good gear.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "In Gothenburg, the local economy reflects Sweden's social-market blend—innovative industry backed by generous services funded through taxes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "In Gothenburg, employers withhold income tax, filings happen digitally, and municipal rates hover near 32%.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "In Gothenburg, combined municipal and national taxes push marginal rates toward 50%, requiring budgeting for lower take-home pay.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "In Gothenburg, BankID and Swish enable seamless digital payments once personnummer arrives; cash use is rare.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "In Gothenburg, housing and groceries cost slightly less than Stockholm but still high; energy-efficient homes and public transit help manage expenses.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "In Gothenburg, citizens build strong multi-pillar pensions with supplemental wellness benefits from employers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "In Gothenburg, occupational pensions accrue with employment; newcomers should maintain private savings until vesting.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "In Gothenburg, large employers sponsor work permits and EU Blue Cards; processing times mirror national averages of 4–6 months.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "In Gothenburg, international professionals are common, yet social integration benefits from learning Swedish and joining local clubs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "In Gothenburg, work permits typically run two years and count toward permanent residency after four qualifying years.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "In Gothenburg, five years of residence (three with a Swedish partner) plus good conduct leads to citizenship without renouncing US nationality.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "In Gothenburg, dependents receive residence permits alongside the main applicant, granting school and healthcare access.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "In Gothenburg, application fees are standard (about 2,000 SEK per adult) and decisions can take up to six months, so plan for transition time.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "In Gothenburg, permits require meeting salary thresholds and notifying authorities when changing jobs; compliance audits focus on payroll accuracy.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "In Gothenburg, Sweden allows dual nationality, so the family can keep US passports when naturalizing.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "In Gothenburg, without personnummer, leasing and banking are hard—employers or relocation firms often provide interim housing and support.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "In Gothenburg, Avalanche Studios, Thunderful, and indie teams create a solid hiring market for engineers and designers.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "In Gothenburg, Avalanche Studios, Thunderful, Bitsquid/Autodesk, and Zoink maintain significant Gothenburg teams.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "In Gothenburg, Gothenburg Game Developers meetup, Lindholmen Game Jam, and coworking at United Spaces support collaboration.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "In Gothenburg, University incubators, Film i Väst funding, and Thunderful's network provide mentorship and potential publishing support, though salaries remain costly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "In Gothenburg, modern tram fleets, widespread fiber, and sustainable district heating keep infrastructure efficient even in rainy weather.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/sweden_malmo_report.json
+++ b/reports/sweden_malmo_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "SE",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "In Malmö, windy Öresund shores, leafy parks like Pildammsparken, and short trips to Skåne's farmland give the family fresh air and easy green escapes despite the compact city core.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "In Malmö, low-lying neighborhoods face storm-surge and sea-level threats from the Öresund, and heavy rains tax drainage, putting Malmö a bit more at risk than inland Swedish cities.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "In Malmö, ocean influence keeps winters milder and summers breezy, though frequent gray skies mean we must plan for damp chill rather than deep freezes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "In Malmö, ship traffic and construction can spike particulates, yet prevailing winds and clean energy keep annual PM2.5 near 8 µg/m³.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "In Malmö, the main concern is coastal flooding during Baltic storms; otherwise quakes and extreme weather remain rare.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "In Malmö, April sits around 4–11 °C (39–52 °F) with blustery showers, warming by May to 8–16 °C (46–61 °F).",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "In Malmö, July averages 16–22 °C (61–72 °F) with sea breezes and occasional heat spikes tempered by low humidity.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "In Malmö, September holds 11–17 °C (52–63 °F) before sliding to 5–10 °C (41–50 °F) by November with windy rain bands.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "In Malmö, December–February usually hover −1 to 4 °C (30–39 °F); snow is intermittent but raw winds call for waterproof layers.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "In Malmö, Ribersborg and Lomma beaches provide easy summer outings with shallower, slightly warmer waters than the Baltic archipelagos.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "In Malmö, Öresund waters peak around 18 °C (64 °F) in July and early August, giving a few comfortable swimming weeks before cooling quickly.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "In Malmö, Skåne's rolling countryside, coastal biking paths, and day trips to Söderåsen National Park deliver varied scenery within an hour.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "In Malmö, collective agreements cover most sectors, but Malmö's service-heavy economy means uncovered gig work can pay less reliably.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "In Malmö, tech salaries run 480k–600k SEK for seniors—lower than Stockholm but paired with slightly cheaper housing and Danish commuting options.",
+      "alignmentValue": 6
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "In Malmö, Massive Entertainment, Øresund consultancies, and corporate IT hubs offer steady .NET roles, though the market is smaller than Stockholm so networking matters.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "In Malmö, the local scene skews toward .NET and Java; Ruby roles exist in a handful of e-commerce startups, so expect a smaller pipeline.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "In Malmö, global studios and Medicon Valley firms do sponsor, yet fewer headcount slots mean we must secure offers early and expect slower processing.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "In Malmö, the city has rebounded from industrial decline via education, gaming, and logistics, yet unemployment stays a point above the national average.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "In Malmö, co-working spaces like MINC and proximity to Copenhagen make cross-border remote work common, with Swedish teams respecting boundaries.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "In Malmö, employers honor collective agreements, fika breaks, and parental duties, keeping evenings available for family time.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "In Malmö, 37.5–40 hour weeks are standard; Danish collaborations may introduce earlier start times but still respect overtime rules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "In Malmö, employees receive 25 statutory days plus Danish-style bridge holidays when working cross-border projects.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "In Malmö, tech teams often close for July and enjoy six weeks off through flex days and collective agreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "In Malmö, the city center is compact and bikeable, letting Sarah enjoy slower commutes while still accessing culture via a 20-minute ride.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "In Malmö, schools start 8:15–8:30 a.m., offices run roughly 8:30–4:30, and fritids programs cover after-school care until 5:30 p.m.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "In Malmö, families bike to the beach, explore Turning Torso waterfront events, or take quick train trips to Copenhagen museums.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "In Malmö, wide sidewalks, family saunas, and stroller access on buses make Malmö accommodating for young kids despite urban density.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "In Malmö, the queer-friendly Möllan district and Copenhagen's proximity offer poly/kink communities, though the scene is smaller than Stockholm's and more private.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "In Malmö, parents share leave and prioritize outdoor play; schools encourage independence and multicultural awareness.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "In Malmö, playgrounds like Stapelbäddsparken, child-friendly libraries, and free museum days keep toddlers entertained year-round.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "In Malmö, Swedish-immersion schools dominate, but IB programs and English-language options exist via Bladins and Malmö International School with waitlists.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "In Malmö, förskola access is guaranteed with capped fees; some neighborhoods have waitlists but the municipality provides temporary slots.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "In Malmö, citizens pay income-capped fees topping out around 1,500 SEK per child even in central districts.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "In Malmö, once personnummer is issued, visa holders pay the same capped rates; bridging private care may be needed while waiting for registration.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "In Malmö, catchment schools and friskolor lotteries provide placement, with strong Swedish-as-second-language support for newcomers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "In Malmö, residence permits place us in the same queue; international schools may prioritize corporate transfers but still admit long-term residents.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "In Malmö, friskolor are publicly funded; IB tuition surcharges remain low compared with US private schools.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "In Malmö, parents enjoy 480 days paid leave, child allowance, and vab days; Malmö also offers free parent groups for new arrivals.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "In Malmö, after receiving residence permits, we can tap parental leave and allowances based on Swedish salary contributions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "In Malmö, Malmö University and nearby Lund University provide tuition-free degrees and adult retraining options for residents.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "In Malmö, non-EU students pay tuition, yet permanent residency unlocks free studies; Lund offers scholarships for high-performing internationals.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "In Malmö, equal parenting is visible—dads push cargo bikes and take long parental leaves, normalizing Trey's involvement.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "In Malmö, events like Malmö Pride and venues such as Inkonst foster queer expression while gender-neutral facilities become standard.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "In Malmö, national anti-discrimination laws protect gender identity, and regional clinics provide trans healthcare with reasonable wait times.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "In Malmö, women blend Scandinavian minimalism with multicultural influences, balancing careers and family with support systems.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "In Malmö, men embrace caregiving roles and creative professions, softening traditional masculinity expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "In Malmö, the city's blend of Nordic social policy and global food and culture scenes keeps daily life eclectic and progressive.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "In Malmö, English is widespread in tech and higher education, yet Danish-Swedish bilingualism is handy due to cross-Øresund ties.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "In Malmö, the city leans strongly left, investing in integration, climate action, and anti-racism—aligning with the family's values.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "In Malmö, left-wing parties debate redistribution openly, though policies stay within social-democratic frameworks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "In Malmö, secular norms dominate public life even with Malmö's religious diversity; schools remain non-denominational.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "In Malmö, comprehensive sex education and inclusive clinics support open, consent-focused attitudes toward sexuality.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "In Malmö, rainbow crosswalks, community centers, and low hate-crime levels show everyday acceptance, though nightlife is smaller than Stockholm's.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "In Malmö, multicultural neighborhoods encourage participation in local associations and urban gardening plots, rewarding proactive engagement.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "In Malmö, residents see the city as youthful, creative, and proudly diverse compared with more traditional Swedish metros.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "In Malmö, residents feel closely tied to Copenhagen and view the wider Öresund region as one metro economy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "In Malmö, Danes and other Swedes view Malmö as edgy and occasionally rougher, yet recognize its innovation in urban planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "In Malmö, bars and clubs cluster around Lilla Torg and Möllan with later hours than Stockholm, though alcohol remains pricey.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "In Malmö, streetwear mixes Scandinavian minimalism with immigrant influences—think tailored coats over sneakers and bold colors.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "In Malmö, women blend minimalist basics with international flair, making it easy for Sarah to stay stylish yet practical.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "In Malmö, cycling, coastal jogging, esports, and communal saunas dominate leisure time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "In Malmö, cafés like Spegeln host board-game nights, and Massive's dev community fuels active tabletop meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "In Malmö, live music ranges from indie venues like KB to electronic nights at Plan B, with frequent trips to Copenhagen for bigger acts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "In Malmö, MINC, Media Evolution City, and international parents groups organize regular networking, language exchanges, and startup meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "In Malmö, 15 minutes by bike reaches beaches, nature reserves like Kungsparken, or countryside cycling routes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "In Malmö, municipal government mirrors Sweden's parliamentary structure and prioritizes participatory budgeting and sustainability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "In Malmö, policy debates stay secular despite the city's diverse faith communities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "In Malmö, strong union presence ensures collective bargaining coverage and supportive unemployment insurance.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "In Malmö, local politics embody Sweden's social-democratic model, emphasizing social services and inclusive urban planning.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "In Malmö, independent media and active civil society keep democratic norms resilient despite national debates over crime.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "In Malmö, entrepreneurial hubs and cross-border commerce thrive alongside redistribution that keeps inequality contained.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "In Malmö, politics stay stable; coalition shifts impact municipal projects but not rule-of-law institutions.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "In Malmö, public media and local press operate independently, keeping overt propaganda minimal.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "In Malmö, government messaging focuses on integration, climate resilience, and public health without heavy-handed ideology.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "In Malmö, comprehensive welfare, housing support, and integration programs remain priorities, offering strong backing for our family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "In Malmö, residents generally trust municipal services like Försäkringskassan and Skatteverket, though some critique slow bureaucracy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "In Malmö, corruption remains rare; transparency requirements and active journalism limit misconduct.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "In Malmö, when issues arise they involve procurement or housing allocation controversies rather than bribery.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "In Malmö, queues are shorter than Stockholm but still lengthy; expect to rely on sublets or new developments in Hyllie while building queue time.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "In Malmö, overall crime is moderate with notable gang incidents in certain suburbs; central districts feel safe yet awareness is needed.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "In Malmö, citizens access Skåne region clinics with low co-pays and integrated specialist referrals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "In Malmö, visa holders pay the same regulated fees after registration; interim private coverage bridges the gap.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "In Malmö, förskola slots, vab leave, and family centers support dual-career households even with occasional waitlists.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "In Malmö, parents commonly split parental leave, receive child allowance, and coordinate flexible work to attend school events.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Education",
+      "alignmentText": "In Malmö, public schools emphasize bilingual support and inclusive classrooms, though academic outcomes lag slightly behind Stockholm's averages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "In Malmö, Skånetrafiken's buses and trains plus Öresund bridge connections make regional travel easy, but local frequency can thin late at night.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "In Malmö, the city showcases Sweden's social-market system with cross-border commerce balancing startups and strong welfare services.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "In Malmö, tax withholding and digital filing mirror national simplicity, with municipal rates around 32%.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "In Malmö, dual tech incomes likely face marginal rates near 48–50% once municipal and national brackets combine.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "In Malmö, BankID, Swish, and near-cashless shops work seamlessly once personal numbers are in place.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "In Malmö, housing and groceries cost less than Stockholm but remain high relative to the US Midwest; Danish commuting perks can offset expenses.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "In Malmö, citizens build pension pillars bolstered by housing allowances and regional wellness programs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "In Malmö, new arrivals build pension rights gradually; employers contribute to occupational plans, while private savings fill early gaps.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "In Malmö, regional employers sponsor standard work permits; fewer positions mean careful job sequencing but rules mirror national process.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "In Malmö, the city values international talent yet expects Swedish language learning and community participation to integrate fully.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "In Malmö, work permits issue for up to two years and contribute toward permanent residency after four qualifying years.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "In Malmö, after five years of residency (or three with a Swedish partner) plus language integration, citizenship is within reach.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "In Malmö, dependents receive residence permits alongside the main applicant, unlocking school and healthcare access.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "In Malmö, application fees mirror national rates and decisions often take 4–6 months, so we must plan bridging housing and finances.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "In Malmö, maintaining salary thresholds and employer compliance is key; changing jobs within the first two years requires Migration Agency approval.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "In Malmö, Sweden permits dual nationality, letting the family retain US passports while naturalizing.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "In Malmö, personnummer delays hinder leasing and banking; employers or relocation agencies often help secure interim housing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "In Malmö, Massive Entertainment, Sharkmob, and Tarsier deliver AAA pipelines and steady demand for engineers and artists.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "In Malmö, Massive Entertainment (Ubisoft), Sharkmob, Tarsier Studios, and King maintain sizable teams locally.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "In Malmö, Game Habitat hub, The Ground co-working, and DevHub meetups connect devs and investors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "In Malmö, Game Habitat's accelerator, regional EU grants, and proximity to Copenhagen investors make launching an indie studio viable if we manage payroll costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "In Malmö, the fiber network, district heating, and smart-city projects like Hyllie keep infrastructure modern and reliable.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/sweden_stockholm_report.json
+++ b/reports/sweden_stockholm_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "SE",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "In Stockholm, Lake Mälaren, Djurgården parklands, and the surrounding archipelago keep everyday life immersed in water and woodland while Sweden's environmental policies hold pollution low for the family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "In Stockholm, Baltic sea-level rise and heavier rainstorms pose localized flooding risks, yet Stockholm's northern latitude still buffers heat extremes and the city invests in adaptation projects.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "In Stockholm, midsummer brings long bright evenings but November–March turns gray and damp with icy sidewalks, so we'd need light therapy and indoor play plans for the kids.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "In Stockholm, year-round PM2.5 averages near 6 µg/m³; congestion taxes and electrified buses keep most days pristine aside from spring street dust.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "In Stockholm, major quakes or hurricanes are unheard of; the main disruptions are occasional storm surges or heavy snow that services clear quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "In Stockholm, April warms from 2–8 °C (36–46 °F) into May's 6–15 °C (43–59 °F), so layered rain gear stays essential for school runs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "In Stockholm, June–August hover around 15–23 °C (59–73 °F) with low humidity, ideal for park picnics and ferry trips without oppressive heat.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "In Stockholm, September slides into 7–13 °C (45–55 °F) and October settles closer to 4–9 °C (39–48 °F) with frequent drizzle and early sunsets.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "In Stockholm, December–February average −5 to 1 °C (23–34 °F); freeze-thaw cycles create slick streets and only six hours of daylight at the solstice.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "In Stockholm, city residents rely on small lakeside bathing spots and the archipelago's rocky beaches—beautiful but chilly, with short July swimming windows.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "In Stockholm, Baltic waters rarely exceed 18 °C (64 °F) even in July, so quick dips or sauna combos replace leisurely warm swims.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "In Stockholm, Djurgården, Tyresta National Park, and ferries out to the archipelago keep wilderness adventures within an hour.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "In Stockholm, sectoral union agreements cover most roles and set Stockholm pay scales high enough to track living costs, though uncovered gig work stays variable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "In Stockholm, senior engineers land 550k–700k SEK packages with pension, wellness stipends, and six weeks vacation, solid locally but modest before high taxes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "In Stockholm, banks, telecoms, and scale-ups along the Kista Science City corridor hire .NET talent steadily, giving Trey ample lead flow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "In Stockholm, startups use Ruby on Rails for consumer platforms, yet the market is smaller than .NET—expect selective roles clustered in Södermalm tech firms.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "In Stockholm, multinationals like Spotify, Ericsson, and Klarna routinely sponsor work permits, though processing still takes months and demands proof of salary benchmarks.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "In Stockholm, the capital anchors Sweden's GDP with strong fintech and life-sciences sectors, keeping unemployment below the national average despite inflation ripples.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "In Stockholm, distributed teams and coworking hubs like SUP46 are normal; Swedish managers respect off-hours and asynchronous collaboration.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "In Stockholm, Managers respect vacation blocks and parental duties, making it normal to log off by 5 p.m. and take full parental leave without stigma.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "In Stockholm, statutory 40-hour weeks are observed, and many tech firms offer 37.5-hour schedules with flex time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "In Stockholm, workers receive 25 days of paid vacation plus 11 public holidays, and tech employers rarely contest using them consecutively.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "In Stockholm, six to seven weeks off is common when combining statutory leave, collective agreements, and company-wide summer shutdowns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "In Stockholm, the core is busy but orderly: 20-minute metro rides and punctual buses keep commutes manageable, while weekends migrate to parks or the archipelago.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "In Stockholm, schools start around 8:30 a.m., most offices run 9–5 with fika breaks, and after-school fritids programs cover care until 5:30 p.m.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "In Stockholm, families hit museums, nature reserves, or community sports in the morning, then host friends for fika; alcohol sales stay limited to Systembolaget hours.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "In Stockholm, the city normalizes dual-career parenting, abundant playgrounds, and stroller access everywhere, so our family fits right in.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "In Stockholm, the LGBTQ+ scene, kink-friendly clubs, and open relationship networks offer discreet yet welcoming support for non-monogamous families.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "In Stockholm, parents are expected to share leave, attend school meetings, and embrace child-led play; helicoptering is frowned upon.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "In Stockholm, playgrounds, pram ramps, and family rooms in transit hubs make it easy to move with toddlers even in winter.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "In Stockholm, municipal and free schools offer bilingual tracks and strong English instruction; international schools require queues but exist across the metro.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "In Stockholm, förskola enrollment is guaranteed from age one with fees capped relative to income, though central districts have waitlists.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "In Stockholm, citizens pay at most about 1,500 SEK per child monthly thanks to national fee caps and municipal subsidies.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "In Stockholm, once we have personnummer IDs, the same capped daycare fees apply; delays only arise if registrations lag.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "In Stockholm, catchment schools guarantee placement and offer Swedish-English immersion, while specialized schools (arts, Montessori) use lottery systems.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "In Stockholm, with residence permits we join the same school queue as citizens; international schools may prioritize diplomat quotas but openings do appear.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "In Stockholm, independent friskolor receive public funding, so tuition stays minimal; elite IB schools charge modest extras but nothing like US private rates.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "In Stockholm, parents share 480 days paid leave, child allowance of 1,250 SEK per kid, and vab sick-day rights to stay home with ill children.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "In Stockholm, after obtaining residence permits and personnummer, visa holders can access parental leave and allowances proportionate to Swedish earnings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "In Stockholm, Stockholm University, KTH, and Karolinska offer world-class degrees with no tuition for citizens and income-based study grants.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "In Stockholm, non-EU tuition applies, but residence permits let kids attend upper-secondary free and pursue subsidized adult education once permanent residency is earned.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "In Stockholm, gender equality is deeply ingrained; dads push strollers and take long parental leaves, making Trey's involvement expected.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "In Stockholm, Stockholm Pride, queer collectives, and gender-neutral facilities make experimenting with presentation low risk.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "In Stockholm, legal gender recognition and anti-discrimination protections are robust, and city services provide support groups for trans and non-binary residents.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "In Stockholm, women balance careers and family with state support; assertiveness and independence are the norm rather than exception.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "In Stockholm, men are encouraged to be caregivers, emotionally open, and fashion-forward, aligning well with Trey's parenting style.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "In Stockholm, we'd join a culture that blends high-tech innovation with communal rituals like fika and allemansrätten outdoor traditions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "In Stockholm, English is widely spoken in tech, schools, and services, though learning Swedish unlocks bureaucracy faster and deepens friendships.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "In Stockholm, the city votes for progressive parties championing feminism, climate action, and social inclusion—squarely matching the family's values.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "In Stockholm, leftist discourse is mainstream but pragmatic; cooperatives and unions focus on equality without pushing full state ownership.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "In Stockholm, roughly half the city is non-religious; secular public life means the kids won't face religious pressure at school.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "In Stockholm, comprehensive sex ed, consent culture, and open conversations around kink/poly spaces make sexual health services approachable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "In Stockholm, rainbow crossings, Pride Week, and anti-discrimination enforcement keep queer families visible and protected.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "In Stockholm, neighborhood associations, resident saunas, and parent co-ops foster community once we engage proactively despite reserved first impressions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "In Stockholm, residents see themselves as cosmopolitan problem-solvers leading the Nordics in design and sustainability.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "In Stockholm, they view fellow Nordics as collaborators and Baltic neighbors as important trade partners, with mild rivalry toward Copenhagen.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "In Stockholm, others respect Stockholm's tech and design scene but tease Swedes for formality and consensus-seeking.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "In Stockholm, bars close early compared to the US and alcohol is expensive, yet cocktail dens and live venues in Södermalm and Östermalm reward planned nights out.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "In Stockholm, men favor tailored streetwear—wool coats, sneakers, and minimalist layers—so Trey's style can lean smart-casual without standing out.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "In Stockholm, women mix structured basics with statement outerwear; Sarah can enjoy sleek Scandinavian fashion that balances comfort and polish.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "In Stockholm, cycling, cold-water plunges, board games, and outdoor excursions dominate weekend plans.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "In Stockholm, board-game cafés like Dragon's Lair plus active Meetup and BGG groups give Trey easy access to tabletop communities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "In Stockholm, venues from Avicii Arena to intimate jazz clubs and techno nights reward planned evenings despite high cover charges and strict door policies.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "In Stockholm, tech meetups, international parents groups, and poly-friendly socials convene weekly around Södermalm and Kista hubs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "In Stockholm, ten minutes on transit lands us in forests, waterfront trails, or cross-country ski tracks once winter arrives.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "In Stockholm, Sweden's parliamentary democracy is headquartered here; agencies are transparent and courts independent.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "In Stockholm, religion remains largely absent from policy debates, keeping laws secular and rights-focused.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "In Stockholm, collective bargaining, mandatory vacation, and strong unemployment insurance support stable careers even during transitions.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "In Stockholm, the city embodies a social-democratic model mixing market competition with generous welfare safeguards.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "In Stockholm, free press, independent judiciary, and civic engagement keep democratic institutions resilient despite rising right-wing parties.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "In Stockholm, startups scale quickly thanks to venture capital access, yet redistribution keeps inequality comparatively low.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "In Stockholm, the capital enjoys low political volatility and efficient institutions, so policy shifts happen through consensus not shock.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "In Stockholm, public broadcasters uphold editorial independence, and media literacy is strong, limiting state-driven narratives.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "In Stockholm, government campaigns focus on health, climate, and safety rather than ideological spin, aligning with the family's preference for pluralistic media.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "In Stockholm, comprehensive welfare, parental leave, and LGBTQ+ protections make social policy one of Stockholm's biggest draws for us.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "In Stockholm, citizens generally trust agencies like Skatteverket thanks to predictable service and digital tools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "In Stockholm, transparency rankings remain top-tier; when scandals occur they are investigated quickly and openly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "In Stockholm, petty bribery is rare; occasional issues involve procurement favoritism but are usually exposed by auditors.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "In Stockholm, rental queues stretch for years and cooperative apartments demand large buy-ins, so we'd likely start with pricey sublets or satellite suburbs while searching.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "In Stockholm, violent crime stays low; concerns center on occasional gang incidents in outer districts, but central neighborhoods feel safe for late-night transit.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "In Stockholm, citizens access universal primary care, maternity clinics, and specialist referrals with modest co-pays and capped annual out-of-pocket costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "In Stockholm, after receiving personal numbers, visa holders pay the same co-pays as citizens; interim private insurance may be needed until registration completes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "In Stockholm, förskola spots plus generous vab sick-leave allow parents to juggle jobs and childcare without risking employment.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "In Stockholm, families routinely split parental leave, receive child allowance, and rely on flexible work norms to attend school events.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Education",
+      "alignmentText": "In Stockholm, public schools deliver solid academics with strong English, though national test scores plateau; we can supplement STEM or gifted needs via after-school clubs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "In Stockholm, SL's metro, commuter rail, trams, and ferries make car-free living viable; buses run frequently even into suburbs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "In Stockholm, the city showcases Sweden's social-market model: dynamic startups alongside high redistributive taxes funding services.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "In Stockholm, employers withhold tax, annual returns are filed digitally in minutes, though combined municipal and national rates exceed 30% once incomes rise.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "In Stockholm, dual tech incomes could see marginal rates around 50% after municipal, national, and pension contributions, shrinking take-home pay.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "In Stockholm, BankID, Swish, and cashless shops mean seamless daily payments once we secure IDs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "In Stockholm, housing, groceries, childcare fees, and services run among the highest in the Nordics, so we'll need a premium budget or consider nearby suburbs.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "In Stockholm, citizens accumulate income, occupational, and premium pensions that provide stable retirement income supplemented by housing allowances.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "In Stockholm, new arrivals build pension rights over time; until permanent residency, we'd rely on private savings alongside employer plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "In Stockholm, employers can sponsor standard work permits or EU Blue Cards, yet processing takes 4–7 months and demands job continuity.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "In Stockholm, international talent is common in tech hubs, but integration expectations mean we must learn Swedish and embrace local norms to feel fully included.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "In Stockholm, work permits issue for two years at a time, extendable to permanent residency after four years of qualifying employment.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "In Stockholm, after five years (or three if married to a Swede) with language integration, we can apply for citizenship without renouncing US nationality.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "In Stockholm, dependents piggyback on the primary permit, gaining access to school and healthcare once residence cards arrive.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "In Stockholm, application fees total about 2,000 SEK per adult and decisions can stretch six months, so we need contingency planning for start dates.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "In Stockholm, permits hinge on minimum salary thresholds and continuous employment; switching employers requires notifying the Migration Agency promptly.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "In Stockholm, Sweden allows dual citizenship, so the kids can retain US passports alongside Swedish if naturalized.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "In Stockholm, without personnummer we can't sign leases or open bank accounts, so bridging housing and employer assistance are critical during the first weeks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "In Stockholm, Mojang, Paradox, DICE, Embark, and multiple indie studios offer deep hiring pipelines across AAA and mobile.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "In Stockholm, Mojang, Paradox Interactive, DICE, Embark Studios, and Resolution Games anchor the local ecosystem.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "In Stockholm, meetups like Stockholm Unity User Group and coworking spaces such as The Park foster collaboration and mentoring.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "In Stockholm, Vinnova grants, Sting incubator programs, and access to seasoned talent make founding an indie studio feasible albeit with high salary expectations.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "In Stockholm, gigabit fiber, 5G, and efficient public services keep everyday logistics slick, matching the family's appetite for modern amenities.",
+      "alignmentValue": 9
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add alignment-driven city reports for Stockholm, Malmö, and Gothenburg that tailor climate, cost, safety, and ecosystem notes to the family profile
- register the three Swedish cities in the main manifest so they surface alongside existing country entries

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e33a589b14832187e0af803759a1a2