### PR TITLE
Add city reports for Nantes, Lyon, and Bordeaux

### DIFF
--- a/main.json
+++ b/main.json
@@ -546,7 +546,21 @@
     },
     {
       "name": "France",
-      "file": "reports/france_report.json"
+      "file": "reports/france_report.json",
+      "cities": [
+        {
+          "name": "Nantes",
+          "file": "reports/france_nantes_report.json"
+        },
+        {
+          "name": "Lyon",
+          "file": "reports/france_lyon_report.json"
+        },
+        {
+          "name": "Bordeaux",
+          "file": "reports/france_bordeaux_report.json"
+        }
+      ]
     },
     {
       "name": "Germany",

--- a/reports/france_bordeaux_report.json
+++ b/reports/france_bordeaux_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "FR",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Bordeaux’s Mérignac aeronautics hub and fintech firms like CDiscount run .NET microservices, and remote roles tied to Paris scale-ups let Trey stay in the Gironde while collaborating with larger teams.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Atlantic winds usually hold PM2.5 near 12 µg/m³, yet harvest season dust and ring-road traffic trigger occasional NO₂ alerts, so the family keeps air purifiers handy.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "High secularism with religion largely private.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Courts, media, and frequent protests keep checks on executive power; even with emergency powers during crises, institutions remain resilient.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "SEPA transfers clear quickly, contactless cards and Apple Pay are ubiquitous, and online banks like Boursorama ease setup once residency documents are ready.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Atlantic beaches like Biarritz and Mediterranean spots near Nice offer lifeguarded sands, though peak tourist season brings crowds and higher prices.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Cafés such as Le Labo du Jeu, the Animasia festival, and wine-country geek collectives foster steady tabletop meetups for Trey.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidized childcare and parental benefits available.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Urban areas offer parks, museums, and family services.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "CAF benefits (PAJE, CMG), free école maternelle from age 3, and generous parental leave let working parents line up structured care without crushing costs—ideal for Sarah’s search for predictable coverage.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Long-stay visa holders who pay into social security can access CAF reimbursements, though paperwork in French and processing delays mean expat families should budget bridging funds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Locals cherish café culture, hiking in the Alps or Pyrenees, and neighborhood sports clubs, offering easy ways for Trey and Sarah to plug into community life.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors may seem reserved at first, yet school parent groups, sports clubs, and local associations open doors once the family shows steady participation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Visa holders must maintain French tax residence, update prefecture records, and keep health insurance active; missed renewals can trigger exit orders.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Plan for €3,000–€3,400 a month: renovated stone townhouses rent around €1,600, and tourism-influenced prices make dining out pricier than Nantes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes—dual nationality is allowed.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "France’s €3 trillion economy posts unemployment near 7% and moderate 1–2% growth, offering diversified job markets even during EU downturns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Mixed economy with significant state role.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "High literacy and strong universities though competitive exams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Airbus, Dassault, and Thales sponsor engineers regularly, while scale-ups in the French Tech Bordeaux network occasionally back Tech Visa hires—smaller wineries seldom do.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "From the Alps to Atlantic dunes, France maintains vast protected areas and clean water standards, giving the family easy escapes to nature close to major cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "High earners face marginal income taxes up to 45% plus ~25% social contributions; with France’s family quotient the effective rate still lands in the low 40s, higher than the family pays today.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn stays gentle, from 24 °C (75 °F) in September to 13 °C (55 °F) by November with light rain, perfect for vineyard hikes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Weekend markets, public parks, and subsidized sports clubs keep families active, and employers expect parents to take school holidays seriously—great for balancing Trey’s work with kid time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Long-stay visas allow spouses to work once OFII paperwork is cleared, and children access public schools and healthcare on par with locals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens tap 16+ weeks paid parental leave, monthly CAF allowances, and tax splitting via the family quotient, all of which underpin generous time with young kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical families rely on state-run childcare, employer meal vouchers, and long school vacations; coordinating all the paperwork takes effort but pays off.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Once the family contributes to Sécurité sociale they can apply for CAF benefits, though proving income and residency history can delay payouts for new arrivals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Minimalist to chic; dresses/knits/trousers with layers; strong fashion/beauty culture.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart‑casual tailoring, minimalist chic, quality sneakers/boots; weather‑appropriate outerwear.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Fashion-conscious culture with broad expressions allowed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Ubisoft, Dontnod, and Amplitude hire engineers regularly, and remote collaboration with EU teams is common, giving Trey steady options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition for gender marker changes exists, yet everyday acceptance varies outside major cities, so queer and trans communities concentrate in urban areas.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Anti-discrimination laws, reproductive rights, and generous parental leave policies align with the family’s equity expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are common and men take more parental leave, though household labor still skews female compared with Nordic norms.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Expect ANEF online submissions, in-person OFII visits, French-language leases, and notarized translations; hiring a relocation attorney eases the learning curve.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "France already faces deadly canicules, drought-stressed rivers, and Atlantic storm surge planning, so the family should expect periodic climate disruptions but benefits from strong adaptation funding.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "France’s universal Sécurité sociale system covers GP visits, maternity care, and prescriptions with low co-pays, delivering reliable care for families.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "After three months of residence the family can enroll in PUMA for public coverage, with supplemental mutuelle plans filling gaps for faster specialist access.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Public universities charge a few hundred euros per year, with prestigious CPGE tracks feeding grandes écoles and CROUS housing keeping living costs manageable for future college-aged kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students pay a few thousand euros annually unless they secure waivers; scholarships and residency status can bring fees closer to citizen rates over time.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Stone row houses in Chartrons or Caudéran command €1,500–€1,700 and require guarantors, while new builds in Euratlantique ease supply—still more affordable than Paris but rising fast.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "France uses pay-as-you-earn withholding plus a streamlined online declaration; expect forms only in French, so hiring an accountant the first year helps.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens enjoy free, secular schools with strong math/language curricula, and larger cities offer international sections that could give Anduin bilingual exposure.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children enroll easily once they show address, vaccination, and birth certificates; specialized French-as-a-second-language support helps new arrivals acclimate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Tourism and wine trade bring more English speakers, yet administrative offices remain French-first, so daily life still leans on the family’s language learning.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Legal protections and growing social acceptance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist traditions influence politics but market economy prevails.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Work-life balance and emotional expression encouraged.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "French Tech Bordeaux, queer collective Le Girofard, and active parenting forums create a friendly landing pad once the family joins local associations.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The SMIC sits near €1,766 gross per month in 2024, supporting local hires better than many EU peers but still tight for big-city rent if we rely solely on one salary.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "High-speed TGV lines, nationwide fiber rollout, and reliable utilities keep daily logistics smooth for tech professionals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "From Loire Valley châteaux to the Alps and lavender fields in Provence, weekend getaways deliver diverse scenery for the family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "River flooding, Atlantic windstorms, and the odd Mediterranean wildfire appear regularly, so insurance and alerts are important but manageable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Regional trains reach hiking trails, vineyards, and coasts within a few hours, making spontaneous nature trips realistic without a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Le Rocher de Palmer, La Rock School Barbey, and riverside guinguettes deliver live music, with trams running late on key lines for easy date nights.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Weekends buzz around Place de la Victoire and Bassins à Flot, while suburban districts quiet early; safety stays manageable with standard precautions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Bordeaux Games and the Bordeaux Geek Festival convene studios and students, keeping the indie scene collaborative and visible.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Asobo Studio, Ubisoft Bordeaux, and Motion Twin headline a dense talent pool alongside indies like Shiro Games—ideal partners for Trey’s projects.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Tax credits (CIJV), CNC grants, and Ubisoft’s entrepreneur labs support indie studios, making France a strong launchpad if Trey builds a local team.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Tram commutes under 35 minutes, long lunches, and a strong café culture balance productive weeks with relaxed evenings by the Garonne.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools emphasize academics and respect for teachers, with manageable extracurricular commitments compared to US over-scheduling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "After five years of residence (or three if married to a citizen), applicants need B1 French and a civics interview; dual citizenship is allowed so the family can retain US passports.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "France scores well on Transparency International indices, though periodic political finance scandals remind us to watch procurement processes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A semi-presidential system with proportional parliamentary elections keeps multiple parties in play and encourages civic engagement.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Polyamory lacks legal recognition and is primarily embraced within urban queer networks, so openness requires discretion outside big cities.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "École maternelle is free and near-universal from age 3, while crèche spots and licensed nannies receive CAF subsidies—Trey and Sarah just need to join waitlists early in dense arrondissements.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Sous contrat schools cost a few hundred euros per year, while international campuses run €12–€20k and require early applications—important if the family wants English-heavy curricula.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "France legalised marriage equality and maintains robust secular policies, yet debates over laïcité and policing show tensions—urban areas feel progressive overall for the family.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government campaigns emphasize republican values, anti-extremism, and climate action—messages the family may appreciate even if they can feel frequent after major protests.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters operate independently and investigative journalism is robust, though government messaging spikes during security incidents.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Tram lines A–D, dedicated bike lanes, and TER links cover daily mobility; peak-hour crowding and early shutdowns on some routes mean occasional planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Strict secularism keeps religion separate from state.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid schedules became standard in tech and many government roles post-pandemic, though fully remote contracts may still require occasional on-site weeks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Multi-year Talent Passports renew in four-year blocks, and after five years of residence the family can seek 10-year cartes de résident if they maintain income and integration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "France’s pay-as-you-go system now targets retirement around age 64; benefits cover basics but assume homeowners supplement with savings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants earning in France accrue the same pension rights once they pay into Sécurité sociale, yet navigating credited quarters and bilateral treaties can be complex.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "US–France totalization lets long-term residents combine contributions, but the family would still rely on private savings given modest state payouts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Shiro Games, CDiscount, and health-tech startups use Rails, and remote-first Paris companies recruit in Bordeaux, though roles remain fewer than .NET openings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Bordeaux centers feel secure, yet nightlife hubs see pickpockets and scooter theft; vigilance around tram hubs keeps risks low for the kids.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public schools perform well, with International School of Bordeaux and Montessori options covering bilingual education when needed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Mediterranean waters warm to 24–26 °C (75–79 °F) by July, while Atlantic coasts stay closer to 19–21 °C, giving the family options depending on comfort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Winters hover around 8 °C (46 °F) with drizzle, summers reach 28 °C (82 °F) and occasional 38 °C (100 °F) heatwaves, so shade and shutters help manage spikes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Sex education is comprehensive and public conversation around relationships is open, though polyamory remains niche outside major cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, extensive family benefits, and strong LGBTQ protections align with the family’s progressive values, even if bureaucracy can feel heavy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "April–May highs climb to 20 °C (68 °F) with crisp mornings near 8 °C (46 °F), inviting park time before the tourist rush.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Frequent strikes and protests create noise, yet NATO/EU membership and predictable institutions keep the long-term outlook steady.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "France blends dirigiste economic planning with social welfare, funding public services while courting strategic industries.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Heavy regulation and worker protections coexist with vibrant private enterprise, offering stability at the cost of some bureaucracy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Typical highs sit at 27–29 °C (81–84 °F), but late July canicules push past 35 °C (95 °F) for several days, making fans and shutters essential.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Consular appointments and OFII validation often stretch 2–4 months, with fees of €200–€450 per adult plus translation costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Eurobarometer surveys show trust hovering near 35%, with protests expressing frustration but not eroding core institutions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption tends to surface in campaign financing or public procurement rather than day-to-day bribery, so diligence on contracts is enough.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers earn €55k–€65k with bonuses; cost of living is lower than Paris yet rising, so negotiating relocation packages matters.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Family meals, markets, parks, sports; many shops open Sat, limited Sun opening outside big cities; cultural outings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Primary ~08:30–16:30 (long lunch); Wed often half-day; offices ~09:00–18:00; after‑school care (garderie/études) common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Five weeks statutory leave plus public holidays.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Many offices close in August offering extended breaks.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Relations with Germany and Spain are pragmatic and cooperative, while historic rivalries show up mostly in sports banter.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "French identity emphasizes republican ideals, culinary heritage, and the role of the state, which locals discuss with pride.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Seen as influential but sometimes aloof.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Talent Passport, EU Blue Card, and Profession Libérale visas cover most scenarios, but each demands diplomas, work contracts, or business plans translated into French.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Sizeable Anglophone communities tied to the wine trade and universities help newcomers settle, and Bordeaux City Hall’s Welcome Office guides families through paperwork.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "UNESCO riverfronts, wine country bike loops, and ocean day trips to Arcachon Bay keep the family’s weekend calendar full.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Northern cities hover around 3–8 °C (37–46 °F) with damp chill, while the south stays milder; snow is rare away from the Alps, matching the family’s dislike of harsh winters.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Statutory 35-hour weeks and overtime caps are enforced, and many tech firms add RTT days, keeping schedules family-friendly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "The 35-hour week, legally mandated rest days, and August shutdowns mean managers expect people to disconnect—great for Sarah’s need for predictable downtime.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Powerful unions, collective bargaining, and strict dismissal rules give employees leverage if workloads creep up.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/france_lyon_report.json
+++ b/reports/france_lyon_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "FR",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Lyon’s Part-Dieu business district houses banks, biotech firms, and consultancies with mature .NET stacks, and SNCF’s digital factory mixes remote flexibility with periodic office collaboration.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "The Rhône valley traps particulates in winter inversions, and NO₂ from the périphérique pushes PM2.5 toward 14 µg/m³, so the family will monitor pollution peaks before outdoor play.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "High secularism with religion largely private.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Courts, media, and frequent protests keep checks on executive power; even with emergency powers during crises, institutions remain resilient.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "SEPA transfers clear quickly, contactless cards and Apple Pay are ubiquitous, and online banks like Boursorama ease setup once residency documents are ready.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Atlantic beaches like Biarritz and Mediterranean spots near Nice offer lifeguarded sands, though peak tourist season brings crowds and higher prices.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Lyon’s LudiKrewe cafés, OctoGônes convention, and thriving role-play clubs give Trey deep tabletop networks without a long train ride.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidized childcare and parental benefits available.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Urban areas offer parks, museums, and family services.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "CAF benefits (PAJE, CMG), free école maternelle from age 3, and generous parental leave let working parents line up structured care without crushing costs—ideal for Sarah’s search for predictable coverage.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Long-stay visa holders who pay into social security can access CAF reimbursements, though paperwork in French and processing delays mean expat families should budget bridging funds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Locals cherish café culture, hiking in the Alps or Pyrenees, and neighborhood sports clubs, offering easy ways for Trey and Sarah to plug into community life.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors may seem reserved at first, yet school parent groups, sports clubs, and local associations open doors once the family shows steady participation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Visa holders must maintain French tax residence, update prefecture records, and keep health insurance active; missed renewals can trigger exit orders.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Expect €3,200–€3,600 monthly for a central T4 (~€1,700 rent), transit, and childcare; salaries cover it, but budgeting for restaurant splurges matters.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes—dual nationality is allowed.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "France’s €3 trillion economy posts unemployment near 7% and moderate 1–2% growth, offering diversified job markets even during EU downturns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Mixed economy with significant state role.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "High literacy and strong universities though competitive exams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Global firms like Sanofi, Capgemini, and Ubisoft Ivory Tower frequently process Talent Passport hires, though smaller Lyon startups still prefer French fluency and EU work rights.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "From the Alps to Atlantic dunes, France maintains vast protected areas and clean water standards, giving the family easy escapes to nature close to major cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "High earners face marginal income taxes up to 45% plus ~25% social contributions; with France’s family quotient the effective rate still lands in the low 40s, higher than the family pays today.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September stays near 22 °C (72 °F) before sliding to 11 °C (52 °F) with foggy mornings along the Saône, so light jackets cover the shoulder season.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Weekend markets, public parks, and subsidized sports clubs keep families active, and employers expect parents to take school holidays seriously—great for balancing Trey’s work with kid time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Long-stay visas allow spouses to work once OFII paperwork is cleared, and children access public schools and healthcare on par with locals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens tap 16+ weeks paid parental leave, monthly CAF allowances, and tax splitting via the family quotient, all of which underpin generous time with young kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical families rely on state-run childcare, employer meal vouchers, and long school vacations; coordinating all the paperwork takes effort but pays off.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Once the family contributes to Sécurité sociale they can apply for CAF benefits, though proving income and residency history can delay payouts for new arrivals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Minimalist to chic; dresses/knits/trousers with layers; strong fashion/beauty culture.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart‑casual tailoring, minimalist chic, quality sneakers/boots; weather‑appropriate outerwear.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Fashion-conscious culture with broad expressions allowed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Ubisoft, Dontnod, and Amplitude hire engineers regularly, and remote collaboration with EU teams is common, giving Trey steady options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition for gender marker changes exists, yet everyday acceptance varies outside major cities, so queer and trans communities concentrate in urban areas.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Anti-discrimination laws, reproductive rights, and generous parental leave policies align with the family’s equity expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are common and men take more parental leave, though household labor still skews female compared with Nordic norms.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Expect ANEF online submissions, in-person OFII visits, French-language leases, and notarized translations; hiring a relocation attorney eases the learning curve.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "France already faces deadly canicules, drought-stressed rivers, and Atlantic storm surge planning, so the family should expect periodic climate disruptions but benefits from strong adaptation funding.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "France’s universal Sécurité sociale system covers GP visits, maternity care, and prescriptions with low co-pays, delivering reliable care for families.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "After three months of residence the family can enroll in PUMA for public coverage, with supplemental mutuelle plans filling gaps for faster specialist access.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Public universities charge a few hundred euros per year, with prestigious CPGE tracks feeding grandes écoles and CROUS housing keeping living costs manageable for future college-aged kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students pay a few thousand euros annually unless they secure waivers; scholarships and residency status can bring fees closer to citizen rates over time.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family-sized flats in Croix-Rousse or Villeurbanne run €1,600–€1,900 and still demand guarantors; supply is better than Paris but competition spikes each September.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "France uses pay-as-you-earn withholding plus a streamlined online declaration; expect forms only in French, so hiring an accountant the first year helps.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens enjoy free, secular schools with strong math/language curricula, and larger cities offer international sections that could give Anduin bilingual exposure.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children enroll easily once they show address, vaccination, and birth certificates; specialized French-as-a-second-language support helps new arrivals acclimate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Corporate teams work bilingually, yet daily errands in markets or prefectures require French; English support clusters in international schools and the expat-heavy Confluence district.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Legal protections and growing social acceptance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist traditions influence politics but market economy prevails.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Work-life balance and emotional expression encouraged.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "La Cuisine du Web, LyonJS, and queer community centers like Centre LGBTI+ host frequent events, letting the family find progressive peers quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The SMIC sits near €1,766 gross per month in 2024, supporting local hires better than many EU peers but still tight for big-city rent if we rely solely on one salary.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "High-speed TGV lines, nationwide fiber rollout, and reliable utilities keep daily logistics smooth for tech professionals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "From Loire Valley châteaux to the Alps and lavender fields in Provence, weekend getaways deliver diverse scenery for the family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "River flooding, Atlantic windstorms, and the odd Mediterranean wildfire appear regularly, so insurance and alerts are important but manageable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Regional trains reach hiking trails, vineyards, and coasts within a few hours, making spontaneous nature trips realistic without a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Venues such as Le Transbordeur, Ninkasi, and Opera de Lyon span indie gigs to classical nights, making date-night tickets easy to snag.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Riverside péniches stay lively past midnight and metro lines run late on weekends, though quieter hilltop neighborhoods wind down earlier.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Game Only and Lyon Game Dev meetups partner with schools like Bellecour École, keeping pipelines active for Trey’s studio ambitions.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Ubisoft Ivory Tower, Arkane Lyon, and Bandai Namco’s studio anchor AAA hiring, while indies such as Agharta Studio keep the ecosystem collaborative.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Tax credits (CIJV), CNC grants, and Ubisoft’s entrepreneur labs support indie studios, making France a strong launchpad if Trey builds a local team.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Weekdays move fast in Part-Dieu’s corporate core, but Presqu’île markets and Rhône riverbanks slow down evenings, giving the family a balance between hustle and leisure.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools emphasize academics and respect for teachers, with manageable extracurricular commitments compared to US over-scheduling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "After five years of residence (or three if married to a citizen), applicants need B1 French and a civics interview; dual citizenship is allowed so the family can retain US passports.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "France scores well on Transparency International indices, though periodic political finance scandals remind us to watch procurement processes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A semi-presidential system with proportional parliamentary elections keeps multiple parties in play and encourages civic engagement.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Polyamory lacks legal recognition and is primarily embraced within urban queer networks, so openness requires discretion outside big cities.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "École maternelle is free and near-universal from age 3, while crèche spots and licensed nannies receive CAF subsidies—Trey and Sarah just need to join waitlists early in dense arrondissements.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Sous contrat schools cost a few hundred euros per year, while international campuses run €12–€20k and require early applications—important if the family wants English-heavy curricula.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "France legalised marriage equality and maintains robust secular policies, yet debates over laïcité and policing show tensions—urban areas feel progressive overall for the family.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government campaigns emphasize republican values, anti-extremism, and climate action—messages the family may appreciate even if they can feel frequent after major protests.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters operate independently and investigative journalism is robust, though government messaging spikes during security incidents.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Four metro lines, two funiculars, and dense tram/BRT corridors make car-free living viable; occasional strike days require backup plans but coverage is strong.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Strict secularism keeps religion separate from state.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid schedules became standard in tech and many government roles post-pandemic, though fully remote contracts may still require occasional on-site weeks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Multi-year Talent Passports renew in four-year blocks, and after five years of residence the family can seek 10-year cartes de résident if they maintain income and integration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "France’s pay-as-you-go system now targets retirement around age 64; benefits cover basics but assume homeowners supplement with savings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants earning in France accrue the same pension rights once they pay into Sécurité sociale, yet navigating credited quarters and bilateral treaties can be complex.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "US–France totalization lets long-term residents combine contributions, but the family would still rely on private savings given modest state payouts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Doctolib, Viveris, and fintech scale-ups hire Rails engineers, and remote-first teams tap Lyon for talent, though competition is stiffer than in Nantes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Central arrondissements feel safe, but purse snatching near Part-Dieu and scooter theft in Guillotière warrant vigilance—still within comfort for a savvy family.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "International School of Lyon, Ombrosa, and bilingual public streams in Lyon 2e give the boys continuity, while public lycées rank highly nationally.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Mediterranean waters warm to 24–26 °C (75–79 °F) by July, while Atlantic coasts stay closer to 19–21 °C, giving the family options depending on comfort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Continental swings bring humid summers topping 32 °C (90 °F) and occasional winter sleet; recent canicules make air conditioning a priority.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Sex education is comprehensive and public conversation around relationships is open, though polyamory remains niche outside major cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, extensive family benefits, and strong LGBTQ protections align with the family’s progressive values, even if bureaucracy can feel heavy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March starts near 7 °C (45 °F) and climbs to 19 °C (66 °F) by May, though pollen from surrounding plains can bother sensitive kids.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Frequent strikes and protests create noise, yet NATO/EU membership and predictable institutions keep the long-term outlook steady.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "France blends dirigiste economic planning with social welfare, funding public services while courting strategic industries.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Heavy regulation and worker protections coexist with vibrant private enterprise, offering stability at the cost of some bureaucracy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Average highs hit 28–30 °C (82–86 °F) with recurrent heatwaves pushing beyond 35 °C (95 °F) and warm nights in the urban core, so cooling strategies are essential.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Consular appointments and OFII validation often stretch 2–4 months, with fees of €200–€450 per adult plus translation costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Eurobarometer surveys show trust hovering near 35%, with protests expressing frustration but not eroding core institutions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption tends to surface in campaign financing or public procurement rather than day-to-day bribery, so diligence on contracts is enough.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers command €60k–€70k plus bonuses; while taxes bite, the pay aligns with Lyon’s higher housing costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Family meals, markets, parks, sports; many shops open Sat, limited Sun opening outside big cities; cultural outings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Primary ~08:30–16:30 (long lunch); Wed often half-day; offices ~09:00–18:00; after‑school care (garderie/études) common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Five weeks statutory leave plus public holidays.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Many offices close in August offering extended breaks.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Relations with Germany and Spain are pragmatic and cooperative, while historic rivalries show up mostly in sports banter.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "French identity emphasizes republican ideals, culinary heritage, and the role of the state, which locals discuss with pride.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Seen as influential but sometimes aloof.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Talent Passport, EU Blue Card, and Profession Libérale visas cover most scenarios, but each demands diplomas, work contracts, or business plans translated into French.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Longstanding expat networks around the American Club of Lyon and bilingual schools ease integration, but prefecture queues still demand patience and French paperwork.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "UNESCO-listed traboules, world-class gastronomy, and quick escapes to the Alps keep weekends full for curious parents and kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Northern cities hover around 3–8 °C (37–46 °F) with damp chill, while the south stays milder; snow is rare away from the Alps, matching the family’s dislike of harsh winters.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Statutory 35-hour weeks and overtime caps are enforced, and many tech firms add RTT days, keeping schedules family-friendly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "The 35-hour week, legally mandated rest days, and August shutdowns mean managers expect people to disconnect—great for Sarah’s need for predictable downtime.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Powerful unions, collective bargaining, and strict dismissal rules give employees leverage if workloads creep up.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/france_nantes_report.json
+++ b/reports/france_nantes_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "FR",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Nantes’ Euronantes tech district clusters Capgemini, Sopra Steria, and aerospace suppliers running .NET stacks for logistics and manufacturing, while hybrid policies let Trey blend on-site sprints with remote work for Paris-based clients.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Atlantic breezes flush Nantes’ basin, keeping PM2.5 around 11 µg/m³; occasional NO₂ spikes near the périphérique mean the family watches rush-hour alerts but enjoys clean air in parks like Parc de Procé.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "High secularism with religion largely private.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Courts, media, and frequent protests keep checks on executive power; even with emergency powers during crises, institutions remain resilient.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "SEPA transfers clear quickly, contactless cards and Apple Pay are ubiquitous, and online banks like Boursorama ease setup once residency documents are ready.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Atlantic beaches like Biarritz and Mediterranean spots near Nice offer lifeguarded sands, though peak tourist season brings crowds and higher prices.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Le Temple du Jeu cafés, the Utopiales festival’s tabletop hall, and Atlangames community nights make it easy for Trey to find regular board-game tables without Paris-level crowds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidized childcare and parental benefits available.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Urban areas offer parks, museums, and family services.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "CAF benefits (PAJE, CMG), free école maternelle from age 3, and generous parental leave let working parents line up structured care without crushing costs—ideal for Sarah’s search for predictable coverage.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Long-stay visa holders who pay into social security can access CAF reimbursements, though paperwork in French and processing delays mean expat families should budget bridging funds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Locals cherish café culture, hiking in the Alps or Pyrenees, and neighborhood sports clubs, offering easy ways for Trey and Sarah to plug into community life.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors may seem reserved at first, yet school parent groups, sports clubs, and local associations open doors once the family shows steady participation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Visa holders must maintain French tax residence, update prefecture records, and keep health insurance active; missed renewals can trigger exit orders.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "A family budget of roughly €2,800–€3,200 covers a three-bedroom rental around €1,400, groceries, transit passes, and childcare top-ups, so careful planning keeps savings on track.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes—dual nationality is allowed.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "France’s €3 trillion economy posts unemployment near 7% and moderate 1–2% growth, offering diversified job markets even during EU downturns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Mixed economy with significant state role.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "High literacy and strong universities though competitive exams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Airbus Atlantic, Accenture, and regional hospitals sponsor Talent Passport hires, yet mid-sized Nantes startups still defer to EU citizens, so Trey should court multinational anchors while Sarah keeps remote U.S. options alive.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "From the Alps to Atlantic dunes, France maintains vast protected areas and clean water standards, giving the family easy escapes to nature close to major cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "High earners face marginal income taxes up to 45% plus ~25% social contributions; with France’s family quotient the effective rate still lands in the low 40s, higher than the family pays today.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September afternoons hover near 20 °C (68 °F) before sliding to 12 °C (54 °F) by November with soft Atlantic rains, giving the family a long shoulder season for Loire bike rides.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Weekend markets, public parks, and subsidized sports clubs keep families active, and employers expect parents to take school holidays seriously—great for balancing Trey’s work with kid time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Long-stay visas allow spouses to work once OFII paperwork is cleared, and children access public schools and healthcare on par with locals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens tap 16+ weeks paid parental leave, monthly CAF allowances, and tax splitting via the family quotient, all of which underpin generous time with young kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical families rely on state-run childcare, employer meal vouchers, and long school vacations; coordinating all the paperwork takes effort but pays off.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Once the family contributes to Sécurité sociale they can apply for CAF benefits, though proving income and residency history can delay payouts for new arrivals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Minimalist to chic; dresses/knits/trousers with layers; strong fashion/beauty culture.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart‑casual tailoring, minimalist chic, quality sneakers/boots; weather‑appropriate outerwear.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Fashion-conscious culture with broad expressions allowed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Ubisoft, Dontnod, and Amplitude hire engineers regularly, and remote collaboration with EU teams is common, giving Trey steady options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition for gender marker changes exists, yet everyday acceptance varies outside major cities, so queer and trans communities concentrate in urban areas.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Anti-discrimination laws, reproductive rights, and generous parental leave policies align with the family’s equity expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are common and men take more parental leave, though household labor still skews female compared with Nordic norms.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Expect ANEF online submissions, in-person OFII visits, French-language leases, and notarized translations; hiring a relocation attorney eases the learning curve.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "France already faces deadly canicules, drought-stressed rivers, and Atlantic storm surge planning, so the family should expect periodic climate disruptions but benefits from strong adaptation funding.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "France’s universal Sécurité sociale system covers GP visits, maternity care, and prescriptions with low co-pays, delivering reliable care for families.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "After three months of residence the family can enroll in PUMA for public coverage, with supplemental mutuelle plans filling gaps for faster specialist access.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Public universities charge a few hundred euros per year, with prestigious CPGE tracks feeding grandes écoles and CROUS housing keeping living costs manageable for future college-aged kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students pay a few thousand euros annually unless they secure waivers; scholarships and residency status can bring fees closer to citizen rates over time.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Recent Île de Nantes builds and suburban maisons average €1,300–€1,500 for a T4, and while guarantors are still expected, vacancy rates beat Paris, letting the family trade paperwork for more space.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "France uses pay-as-you-earn withholding plus a streamlined online declaration; expect forms only in French, so hiring an accountant the first year helps.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens enjoy free, secular schools with strong math/language curricula, and larger cities offer international sections that could give Anduin bilingual exposure.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children enroll easily once they show address, vaccination, and birth certificates; specialized French-as-a-second-language support helps new arrivals acclimate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Outside tech coworking spaces, shopkeepers and prefecture staff expect French; English pops up in tourism and engineering firms, so the family should budget for classes and translation help.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Legal protections and growing social acceptance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist traditions influence politics but market economy prevails.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Work-life balance and emotional expression encouraged.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "La Cantine’s digital meetups, Queer Nantes socials, and bilingual parent groups in Trentemoult give Trey and Sarah quick ways to plug into progressive circles once they show up consistently.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The SMIC sits near €1,766 gross per month in 2024, supporting local hires better than many EU peers but still tight for big-city rent if we rely solely on one salary.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "High-speed TGV lines, nationwide fiber rollout, and reliable utilities keep daily logistics smooth for tech professionals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "From Loire Valley châteaux to the Alps and lavender fields in Provence, weekend getaways deliver diverse scenery for the family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "River flooding, Atlantic windstorms, and the odd Mediterranean wildfire appear regularly, so insurance and alerts are important but manageable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Regional trains reach hiking trails, vineyards, and coasts within a few hours, making spontaneous nature trips realistic without a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Venues like Stereolux and Le Ferrailleur host indie tours, and Île de Nantes warehouses run late-night DJ sets, offering occasional date nights without Parisian price tags.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Weeknights wind down early in family-heavy neighborhoods, yet the Hangar à Bananes strip stays lively on weekends; walking or tram rides home feel safe with normal big-city awareness.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Atlangames gathers 60+ studios and schools for demo nights, and Nantes Game Dev meetups share tooling tips—ideal for Trey to scout collaborators.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Local outfits like Ouat Entertainment, Alkemi, and indie VR teams incubated at Atlangames keep a mid-sized talent pool on tap, even if AAA giants sit in Lyon or Bordeaux.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Tax credits (CIJV), CNC grants, and Ubisoft’s entrepreneur labs support indie studios, making France a strong launchpad if Trey builds a local team.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Commutes rarely exceed 30 minutes by tram or bike, markets anchor weekends, and employers honor the 35-hour week, giving Sarah the calmer rhythm she wants without sacrificing urban amenities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools emphasize academics and respect for teachers, with manageable extracurricular commitments compared to US over-scheduling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "After five years of residence (or three if married to a citizen), applicants need B1 French and a civics interview; dual citizenship is allowed so the family can retain US passports.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "France scores well on Transparency International indices, though periodic political finance scandals remind us to watch procurement processes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A semi-presidential system with proportional parliamentary elections keeps multiple parties in play and encourages civic engagement.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Polyamory lacks legal recognition and is primarily embraced within urban queer networks, so openness requires discretion outside big cities.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "École maternelle is free and near-universal from age 3, while crèche spots and licensed nannies receive CAF subsidies—Trey and Sarah just need to join waitlists early in dense arrondissements.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Sous contrat schools cost a few hundred euros per year, while international campuses run €12–€20k and require early applications—important if the family wants English-heavy curricula.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "France legalised marriage equality and maintains robust secular policies, yet debates over laïcité and policing show tensions—urban areas feel progressive overall for the family.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government campaigns emphasize republican values, anti-extremism, and climate action—messages the family may appreciate even if they can feel frequent after major protests.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters operate independently and investigative journalism is robust, though government messaging spikes during security incidents.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Three tram lines, BusWay routes, and Chronobus services stitch together Nantes Métropole; service thins after midnight, but day-to-day errands rarely require a car.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Strict secularism keeps religion separate from state.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid schedules became standard in tech and many government roles post-pandemic, though fully remote contracts may still require occasional on-site weeks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Multi-year Talent Passports renew in four-year blocks, and after five years of residence the family can seek 10-year cartes de résident if they maintain income and integration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "France’s pay-as-you-go system now targets retirement around age 64; benefits cover basics but assume homeowners supplement with savings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants earning in France accrue the same pension rights once they pay into Sécurité sociale, yet navigating credited quarters and bilateral treaties can be complex.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "US–France totalization lets long-term residents combine contributions, but the family would still rely on private savings given modest state payouts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Rails roles surface in ecommerce boutiques like Akeneo and at remote-friendly SaaS shops, yet many Nantes employers lean on Java or PHP, so Sarah may keep a remote client roster.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime stays low, though bike theft and pickpockets around Commerce tram stops are common, so standard urban precautions keep the family comfortable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Catchment-area public schools score well, and the International School of Nantes plus bilingual programs in Sainte-Luce cover English tracks if the boys need them.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Mediterranean waters warm to 24–26 °C (75–79 °F) by July, while Atlantic coasts stay closer to 19–21 °C, giving the family options depending on comfort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Oceanic patterns mean mild winters around 7 °C (45 °F) and warm but rarely scorching summers near 25 °C (77 °F); occasional Atlantic storms bring wind but little snow.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Sex education is comprehensive and public conversation around relationships is open, though polyamory remains niche outside major cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, extensive family benefits, and strong LGBTQ protections align with the family’s progressive values, even if bureaucracy can feel heavy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March mornings start near 6 °C (43 °F) and climb to 17 °C (63 °F) by May with light showers, perfect for park play without the humidity the family dislikes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Frequent strikes and protests create noise, yet NATO/EU membership and predictable institutions keep the long-term outlook steady.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "France blends dirigiste economic planning with social welfare, funding public services while courting strategic industries.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Heavy regulation and worker protections coexist with vibrant private enterprise, offering stability at the cost of some bureaucracy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Highs average 24–26 °C (75–79 °F) with ocean breezes, though rare canicules nudge above 34 °C (93 °F); late sunsets encourage evening walks once the heat breaks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Consular appointments and OFII validation often stretch 2–4 months, with fees of €200–€450 per adult plus translation costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Eurobarometer surveys show trust hovering near 35%, with protests expressing frustration but not eroding core institutions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption tends to surface in campaign financing or public procurement rather than day-to-day bribery, so diligence on contracts is enough.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers earn €50k–€60k plus profit-sharing, which stretches further thanks to lower housing costs but still trails Paris paychecks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Family meals, markets, parks, sports; many shops open Sat, limited Sun opening outside big cities; cultural outings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Primary ~08:30–16:30 (long lunch); Wed often half-day; offices ~09:00–18:00; after‑school care (garderie/études) common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Five weeks statutory leave plus public holidays.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Many offices close in August offering extended breaks.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Relations with Germany and Spain are pragmatic and cooperative, while historic rivalries show up mostly in sports banter.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "French identity emphasizes republican ideals, culinary heritage, and the role of the state, which locals discuss with pride.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Seen as influential but sometimes aloof.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Talent Passport, EU Blue Card, and Profession Libérale visas cover most scenarios, but each demands diplomas, work contracts, or business plans translated into French.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "The expat scene is smaller yet supportive, with Nantes Métropole’s Welcome Office and anglophone Facebook groups smoothing bureaucracy for newcomers willing to navigate French forms.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Les Machines de l’Île, riverside greenways, and day trips to Atlantic beaches keep weekends novel without long travel days.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Northern cities hover around 3–8 °C (37–46 °F) with damp chill, while the south stays milder; snow is rare away from the Alps, matching the family’s dislike of harsh winters.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Statutory 35-hour weeks and overtime caps are enforced, and many tech firms add RTT days, keeping schedules family-friendly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "The 35-hour week, legally mandated rest days, and August shutdowns mean managers expect people to disconnect—great for Sarah’s need for predictable downtime.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Powerful unions, collective bargaining, and strict dismissal rules give employees leverage if workloads creep up.",
+      "alignmentValue": 8
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Nantes city report with localized scores covering its tech scene, family costs, transit, and creative communities
- add dedicated Lyon and Bordeaux city reports with tailored climate, employment, and cultural notes for the family profile
- register the three new French city files in `main.json` so they surface in the catalog

## Testing
- node -e "const fs=require('fs');['reports/france_nantes_report.json','reports/france_lyon_report.json','reports/france_bordeaux_report.json','main.json'].forEach(f=>JSON.parse(fs.readFileSync(f,'utf8')));"

------
https://chatgpt.com/codex/tasks/task_e_68e33a63fd6c83219a11df6553499a5c