### PR TITLE
Add detailed migration reports for major Canadian cities

### DIFF
--- a/main.json
+++ b/main.json
@@ -572,7 +572,29 @@
     },
     {
       "name": "Canada",
-      "file": "reports/canada_report.json"
+      "file": "reports/canada_report.json",
+      "cities": [
+        {
+          "name": "Vancouver",
+          "file": "reports/canada_vancouver_report.json"
+        },
+        {
+          "name": "Victoria",
+          "file": "reports/canada_victoria_report.json"
+        },
+        {
+          "name": "Montreal",
+          "file": "reports/canada_montreal_report.json"
+        },
+        {
+          "name": "Ottawa",
+          "file": "reports/canada_ottawa_report.json"
+        },
+        {
+          "name": "Toronto",
+          "file": "reports/canada_toronto_report.json"
+        }
+      ]
     },
     {
       "name": "Portugal",

--- a/reports/canada_montreal_report.json
+++ b/reports/canada_montreal_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "CA",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Montreal’s banks, gaming giants, and AI labs hire senior .NET developers, but French-language interviews and day-to-day collaboration mean Trey prepares to work bilingually.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Most days stay in the good AQI range, yet winter wood burning and summer wildfire haze push us to monitor alerts before sending the kids outside.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular norms dominate public life, letting the family raise the kids without religious pressure even though faith communities stay visible.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Canada’s institutions, courts, and media remain resilient, aligning with the family’s demand for a progressive, rights-protecting democracy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "The big-five banks, Interac, and wide contactless adoption make everyday payments smooth for the family, albeit with higher fees than U.S. online banks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Clock Tower Beach and Parc Jean-Drapeau offer seasonal river swims, but water quality checks and limited warm days keep beach outings occasional.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Randolph pubs, Boutique Imaginaire, and bilingual RPG nights keep the tabletop scene buzzing with designers and playtesters.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Federal-provincial $10/day deals lower tuition, yet Sarah would still face waitlists and patchy infant care until the new spaces open.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Family zones in parks, extensive library programming, and snow-cleared bike paths offset the winter slog of bundling kids for school.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Once in a CPE, low fees plus provincial family allowances make childcare among the most affordable in North America.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Temporary residents can access subsidies after filing Quebec taxes, but must navigate French-language paperwork and waitlists.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Winter skating, summer biking along the Lachine Canal, and endless cultural festivals give the family year-round outlets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Borough councils, neighborhood festivals, and bilingual co-ops make it easy to plug in once we participate in French as well as English spaces.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Rules are strict but transparent, meaning the family must stay on top of filings yet benefits from clear guidance and digital portals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Rents average 30–40% below Toronto, so a family-sized Plateau or Rosemont flat fits the budget even after factoring daycare and winter utilities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Canada allows dual citizenship, letting Trey and Sarah retain U.S. passports while securing long-term Canadian rights for the kids.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "The economy is steady with low unemployment, yet commodity swings and high household debt encourage the family to keep a solid emergency fund.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A social-market mix funds healthcare and childcare while maintaining private enterprise, matching the family’s preference for progressive capitalism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Public schools deliver strong outcomes, but English-language spots require eligibility certificates; immersion tracks help the kids become bilingual quickly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Employers sponsor via LMIA or Global Talent Stream, but Trey would need standout credentials and patient timelines to secure a work permit.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "The island offers extensive bike lanes, composting, and park space, though older industrial corridors along the Saint-Laurent still show hot spots.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Stacked federal and provincial brackets push combined rates near 35-40% on tech incomes, so Trey’s startup budget must include higher payroll taxes.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September and October hover around 10–18 °C (50–64 °F) with vibrant foliage, giving the family prime hiking weekends before November chill.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Family-focused policies, parental leave, and community programs support Sarah’s hunt for balance even if winter hibernation is real.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and dependent children can ride along on most residency streams, easing worries about keeping the household together.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens enjoy generous leave, universal healthcare, and indexed child benefits—exactly the safety net Sarah asked for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical families rely on paid leave and subsidized childcare, so Trey and Sarah would see peers modeling the balance they want.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Work-permit families qualify for many supports after meeting residency and contribution rules, so Trey and Sarah get a safety net once they clear province-specific requirements.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Urban centers lean toward practical minimalist layers—great for Sarah’s casual tech style, less exciting if she craves bold fashion.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men’s fashion centers on technical outerwear and smart-casual looks, so Trey blends in with jeans, flannels, and weather-ready jackets.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Gender expectations are flexible; mothers balance careers and family without heavy social penalty, aligning with Sarah’s goals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Ubisoft, Eidos, Warner Games, Behaviour Interactive, and indie powerhouses like Tribute make Montreal a top-tier fallback if Trey pauses his studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition of non-binary markers and inclusive school policies make it easier to raise kids in the sex-positive environment the family values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal pay laws, reproductive rights, and parental leave are well protected, giving the household confidence their progressive values will be upheld.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are normal and dads take leave, matching Trey and Sarah’s expectation of shared parenting.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "The family must navigate SIN applications, provincial health wait periods, and auto insurance rules before feeling fully settled.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier rainstorms, urban heat waves, and Saint-Laurent flooding require resilient housing choices and backup cooling for July heat.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "RAMQ covers comprehensive care, yet finding a family doctor can take months, so we plan to lean on CLSCs and pediatric urgent care.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Newcomers wait up to three months for RAMQ and must present study or work permits, making private insurance prudent during the transition.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Domestic tuition plus RESP incentives keep university accessible for the boys, even if spots in top programs stay competitive.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International fees remain steep and aid is limited, so the family would budget extra if the kids enroll before citizenship.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Older triplexes offer roomy apartments, yet July 1 lease turnover and aging insulation mean we book movers early and budget for energy upgrades.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "CRA prefilled slips and online filing keep compliance manageable, yet the family will still hire cross-border tax help to reconcile U.S. obligations.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Free public schools with French immersion, STEM academies, and inclusive policies match the family’s education priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Dependent kids enroll as domestic students with ESL supports, letting the boys integrate quickly once paperwork clears.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Downtown services are bilingual, yet daily life in most boroughs happens in French, so the family commits to immersion to avoid barriers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Village Montréal, robust Pride events, and inclusive provincial policies make it easy to live openly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Left politics inform policy debates, yet mainstream parties stay centrist, so Trey’s curiosity about socialist experiments is met mostly in academia.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Canadian dads take leave and show-up in schools, giving Trey role models for engaged, emotionally open fatherhood.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech, gaming, and parenting meetups crowd Eventbrite in the big metros, helping the family build community quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Quebec’s 15.75 CAD minimum wage trails living-wage estimates, but strong tenant protections and subsidized childcare cushion lower incomes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber, reliable utilities, and modern transit projects keep cities functional, though rural broadband still lags Trey’s latency needs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Mount Royal Park, the Lachine Canal, and quick drives to the Laurentians deliver four-season scenery without leaving the metro area.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Ice storms and spring floods are the main hazards, and while earthquakes are rare, we still prep emergency kits for prolonged outages.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Commuter trains and carpools put Mont-Tremblant, Parc national d’Oka, and Eastern Townships trails within 60–90 minutes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "From jazz clubs to late-night electronic venues, Montreal’s music culture rivals much larger cities, giving the parents options once childcare is sorted.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Bars, speakeasies, and festivals run well past midnight, though strict licensing still keeps things organized compared to U.S. party scenes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "MIGS, GamePlay Space, and Pixelles host meetups, mentorship, and accelerators that welcome newcomers in both French and English.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Ubisoft Montréal, Eidos Montréal, Behaviour, WB Games, and indie hits like Kitfox cluster across Mile-End and downtown campuses.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Generous Quebec tax credits, GamePlay Space incubators, and a deep talent pool make it one of North America’s best launchpads for an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Weekdays feel like a fast-moving metropolis, but extended lunches, five-week vacations, and car-lite living balance the pace.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Parents juggle structured activities with free play; the family can choose hockey or coding clubs without judgment for charting a balanced path.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Three years of residency and language tests set a clear path to passports for the whole family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Canada highly, reassuring the family that public funds and services rarely suffer from graft.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A parliamentary democracy with strong courts and charter rights aligns with the family’s progressive expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Polyamory-friendly cafés, consent education hubs, and active online groups provide a welcoming network for non-monogamous families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Quebec’s CPE network offers high-quality care at roughly 8.85 CAD a day, though families queue early or use private spots while waiting.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Independent schools offer IB and alternative curricula, but tuition is steep, so the family views them as optional backups rather than a must.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Municipal politics emphasize transit, housing co-ops, and climate adaptation, aligning with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government messaging leans on multicultural unity and national pride, but pluralistic media offer counterpoints the family appreciates.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters and private conglomerates dominate narratives, yet independent outlets stay accessible so the family can compare perspectives.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The Metro, REM expansion, and dense bus grid make car-free living realistic, though winter storms can disrupt surface routes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Faith groups rarely drive policy, supporting the secular governance the family wants for raising the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Co-working hubs like Crew Collective, Aire Commune, and Mile-End studios support hybrid teams, though some employers still expect office French immersion a few days a week.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Express Entry, provincial nominee programs, and study-to-work paths offer multi-year permits, giving the family flexibility if one route stalls.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "CPP/QPP plus OAS provide a stable base, but the family would still build RRSP and TFSA savings to maintain U.S.-level comfort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Newcomers qualify for CPP after meeting residency years, so the household builds private savings knowing public pensions alone won’t mirror U.S. income levels.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Work permits grant access to CPP with contributions, but portability and benefits end if status lapses, prompting the family to maintain RRSPs and U.S. accounts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Rails teams at Lightspeed, Hopper, and numerous consultancies post openings, provided Sarah can collaborate in French and English.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime remains low, and even nightlife districts feel manageable; we mainly watch for bike theft and winter slip hazards.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public, French immersion, and alternative programs let the family tailor education without leaving secular schools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "St. Lawrence waters can reach 20 °C (68 °F) in July, letting the kids splash briefly before cooler currents return by late August.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers swing hot and humid while winters plunge below −15 °C (5 °F), so we budget for both AC and serious winter gear.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education and queer-inclusive spaces make it easier to live the family’s sex-positive values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, child benefits, and progressive labor laws deliver the social contract Trey and Sarah want while raising the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March and April seesaw between thaw and late snow, ranging −2 to 12 °C (28–54 °F), so playground plans wait until May.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Political and economic stability is high, keeping immigration policies and social services predictable for the family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Canada blends market economics with social welfare, aligning with Trey’s preference for regulated capitalism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "The system favors regulated markets with SME supports, so Trey can pursue entrepreneurship without extreme inequality concerns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "June through August bring 24–28 °C (75–82 °F) highs with humidex spikes, encouraging us to seek shade and splash pads on peak afternoons.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Express Entry fees are reasonable, but biometrics and medicals add time, so the family should budget 12-18 months for PR.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate-to-high trust in institutions, reinforcing the family’s desire for dependable governance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption surfaces as isolated patronage or procurement issues, which gives the family confidence they won’t need insider favors to access services.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers earn around 110k–140k CAD at Lightspeed, Unity, or CAE; total comp beats the cost of living but lags Toronto and Vancouver.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Festivals, street closures for cycling, and winter sledding on Mount Royal keep weekends packed with affordable family outings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools generally run 8:00–15:00, and offices favor 9–5 with lunch breaks, leaving room for after-school care or extracurriculars before dinner.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Statutory leave is two weeks plus holidays, requiring Trey to negotiate extra time for U.S. family visits.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers often grant three to four weeks, which helps Sarah guard downtime but still trails European norms.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Canadians view the U.S. as a vital partner with cautious critiques, so the family can discuss politics openly without hostility.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Canadians embrace an inclusive, polite national identity, matching the family’s desire for collaborative communities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighboring countries generally see Canada as friendly and reliable, which helps Trey when pitching cross-border clients.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Express Entry, provincial nominations, and Start-up visas give the family multiple routes, though each demands meticulous documentation and proof of funds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Shared culture and existing American expats mean the family fits in quickly, though housing competition is stiff.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Bilingual arts, avant-garde tech, and generous social programs create a culturally rich, values-aligned base for the family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "December to February often sits between −12 and −4 °C (10–25 °F) with windchill, so we plan for indoor play spaces and frequent snow shoveling.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Standard 40-hour expectations persist, with occasional crunch in tech; Trey and Sarah can guard evenings by negotiating boundaries.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Canadian employers respect boundaries more than U.S. counterparts, letting the family schedule dinners and bedtime routines even when tech projects peak.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong labor laws, paid leave, and union coverage support the family’s need for stability and predictable schedules.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/canada_ottawa_report.json
+++ b/reports/canada_ottawa_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "CA",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Federal digital services, Shopify, and defence contractors like Ciena and Nokia keep senior .NET positions plentiful, letting Trey choose between public service stability and private-sector pace.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Ottawa usually posts low PM2.5 thanks to green belts, with wildfire smoke from Quebec and Ontario only spiking a few weeks each summer.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular norms dominate public life, letting the family raise the kids without religious pressure even though faith communities stay visible.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Canada’s institutions, courts, and media remain resilient, aligning with the family’s demand for a progressive, rights-protecting democracy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "The big-five banks, Interac, and wide contactless adoption make everyday payments smooth for the family, albeit with higher fees than U.S. online banks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Mooney’s Bay and Petrie Island offer lifeguarded river beaches each summer, though water-quality advisories pop up after storms.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Loft Board Game Lounge, House of Targ, and Carleton University clubs keep a steady tabletop calendar for Trey’s interests.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Federal-provincial $10/day deals lower tuition, yet Sarah would still face waitlists and patchy infant care until the new spaces open.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "National museums, bilingual library programs, and safe neighborhoods make raising young kids straightforward despite the winter chill.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Once placed, CWELCC subsidies and Ontario child benefits keep monthly costs manageable for mid-income households.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Work-permit holders qualify for CWELCC once they secure SINs and file taxes, though reimbursements may lag their first few months.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Skating the Rideau Canal, winter skiing, and summer cycling provide accessible hobbies that fit the family’s outdoor goals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Civic events, bilingual school councils, and community leagues welcome families once we show up consistently despite the government-town reserve.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Rules are strict but transparent, meaning the family must stay on top of filings yet benefits from clear guidance and digital portals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Rents and groceries run 15–20% lower than Toronto, so a family-friendly rowhouse in Old Ottawa South or Kanata fits budget projections.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Canada allows dual citizenship, letting Trey and Sarah retain U.S. passports while securing long-term Canadian rights for the kids.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "The economy is steady with low unemployment, yet commodity swings and high household debt encourage the family to keep a solid emergency fund.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A social-market mix funds healthcare and childcare while maintaining private enterprise, matching the family’s preference for progressive capitalism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Ottawa-Carleton and Conseil des écoles publiques offer English, French, and immersion tracks with strong outcomes, though popular programs require early lotteries.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Employers sponsor via LMIA or Global Talent Stream, but Trey would need standout credentials and patient timelines to secure a work permit.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Extensive parks, the Rideau Canal, and strict river protection deliver clean air and water, aligning with the family’s love of outdoors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Stacked federal and provincial brackets push combined rates near 35-40% on tech incomes, so Trey’s startup budget must include higher payroll taxes.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September and October stay between 8 and 18 °C (46–64 °F), giving prime biking weather before the November chill.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Family-focused policies, parental leave, and community programs support Sarah’s hunt for balance even if winter hibernation is real.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and dependent children can ride along on most residency streams, easing worries about keeping the household together.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens enjoy generous leave, universal healthcare, and indexed child benefits—exactly the safety net Sarah asked for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical families rely on paid leave and subsidized childcare, so Trey and Sarah would see peers modeling the balance they want.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Work-permit families qualify for many supports after meeting residency and contribution rules, so Trey and Sarah get a safety net once they clear province-specific requirements.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Urban centers lean toward practical minimalist layers—great for Sarah’s casual tech style, less exciting if she craves bold fashion.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men’s fashion centers on technical outerwear and smart-casual looks, so Trey blends in with jeans, flannels, and weather-ready jackets.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Gender expectations are flexible; mothers balance careers and family without heavy social penalty, aligning with Sarah’s goals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Ubisoft Ottawa, Snowed In, and Raven Software satellite teams provide roles, but the market is smaller than Montreal or Toronto.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition of non-binary markers and inclusive school policies make it easier to raise kids in the sex-positive environment the family values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal pay laws, reproductive rights, and parental leave are well protected, giving the household confidence their progressive values will be upheld.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are normal and dads take leave, matching Trey and Sarah’s expectation of shared parenting.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "The family must navigate SIN applications, provincial health wait periods, and auto insurance rules before feeling fully settled.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Ottawa River flooding, freezing rain, and hotter summers are intensifying, so we favor higher-ground neighborhoods and invest in sump pumps and backup cooling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "OHIP covers primary and pediatric care, yet family doctors can be scarce, so we expect to join a waitlist while using walk-in clinics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Ontario reinstated the three-month OHIP wait, making private insurance essential for newcomers until coverage begins.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Domestic tuition plus RESP incentives keep university accessible for the boys, even if spots in top programs stay competitive.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International fees remain steep and aid is limited, so the family would budget extra if the kids enroll before citizenship.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Townhomes and semi-detached houses remain attainable compared with GTA prices, though bidding wars still happen near top schools.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "CRA prefilled slips and online filing keep compliance manageable, yet the family will still hire cross-border tax help to reconcile U.S. obligations.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Free public schools with French immersion, STEM academies, and inclusive policies match the family’s education priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Dependent kids enroll as domestic students with ESL supports, letting the boys integrate quickly once paperwork clears.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominates, yet access to French schooling and services makes bilingual education easy without language barriers.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Capital Pride, inclusive public servants, and supportive school policies create a welcoming environment for queer families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Left politics inform policy debates, yet mainstream parties stay centrist, so Trey’s curiosity about socialist experiments is met mostly in academia.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Canadian dads take leave and show-up in schools, giving Trey role models for engaged, emotionally open fatherhood.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech, gaming, and parenting meetups crowd Eventbrite in the big metros, helping the family build community quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Ontario’s 16.55 CAD minimum wage helps, yet rising rents still require roommates or subsidies for service workers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber, reliable utilities, and modern transit projects keep cities functional, though rural broadband still lags Trey’s latency needs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Rideau Canal vistas, Parliament Hill greenspace, and fall foliage along the river keep nature visible even downtown.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Floods, the odd tornado, and ice storms are the main risks; we follow city alerts and keep emergency supplies stocked.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Gatineau Park, Greenbelt trails, and cross-country ski loops lie 20 minutes away, making weekend adventures easy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Nightlife clusters in the ByWard Market and Elgin Street but quiets early compared to Toronto or Montreal, suiting parents focused on family time.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Craft breweries and live-music lounges thrive on weekends, yet weekday scenes are subdued, so social life leans toward house gatherings.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Ottawa Game Dev, Invest Ottawa’s Digital Media Lab, and Algonquin College meetups foster collaboration even in a mid-sized community.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Ubisoft Ottawa, Snowed In Studios, Fuel Studios, and Beamdog’s Ottawa office anchor the local scene alongside federal XR labs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Invest Ottawa accelerators, Ontario Creates tax credits, and proximity to federal grants help launches, though local venture funding remains limited.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Government hours and shorter commutes deliver a calmer rhythm than Toronto while still offering urban amenities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Parents juggle structured activities with free play; the family can choose hockey or coding clubs without judgment for charting a balanced path.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Three years of residency and language tests set a clear path to passports for the whole family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Canada highly, reassuring the family that public funds and services rarely suffer from graft.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A parliamentary democracy with strong courts and charter rights aligns with the family’s progressive expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Ottawa Polyamory and Consent Ottawa host regular meetups and workshops, offering community even if circles are smaller than Toronto’s.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "CWELCC $10-a-day conversions are underway, but infant spaces in central neighborhoods have 12–18 month queues, so we plan for interim sitters.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Independent schools offer IB and alternative curricula, but tuition is steep, so the family views them as optional backups rather than a must.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Municipal politics focus on transit, climate adaptation, and reconciliation, aligning with the family’s progressive leanings despite federal bureaucracy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government messaging leans on multicultural unity and national pride, but pluralistic media offer counterpoints the family appreciates.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters and private conglomerates dominate narratives, yet independent outlets stay accessible so the family can compare perspectives.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "OC Transpo buses and the new LRT cover key corridors, but reliability issues and suburban gaps mean we likely keep a car for backup.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Faith groups rarely drive policy, supporting the secular governance the family wants for raising the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Federal agencies, Shopify, and numerous contractors support hybrid policies, and EST hours sync perfectly with U.S. partners.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Express Entry, provincial nominee programs, and study-to-work paths offer multi-year permits, giving the family flexibility if one route stalls.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "CPP/QPP plus OAS provide a stable base, but the family would still build RRSP and TFSA savings to maintain U.S.-level comfort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Newcomers qualify for CPP after meeting residency years, so the household builds private savings knowing public pensions alone won’t mirror U.S. income levels.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Work permits grant access to CPP with contributions, but portability and benefits end if status lapses, prompting the family to maintain RRSPs and U.S. accounts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Shopify’s headquarters and spin-offs keep Ruby in demand, though Sarah may balance local work with remote contracts during hiring freezes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime remains low and neighborhoods feel safe; we mainly guard against car break-ins and downtown protests.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public, French immersion, and alternative programs let the family tailor education without leaving secular schools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Ottawa River temperatures reach 22 °C (72 °F) in July, letting the kids swim comfortably for a couple of months.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Winters are long and cold while summers turn humid, forcing the family to rotate between skating gear and robust air conditioning.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education and queer-inclusive spaces make it easier to live the family’s sex-positive values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, child benefits, and progressive labor laws deliver the social contract Trey and Sarah want while raising the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "April swings between 2 and 12 °C (36–54 °F) with lingering slush, so playground plans wait until late spring.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Political and economic stability is high, keeping immigration policies and social services predictable for the family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Canada blends market economics with social welfare, aligning with Trey’s preference for regulated capitalism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "The system favors regulated markets with SME supports, so Trey can pursue entrepreneurship without extreme inequality concerns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "July highs around 26 °C (79 °F) feel pleasant, with humid heat waves pushing us toward splash pads and shaded trails.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Express Entry fees are reasonable, but biometrics and medicals add time, so the family should budget 12-18 months for PR.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate-to-high trust in institutions, reinforcing the family’s desire for dependable governance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption surfaces as isolated patronage or procurement issues, which gives the family confidence they won’t need insider favors to access services.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers at Shopify, You.i TV, and government contractors earn 120k–160k CAD with pensions or stock, supporting a comfortable lifestyle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends mix museum visits, skating or biking along the Canal, and Gatineau hikes, giving the kids structured and outdoor options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools operate about 8:30–15:00, and many offices follow 8:30–4:30 schedules, leaving an hour buffer for after-school programs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Statutory leave is two weeks plus holidays, requiring Trey to negotiate extra time for U.S. family visits.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers often grant three to four weeks, which helps Sarah guard downtime but still trails European norms.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Canadians view the U.S. as a vital partner with cautious critiques, so the family can discuss politics openly without hostility.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Canadians embrace an inclusive, polite national identity, matching the family’s desire for collaborative communities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighboring countries generally see Canada as friendly and reliable, which helps Trey when pitching cross-border clients.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Express Entry, provincial nominations, and Start-up visas give the family multiple routes, though each demands meticulous documentation and proof of funds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Shared culture and existing American expats mean the family fits in quickly, though housing competition is stiff.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "A bilingual capital with generous public services, easy access to nature, and a calmer pace offers a balanced option for the family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "January often sits between −15 and −5 °C (5–23 °F), so we plan for heated garages, snow tires, and indoor play spaces.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Standard 40-hour expectations persist, with occasional crunch in tech; Trey and Sarah can guard evenings by negotiating boundaries.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Canadian employers respect boundaries more than U.S. counterparts, letting the family schedule dinners and bedtime routines even when tech projects peak.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong labor laws, paid leave, and union coverage support the family’s need for stability and predictable schedules.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/canada_toronto_report.json
+++ b/reports/canada_toronto_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "CA",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Toronto’s financial district, provincial ministries, and tech giants like Microsoft, Google, and RBC keep senior .NET roles abundant with competitive pay.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Daily AQI stays moderate, yet summer wildfire smoke and Gardiner Expressway traffic bring smog days that send us checking alerts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular norms dominate public life, letting the family raise the kids without religious pressure even though faith communities stay visible.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Canada’s institutions, courts, and media remain resilient, aligning with the family’s demand for a progressive, rights-protecting democracy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "The big-five banks, Interac, and wide contactless adoption make everyday payments smooth for the family, albeit with higher fees than U.S. online banks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Woodbine and Hanlan’s Point beaches earn Blue Flag status, but water temps and occasional E. coli advisories limit spontaneous swims.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Snakes & Lattes, The Board Room, and Toronto Board Game Design Guild events provide constant tabletop meetups and prototype nights.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Federal-provincial $10/day deals lower tuition, yet Sarah would still face waitlists and patchy infant care until the new spaces open.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Aquariums, museums, and neighbourhood family hubs abound, yet traffic and transit crowding require planning with strollers.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Once enrolled, CWELCC reductions and Ontario benefits significantly cut childcare costs for middle-income families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Work-permit holders access subsidies after securing SINs and tax files, but reimbursements often trail the first months of payments.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From professional sports and theatre to maker spaces and climbing gyms, the city offers hobbies for every family member year-round.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighborhood associations, multicultural festivals, and school councils create community, but we invest effort to break the big-city anonymity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Rules are strict but transparent, meaning the family must stay on top of filings yet benefits from clear guidance and digital portals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Toronto housing, daycare, and groceries stretch budgets—even six-figure tech salaries demand careful planning or commuting from outer suburbs.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Canada allows dual citizenship, letting Trey and Sarah retain U.S. passports while securing long-term Canadian rights for the kids.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "The economy is steady with low unemployment, yet commodity swings and high household debt encourage the family to keep a solid emergency fund.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A social-market mix funds healthcare and childcare while maintaining private enterprise, matching the family’s preference for progressive capitalism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "TDSB and TCDSB offer specialized STEM, arts, and French programs, though lotteries and waitlists mean applying early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Employers sponsor via LMIA or Global Talent Stream, but Trey would need standout credentials and patient timelines to secure a work permit.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Urban ravines, tree-planting programs, and lakefront parks balance the concrete, though construction dust and highway corridors remain unavoidable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Stacked federal and provincial brackets push combined rates near 35-40% on tech incomes, so Trey’s startup budget must include higher payroll taxes.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September and October sit around 10–18 °C (50–64 °F), giving comfortable weather for ravine hikes and street festivals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Family-focused policies, parental leave, and community programs support Sarah’s hunt for balance even if winter hibernation is real.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and dependent children can ride along on most residency streams, easing worries about keeping the household together.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens enjoy generous leave, universal healthcare, and indexed child benefits—exactly the safety net Sarah asked for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical families rely on paid leave and subsidized childcare, so Trey and Sarah would see peers modeling the balance they want.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Work-permit families qualify for many supports after meeting residency and contribution rules, so Trey and Sarah get a safety net once they clear province-specific requirements.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Urban centers lean toward practical minimalist layers—great for Sarah’s casual tech style, less exciting if she craves bold fashion.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men’s fashion centers on technical outerwear and smart-casual looks, so Trey blends in with jeans, flannels, and weather-ready jackets.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Gender expectations are flexible; mothers balance careers and family without heavy social penalty, aligning with Sarah’s goals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Ubisoft Toronto, Rockstar, Behaviour, and dozens of indie studios offer a wide ladder if Trey needs salaried stability.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition of non-binary markers and inclusive school policies make it easier to raise kids in the sex-positive environment the family values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal pay laws, reproductive rights, and parental leave are well protected, giving the household confidence their progressive values will be upheld.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are normal and dads take leave, matching Trey and Sarah’s expectation of shared parenting.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "The family must navigate SIN applications, provincial health wait periods, and auto insurance rules before feeling fully settled.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Urban heat islands, basement flooding, and Lake Ontario storms are increasing, so we favor mid-rise buildings with good drainage and AC.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "OHIP covers comprehensive care, but family doctors and pediatric specialists have queues, so we expect to rely on team-based clinics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Newcomers face Ontario’s three-month OHIP wait and must secure private coverage during the transition.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Domestic tuition plus RESP incentives keep university accessible for the boys, even if spots in top programs stay competitive.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International fees remain steep and aid is limited, so the family would budget extra if the kids enroll before citizenship.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Two-bedroom rentals easily top 3,200 CAD downtown, so we consider midtown condos, co-ops, or nearby municipalities like Mississauga for more space.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "CRA prefilled slips and online filing keep compliance manageable, yet the family will still hire cross-border tax help to reconcile U.S. obligations.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Free public schools with French immersion, STEM academies, and inclusive policies match the family’s education priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Dependent kids enroll as domestic students with ESL supports, letting the boys integrate quickly once paperwork clears.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English is dominant, with multilingual services readily available, so integration is immediate while the kids can add French or other languages through school.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Church-Wellesley Village, Pride Toronto, and inclusive city policies keep queer families visible and supported.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Left politics inform policy debates, yet mainstream parties stay centrist, so Trey’s curiosity about socialist experiments is met mostly in academia.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Canadian dads take leave and show-up in schools, giving Trey role models for engaged, emotionally open fatherhood.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech, gaming, and parenting meetups crowd Eventbrite in the big metros, helping the family build community quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Ontario’s 16.55 CAD minimum wage offers a floor, yet city housing costs still force service workers to share apartments or rely on subsidies.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber, reliable utilities, and modern transit projects keep cities functional, though rural broadband still lags Trey’s latency needs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Toronto Islands, High Park, and the Don Valley ravines offer natural escapes within minutes of downtown.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Toronto sees minimal earthquakes or hurricanes, but localized floods and ice storms still warrant renters insurance and emergency kits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "GO Transit and highways put Algonquin, Bruce Trail, and cottage country within a few hours for weekend trips.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Live music, theatre, and late-night food scenes span Queen West to Danforth, offering plenty of adult nights out when childcare is sorted.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "From speakeasies to queer dance nights, venues stay open late, though reservations help avoid crowds.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "DMG Toronto, TOJam, Hand Eye Society, and Gamma Space host jams, mentorship, and co-working tailored to diverse creators.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Rockstar Toronto, Ubisoft Toronto, Behaviour, Gameloft, DrinkBox, and Capybara Games anchor a thriving mix of AAA and indie teams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Ontario Creates credits, CMF programs, and investor interest make launching an indie studio feasible if we manage burn rate and rent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Downtown runs fast with long commutes and packed calendars, so we rely on intentional scheduling to protect Sarah’s downtime.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Parents juggle structured activities with free play; the family can choose hockey or coding clubs without judgment for charting a balanced path.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Three years of residency and language tests set a clear path to passports for the whole family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Canada highly, reassuring the family that public funds and services rarely suffer from graft.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A parliamentary democracy with strong courts and charter rights aligns with the family’s progressive expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Toronto Polyamory, Oasis Aqualounge workshops, and sex-positive communities offer frequent meetups and legal resources for non-monogamous households.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "CWELCC keeps fees trending toward $10/day, yet infant spots in downtown centres are scarce, prompting waitlists and nanny shares.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Independent schools offer IB and alternative curricula, but tuition is steep, so the family views them as optional backups rather than a must.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "City council leans progressive on housing, transit, and equity, aligning with the family’s politics despite occasional provincial clashes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government messaging leans on multicultural unity and national pride, but pluralistic media offer counterpoints the family appreciates.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters and private conglomerates dominate narratives, yet independent outlets stay accessible so the family can compare perspectives.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Subways, streetcars, and GO trains make car-free living viable, though signal issues and crowding require backup plans for school pickups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Faith groups rarely drive policy, supporting the secular governance the family wants for raising the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid policies are common, co-working spaces like Centre for Social Innovation thrive, and EST overlaps with U.S. teams simplify remote collaboration.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Express Entry, provincial nominee programs, and study-to-work paths offer multi-year permits, giving the family flexibility if one route stalls.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "CPP/QPP plus OAS provide a stable base, but the family would still build RRSP and TFSA savings to maintain U.S.-level comfort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Newcomers qualify for CPP after meeting residency years, so the household builds private savings knowing public pensions alone won’t mirror U.S. income levels.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Work permits grant access to CPP with contributions, but portability and benefits end if status lapses, prompting the family to maintain RRSPs and U.S. accounts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Rails teams at Shopify, Wave, and numerous agencies keep Ruby roles available, though competition is stiff.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime rates remain moderate, but we stay alert on late-night transit and guard against bike theft downtown.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public, French immersion, and alternative programs let the family tailor education without leaving secular schools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Lake Ontario hits roughly 20 °C (68 °F) in mid-summer, making dips refreshing but short-lived outside July and August.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Humid summers and slushy winters mean the family toggles between cooling, snow gear, and indoor play spaces.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education and queer-inclusive spaces make it easier to live the family’s sex-positive values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, child benefits, and progressive labor laws deliver the social contract Trey and Sarah want while raising the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "April ranges 5–15 °C (41–59 °F) with alternating rain and sunshine, so playground outings wait for drier afternoons.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Political and economic stability is high, keeping immigration policies and social services predictable for the family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Canada blends market economics with social welfare, aligning with Trey’s preference for regulated capitalism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "The system favors regulated markets with SME supports, so Trey can pursue entrepreneurship without extreme inequality concerns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "July highs average 27 °C (81 °F) with humidity; lake breezes help, but we plan midday breaks or pool time during heat warnings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Express Entry fees are reasonable, but biometrics and medicals add time, so the family should budget 12-18 months for PR.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate-to-high trust in institutions, reinforcing the family’s desire for dependable governance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption surfaces as isolated patronage or procurement issues, which gives the family confidence they won’t need insider favors to access services.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers at Shopify, Microsoft, and fintech unicorns command 150k–200k CAD plus stock, matching the high cost of living.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends feature festivals, sports events, Science Centre trips, and ferry rides to the Islands, keeping the kids engaged regardless of season.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools operate 8:45–15:15, while many offices run 9–5 with flexible hybrid days, giving space for after-school programs before dinner.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Statutory leave is two weeks plus holidays, requiring Trey to negotiate extra time for U.S. family visits.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers often grant three to four weeks, which helps Sarah guard downtime but still trails European norms.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Canadians view the U.S. as a vital partner with cautious critiques, so the family can discuss politics openly without hostility.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Canadians embrace an inclusive, polite national identity, matching the family’s desire for collaborative communities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighboring countries generally see Canada as friendly and reliable, which helps Trey when pitching cross-border clients.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Express Entry, provincial nominations, and Start-up visas give the family multiple routes, though each demands meticulous documentation and proof of funds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Shared culture and existing American expats mean the family fits in quickly, though housing competition is stiff.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "A globally connected city with deep multicultural communities, arts, and funding opportunities lets the family chase big ambitions.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winter hovers between −7 and 0 °C (19–32 °F) with frequent freeze-thaw cycles, requiring waterproof boots and patience with slush.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Standard 40-hour expectations persist, with occasional crunch in tech; Trey and Sarah can guard evenings by negotiating boundaries.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Canadian employers respect boundaries more than U.S. counterparts, letting the family schedule dinners and bedtime routines even when tech projects peak.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong labor laws, paid leave, and union coverage support the family’s need for stability and predictable schedules.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/canada_vancouver_report.json
+++ b/reports/canada_vancouver_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "CA",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Vancouver’s tech corridor—anchored by Microsoft, Amazon, SAP, and a dense startup scene in Gastown and Mount Pleasant—keeps senior .NET architects in demand, and Pacific time overlap lets Trey mix local contracts with West Coast U.S. clients.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Marine breezes normally keep PM2.5 near the teens, yet each late summer the family monitors wildfire smoke drifting down the Fraser Valley before planning playground time.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular norms dominate public life, letting the family raise the kids without religious pressure even though faith communities stay visible.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Canada’s institutions, courts, and media remain resilient, aligning with the family’s demand for a progressive, rights-protecting democracy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "The big-five banks, Interac, and wide contactless adoption make everyday payments smooth for the family, albeit with higher fees than U.S. online banks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Kitsilano, Jericho, and Spanish Banks are spotless and transit-accessible, yet chilly Pacific water and occasional E. coli advisories keep swims short.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Stores like Rain City Games, Dicey Business, and Vancouver’s D&D Adventurers League keep English-friendly tables open for campaigns and prototype nights.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Federal-provincial $10/day deals lower tuition, yet Sarah would still face waitlists and patchy infant care until the new spaces open.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Strong community-center programming, seawall cycling, and the Playland/Science World combo give the kids abundant options despite long rainy spells.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Once enrolled, provincial fee reductions and Canada Child Benefit top-ups keep monthly costs reasonable for middle-income families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Work-permit holders with SINs qualify for subsidies, but verifying residency and tax status can delay reimbursements in the first year.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Climbing gyms, mountain biking, and board-game cafés are plentiful, giving Trey and Sarah four-season outlets even when weather keeps everyone indoors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors are polite but the “Vancouver freeze” is real, so we plan to build friendships through school councils, climbing gyms, and gaming meetups.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Rules are strict but transparent, meaning the family must stay on top of filings yet benefits from clear guidance and digital portals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Metro Vancouver’s rents, daycare fees, and grocery prices consistently rank among Canada’s highest, so even with tech incomes we model budgets carefully before committing to leases.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Canada allows dual citizenship, letting Trey and Sarah retain U.S. passports while securing long-term Canadian rights for the kids.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "The economy is steady with low unemployment, yet commodity swings and high household debt encourage the family to keep a solid emergency fund.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A social-market mix funds healthcare and childcare while maintaining private enterprise, matching the family’s preference for progressive capitalism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Vancouver School Board offers robust French immersion and STEM mini-schools, though we may need to lottery in early for the best programs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Employers sponsor via LMIA or Global Talent Stream, but Trey would need standout credentials and patient timelines to secure a work permit.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Urban tree canopies, seawall greenways, and aggressive waste-diversion targets make day-to-day life feel clean, with only port traffic and construction dust creating occasional hotspots.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Stacked federal and provincial brackets push combined rates near 35-40% on tech incomes, so Trey’s startup budget must include higher payroll taxes.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September stays pleasant around 12–18 °C (54–64 °F), but by late October Pacific storms bring long wet weeks that push weekend plans indoors.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Family-focused policies, parental leave, and community programs support Sarah’s hunt for balance even if winter hibernation is real.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and dependent children can ride along on most residency streams, easing worries about keeping the household together.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens enjoy generous leave, universal healthcare, and indexed child benefits—exactly the safety net Sarah asked for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical families rely on paid leave and subsidized childcare, so Trey and Sarah would see peers modeling the balance they want.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Work-permit families qualify for many supports after meeting residency and contribution rules, so Trey and Sarah get a safety net once they clear province-specific requirements.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Urban centers lean toward practical minimalist layers—great for Sarah’s casual tech style, less exciting if she craves bold fashion.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men’s fashion centers on technical outerwear and smart-casual looks, so Trey blends in with jeans, flannels, and weather-ready jackets.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Gender expectations are flexible; mothers balance careers and family without heavy social penalty, aligning with Sarah’s goals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "EA Vancouver, The Coalition, Relic, Blackbird Interactive, and a deep mobile sector create a steady ladder of roles if Trey needs salaried stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition of non-binary markers and inclusive school policies make it easier to raise kids in the sex-positive environment the family values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal pay laws, reproductive rights, and parental leave are well protected, giving the household confidence their progressive values will be upheld.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are normal and dads take leave, matching Trey and Sarah’s expectation of shared parenting.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "The family must navigate SIN applications, provincial health wait periods, and auto insurance rules before feeling fully settled.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Sea-level rise projections for False Creek and more frequent wildfire smoke give the family equal parts manageable and disruptive risk, pushing us to favor higher-elevation neighborhoods and renter’s insurance.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "B.C.’s MSP covers hospital and pediatric care, yet family doctors are scarce, so we expect to rely on nurse practitioners and urgent-care clinics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Newcomers face a three-month MSP wait and must show work permits, so we budget for interim private insurance while filing paperwork.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Domestic tuition plus RESP incentives keep university accessible for the boys, even if spots in top programs stay competitive.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International fees remain steep and aid is limited, so the family would budget extra if the kids enroll before citizenship.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family-friendly rentals under 3,000 CAD are scarce, pushing us toward Burnaby or New Westminster condos unless we secure co-op housing.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "CRA prefilled slips and online filing keep compliance manageable, yet the family will still hire cross-border tax help to reconcile U.S. obligations.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Free public schools with French immersion, STEM academies, and inclusive policies match the family’s education priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Dependent kids enroll as domestic students with ESL supports, letting the boys integrate quickly once paperwork clears.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominates civic life, with Cantonese and Mandarin prevalent in services—handy for multicultural exposure without language barriers.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Davie Village, trans-inclusive healthcare, and Pride’s citywide support signal that queer and poly-friendly values are openly embraced.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Left politics inform policy debates, yet mainstream parties stay centrist, so Trey’s curiosity about socialist experiments is met mostly in academia.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Canadian dads take leave and show-up in schools, giving Trey role models for engaged, emotionally open fatherhood.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech, gaming, and parenting meetups crowd Eventbrite in the big metros, helping the family build community quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "B.C.’s 17.40 CAD minimum wage climbs annually with inflation, yet housing costs outpace it, so entry-level earners still need roommates or supplements.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber, reliable utilities, and modern transit projects keep cities functional, though rural broadband still lags Trey’s latency needs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Snow-capped Coast Mountains, Stanley Park’s old-growth remnants, and ferry access to the Gulf Islands put bucket-list scenery within an hour of home.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Daily life is calm, yet Cascadia megathrust planning, atmospheric river floods, and landslide-prone North Shore slopes mean we maintain earthquake kits and renters insurance.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "SkyTrain and SeaBus rides lead straight to Lynn Canyon, Grouse Mountain, and the North Shore trails, letting Trey and Sarah slot hikes into regular weekends.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "A midsized live-music circuit—from the Commodore Ballroom to Fortune Sound—offers variety, but liquor curfews and zoning caps make late nights quieter than Seattle.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Craft breweries and cocktail lounges anchor evening plans, yet few venues run past 1 a.m., suiting parents who prefer earlier wrap-ups.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "DigiBC, Vancouver Game Dev, and events at Vancouver Film School host monthly mixers, jams, and mentorship nights that welcome newcomers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "From EA’s Burnaby campus to indie standouts like Klei, East Side Games, and Hinterland, Vancouver packs AAA and boutique studios within a 30-minute commute.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Creative BC tax credits, Canada Media Fund, and access to veteran talent make studio launches feasible, though high burn rates demand disciplined budgeting.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Downtown runs at a big-city tempo, but neighborhood high streets and easy access to beaches create natural pauses that help Sarah downshift.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Parents juggle structured activities with free play; the family can choose hockey or coding clubs without judgment for charting a balanced path.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Three years of residency and language tests set a clear path to passports for the whole family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Canada highly, reassuring the family that public funds and services rarely suffer from graft.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A parliamentary democracy with strong courts and charter rights aligns with the family’s progressive expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Polyamory-friendly meetups, legal aid workshops, and inclusive housing co-ops make it socially safe to be out, even if legal structures remain monogamy-centric.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "$10-a-Day conversions are rolling out, but waitlists in Kitsilano and East Van stretch 12–18 months, so we join co-op daycares early.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Independent schools offer IB and alternative curricula, but tuition is steep, so the family views them as optional backups rather than a must.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "City Hall leans left on housing, climate, and harm reduction, aligning with the family’s progressive politics despite occasional provincial pushback.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government messaging leans on multicultural unity and national pride, but pluralistic media offer counterpoints the family appreciates.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters and private conglomerates dominate narratives, yet independent outlets stay accessible so the family can compare perspectives.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "SkyTrain, RapidBus, and the SeaBus keep the core car-optional, yet coverage thins east of Coquitlam and late-night service is limited for parents heading home from events.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Faith groups rarely drive policy, supporting the secular governance the family wants for raising the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Co-working hubs like WeWork Marine Gateway and L’Atelier plus PST overlap with Seattle and California make hybrid schedules normal in tech.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Express Entry, provincial nominee programs, and study-to-work paths offer multi-year permits, giving the family flexibility if one route stalls.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "CPP/QPP plus OAS provide a stable base, but the family would still build RRSP and TFSA savings to maintain U.S.-level comfort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Newcomers qualify for CPP after meeting residency years, so the household builds private savings knowing public pensions alone won’t mirror U.S. income levels.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Work permits grant access to CPP with contributions, but portability and benefits end if status lapses, prompting the family to maintain RRSPs and U.S. accounts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Rails shops like Clio, Later, and Bench keep a steady trickle of roles, but Sarah may supplement with remote U.S. clients when local openings slow.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime stays low, but property theft and visible opioid crises downtown mean we stay alert around the Granville and East Hastings corridors.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public, French immersion, and alternative programs let the family tailor education without leaving secular schools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Summer sea temperatures peak around 17 °C (63 °F), which is swimmable only with brief dips or wetsuits, so full beach days revolve around sand play.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Mild temperatures line up with Sarah’s preferences, but months of cold rain from November through March have us stockpiling waterproof gear and backup indoor plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education and queer-inclusive spaces make it easier to live the family’s sex-positive values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, child benefits, and progressive labor laws deliver the social contract Trey and Sarah want while raising the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March and April hover around 6–14 °C (43–57 °F) with steady drizzle, so playground days alternate with Science World and community centers until May dries out.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Political and economic stability is high, keeping immigration policies and social services predictable for the family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Canada blends market economics with social welfare, aligning with Trey’s preference for regulated capitalism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "The system favors regulated markets with SME supports, so Trey can pursue entrepreneurship without extreme inequality concerns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Typical July highs sit near 22–24 °C (72–75 °F) with low humidity, letting the kids bike the seawall, while brief heat domes require shaded parks and portable AC.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Express Entry fees are reasonable, but biometrics and medicals add time, so the family should budget 12-18 months for PR.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate-to-high trust in institutions, reinforcing the family’s desire for dependable governance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption surfaces as isolated patronage or procurement issues, which gives the family confidence they won’t need insider favors to access services.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers pull 140k–170k CAD plus stock at Amazon, Microsoft, and local unicorns, supporting a middle-class lifestyle if we rein in housing spend.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends lean into Grouse gondola hikes, Granville Island markets, and rainy-day museum passes, keeping the kids engaged year-round.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools operate roughly 8:55–3:00, and tech teams often start 9:30 to sync with Toronto or Seattle, giving us time for school drop-off before stand-up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Statutory leave is two weeks plus holidays, requiring Trey to negotiate extra time for U.S. family visits.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers often grant three to four weeks, which helps Sarah guard downtime but still trails European norms.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Canadians view the U.S. as a vital partner with cautious critiques, so the family can discuss politics openly without hostility.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Canadians embrace an inclusive, polite national identity, matching the family’s desire for collaborative communities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighboring countries generally see Canada as friendly and reliable, which helps Trey when pitching cross-border clients.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Express Entry, provincial nominations, and Start-up visas give the family multiple routes, though each demands meticulous documentation and proof of funds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Shared culture and existing American expats mean the family fits in quickly, though housing competition is stiff.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "The blend of seawall cycling, mountain vistas, and progressive civic culture gives the family a rare mix of adventure and shared values.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters hover near 1–7 °C (34–45 °F) with damp chill and occasional snowfall that freezes streets, so we budget for rain gear more than heavy parkas.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Standard 40-hour expectations persist, with occasional crunch in tech; Trey and Sarah can guard evenings by negotiating boundaries.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Canadian employers respect boundaries more than U.S. counterparts, letting the family schedule dinners and bedtime routines even when tech projects peak.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong labor laws, paid leave, and union coverage support the family’s need for stability and predictable schedules.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/canada_victoria_report.json
+++ b/reports/canada_victoria_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "CA",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Victoria’s market leans on B.C. public service digital teams, fintech scale-ups like Beanworks, and a growing remote cohort, so senior .NET roles exist but require patience or hybrid with Vancouver employers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Island breezes keep daily AQI low, yet wildfire smoke from Vancouver Island and the Interior can settle for a week or two each summer, nudging us indoors.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular norms dominate public life, letting the family raise the kids without religious pressure even though faith communities stay visible.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Canada’s institutions, courts, and media remain resilient, aligning with the family’s demand for a progressive, rights-protecting democracy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "The big-five banks, Interac, and wide contactless adoption make everyday payments smooth for the family, albeit with higher fees than U.S. online banks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Willows Beach and Gonzales Bay offer clean sand and calm water, though summer swims are short thanks to 15–17 °C temperatures and the occasional jellyfish advisory.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Yellowjacket Comics, Curious Comics, and the Victoria Board Game Café host leagues and open tables, though events are smaller than Vancouver’s.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Federal-provincial $10/day deals lower tuition, yet Sarah would still face waitlists and patchy infant care until the new spaces open.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Free museums for kids, Beacon Hill petting zoo, and abundant playgrounds make the city easy for young families despite limited indoor play on rainy days.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Once placed, provincial fee reductions and Canada Child Benefit payments meaningfully offset costs for middle-income families.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Work-permit holders can access subsidies after securing SINs and tax filings, though reimbursements may lag a few months.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Kayaking, sailing lessons, cycling, and tabletop nights at local cafés give both adults plenty of ways to plug into community year-round.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Victoria’s neighborhood associations and school PACs are active, and locals welcome newcomers once we show up consistently at community events.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Rules are strict but transparent, meaning the family must stay on top of filings yet benefits from clear guidance and digital portals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Rents run 10–15% below Vancouver but still sting—three-bedroom units routinely hit 2,600–3,000 CAD—so we budget carefully before selling the Kansas City home.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Canada allows dual citizenship, letting Trey and Sarah retain U.S. passports while securing long-term Canadian rights for the kids.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "The economy is steady with low unemployment, yet commodity swings and high household debt encourage the family to keep a solid emergency fund.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A social-market mix funds healthcare and childcare while maintaining private enterprise, matching the family’s preference for progressive capitalism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "School District 61 offers French immersion and nature-based programs, yet specialized STEM tracks are fewer than on the mainland, so we apply early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Employers sponsor via LMIA or Global Talent Stream, but Trey would need standout credentials and patient timelines to secure a work permit.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "The city invests in urban forests, composting, and bike infrastructure, giving the family clean air and walkable neighborhoods with only minor port emissions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Stacked federal and provincial brackets push combined rates near 35-40% on tech incomes, so Trey’s startup budget must include higher payroll taxes.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September feels like late summer at 12–18 °C (54–64 °F), with rain picking up in November but rarely delivering storms intense enough to cancel plans.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Family-focused policies, parental leave, and community programs support Sarah’s hunt for balance even if winter hibernation is real.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and dependent children can ride along on most residency streams, easing worries about keeping the household together.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens enjoy generous leave, universal healthcare, and indexed child benefits—exactly the safety net Sarah asked for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical families rely on paid leave and subsidized childcare, so Trey and Sarah would see peers modeling the balance they want.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Work-permit families qualify for many supports after meeting residency and contribution rules, so Trey and Sarah get a safety net once they clear province-specific requirements.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Urban centers lean toward practical minimalist layers—great for Sarah’s casual tech style, less exciting if she craves bold fashion.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men’s fashion centers on technical outerwear and smart-casual looks, so Trey blends in with jeans, flannels, and weather-ready jackets.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Gender expectations are flexible; mothers balance careers and family without heavy social penalty, aligning with Sarah’s goals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios such as Studio MDHR’s satellite team, Kano, and small VR outfits offer roles, but most AAA work sits across the Strait, so Trey keeps remote options alive.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition of non-binary markers and inclusive school policies make it easier to raise kids in the sex-positive environment the family values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal pay laws, reproductive rights, and parental leave are well protected, giving the household confidence their progressive values will be upheld.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are normal and dads take leave, matching Trey and Sarah’s expectation of shared parenting.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "The family must navigate SIN applications, provincial health wait periods, and auto insurance rules before feeling fully settled.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Sea-level rise threatens the Inner Harbour and Esquimalt shoreline, while drought stress and wildfire smoke are growing concerns, so we plan for flood-ready rentals and air purifiers.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "MSP covers essentials, but family doctors are in short supply; we expect to rely on walk-in clinics or nurse practitioners until rostered.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "The three-month MSP waiting period applies and paperwork must be mailed, so we budget for private insurance when first landing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Domestic tuition plus RESP incentives keep university accessible for the boys, even if spots in top programs stay competitive.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International fees remain steep and aid is limited, so the family would budget extra if the kids enroll before citizenship.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Limited new construction and high demand from retirees mean few large rentals; we may target Saanich duplexes or Langford townhomes for space.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "CRA prefilled slips and online filing keep compliance manageable, yet the family will still hire cross-border tax help to reconcile U.S. obligations.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Free public schools with French immersion, STEM academies, and inclusive policies match the family’s education priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Dependent kids enroll as domestic students with ESL supports, letting the boys integrate quickly once paperwork clears.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominates, signage is monolingual, and any French exposure is optional, letting the family integrate immediately.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Capital Pride events, inclusive schools, and visible queer-owned businesses keep the social climate welcoming even in a smaller city.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Left politics inform policy debates, yet mainstream parties stay centrist, so Trey’s curiosity about socialist experiments is met mostly in academia.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Canadian dads take leave and show-up in schools, giving Trey role models for engaged, emotionally open fatherhood.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech, gaming, and parenting meetups crowd Eventbrite in the big metros, helping the family build community quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "B.C.’s 17.40 CAD minimum wage applies, but high island costs mean service workers still juggle roommates or multiple gigs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber, reliable utilities, and modern transit projects keep cities functional, though rural broadband still lags Trey’s latency needs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Coastal bluffs, Garry oak meadows, and easy ferry hops to the Gulf Islands put postcard scenery within reach of an after-school outing.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Like the rest of coastal B.C., Cascadia quake planning is serious; tsunami routes and storm surge maps become part of our relocation prep.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Galloping Goose Trail, Goldstream Provincial Park, and daily whale-watching departures make nature immersion effortless without a car.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Live music and pubs cluster around Wharf and Government Streets, but venues wind down early, suiting parents who prefer quiet nights.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Craft breweries and cideries dominate, with few late-night options beyond weekends, so socializing leans toward house gatherings.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "VIATEC, Victoria Game Makers, and OrcaJam provide mentorship, co-working, and annual jams tailored to indie and remote devs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Kano, Codename Entertainment, and indie outfits clustered at Fort Tectoria anchor the local scene, with EA and The Coalition only a ferry ride away.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "VIATEC’s accelerator, Creative BC credits, and Canada Media Fund grants help bootstrap studios, but limited local venture capital means we plan for lean operations.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Government schedules and island culture keep evenings quiet, giving Sarah the slower rhythm she craves while still offering urban amenities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Parents juggle structured activities with free play; the family can choose hockey or coding clubs without judgment for charting a balanced path.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Three years of residency and language tests set a clear path to passports for the whole family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Canada highly, reassuring the family that public funds and services rarely suffer from graft.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A parliamentary democracy with strong courts and charter rights aligns with the family’s progressive expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Groups like Victoria Polyamory and consent-focused community centers host regular meetups, though circles are tight-knit and benefit from active participation.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "$10-a-Day spaces are expanding, yet infant care waitlists can exceed 18 months; we plan for part-time nannies or co-op care initially.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Independent schools offer IB and alternative curricula, but tuition is steep, so the family views them as optional backups rather than a must.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Municipal politics emphasize climate action and reconciliation, aligning with the family’s values even if provincial debates sometimes slow reforms.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government messaging leans on multicultural unity and national pride, but pluralistic media offer counterpoints the family appreciates.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters and private conglomerates dominate narratives, yet independent outlets stay accessible so the family can compare perspectives.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "BC Transit buses serve the core reliably, yet suburban routes thin out after 10 p.m., so we likely keep one car for family logistics.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Faith groups rarely drive policy, supporting the secular governance the family wants for raising the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Co-working hubs like KWENCH and Club KW3 host remote tech teams, and Pacific time lets Trey collaborate with Seattle or Bay Area partners without brutal hours.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Express Entry, provincial nominee programs, and study-to-work paths offer multi-year permits, giving the family flexibility if one route stalls.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "CPP/QPP plus OAS provide a stable base, but the family would still build RRSP and TFSA savings to maintain U.S.-level comfort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Newcomers qualify for CPP after meeting residency years, so the household builds private savings knowing public pensions alone won’t mirror U.S. income levels.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Work permits grant access to CPP with contributions, but portability and benefits end if status lapses, prompting the family to maintain RRSPs and U.S. accounts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Rails teams exist at firms like Checkfront and tiny consultancies, yet openings are sporadic, encouraging Sarah to cultivate remote clients.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime is rare, but downtown has visible homelessness and property theft, so we stay mindful around the Inner Harbour at night.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public, French immersion, and alternative programs let the family tailor education without leaving secular schools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Even in August, Strait of Juan de Fuca waters rarely top 17 °C (63 °F), so wetsuits or quick dips are the norm for the kids.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Victoria delivers cool, mostly dry summers and shoulder seasons that are rainy but not punishing, matching the family’s mild-climate goals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education and queer-inclusive spaces make it easier to live the family’s sex-positive values.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, child benefits, and progressive labor laws deliver the social contract Trey and Sarah want while raising the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March and April range roughly 5–13 °C (41–55 °F) with intermittent drizzle, so outdoor play is feasible with layers and rubber boots.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Political and economic stability is high, keeping immigration policies and social services predictable for the family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Canada blends market economics with social welfare, aligning with Trey’s preference for regulated capitalism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "The system favors regulated markets with SME supports, so Trey can pursue entrepreneurship without extreme inequality concerns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summer highs hover near 22 °C (72 °F) with low humidity, creating perfect biking and beach weather aside from the odd heat dome.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Express Entry fees are reasonable, but biometrics and medicals add time, so the family should budget 12-18 months for PR.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate-to-high trust in institutions, reinforcing the family’s desire for dependable governance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption surfaces as isolated patronage or procurement issues, which gives the family confidence they won’t need insider favors to access services.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers at local SaaS firms earn roughly 110k–140k CAD, so Trey may mix government contracts with remote U.S. work to match Vancouver pay.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends revolve around farmers markets, island hikes, beachcombing, and ferry day trips, keeping the kids entertained without long drives.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run roughly 8:45–2:45, and public servants clock 8:30–4:30, so we can coordinate drop-offs with Trey’s remote stand-ups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Statutory leave is two weeks plus holidays, requiring Trey to negotiate extra time for U.S. family visits.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers often grant three to four weeks, which helps Sarah guard downtime but still trails European norms.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Canadians view the U.S. as a vital partner with cautious critiques, so the family can discuss politics openly without hostility.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Canadians embrace an inclusive, polite national identity, matching the family’s desire for collaborative communities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighboring countries generally see Canada as friendly and reliable, which helps Trey when pitching cross-border clients.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Express Entry, provincial nominations, and Start-up visas give the family multiple routes, though each demands meticulous documentation and proof of funds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Shared culture and existing American expats mean the family fits in quickly, though housing competition is stiff.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "An island capital with mild weather, ferry adventures, and tight-knit creative circles offers the family a gentler landing pad than mainland metros.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters settle around 1–8 °C (34–46 °F) with light snow only a few days a year, keeping commutes manageable even if the damp chill requires dehumidifiers.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Standard 40-hour expectations persist, with occasional crunch in tech; Trey and Sarah can guard evenings by negotiating boundaries.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Canadian employers respect boundaries more than U.S. counterparts, letting the family schedule dinners and bedtime routines even when tech projects peak.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong labor laws, paid leave, and union coverage support the family’s need for stability and predictable schedules.",
+      "alignmentValue": 8
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add tailored migration reports for Vancouver, Victoria, Montreal, Ottawa, and Toronto with city-specific climate, cost, childcare, and tech ecosystem insights
- register the new city reports under Canada in the main catalog so they appear alongside the national profile

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e33a85f1e08321be0fe6539ff60abd