### PR TITLE
Add Australian city reports for Melbourne, Sydney, Adelaide, and Hobart

### DIFF
--- a/main.json
+++ b/main.json
@@ -628,7 +628,25 @@
     },
     {
       "name": "Australia",
-      "file": "reports/australia_report.json"
+      "file": "reports/australia_report.json",
+      "cities": [
+        {
+          "name": "Melbourne",
+          "file": "reports/australia_melbourne_report.json"
+        },
+        {
+          "name": "Sydney",
+          "file": "reports/australia_sydney_report.json"
+        },
+        {
+          "name": "Adelaide",
+          "file": "reports/australia_adelaide_report.json"
+        },
+        {
+          "name": "Hobart",
+          "file": "reports/australia_hobart_report.json"
+        }
+      ]
     },
     {
       "name": "Austria",

--- a/reports/australia_adelaide_report.json
+++ b/reports/australia_adelaide_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "AU",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, compact urban growth, extensive parklands, and coastal breezes keep air and water quality high for the family."
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, summer heatwaves and Adelaide Hills bushfire seasons are the main climate risks, so we plan shading, cool roofs, and evacuation routes."
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, Mediterranean patterns bring warm, dry summers and mild winters, but January heat spikes above 40°C require afternoon retreats indoors."
+    },
+    {
+      "key": "Air Quality",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, PM2.5 levels stay low outside of rare dust storms, giving the kids consistent outdoor time."
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, we stay alert for grassfires and lightning storms in the Hills, yet the city core faces minimal flood or earthquake risk."
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, spring days land around 12–24°C (54–75°F) with wildflower hikes in the Hills and only occasional windy fronts."
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, summer averages 29–31°C (84–88°F) but dry heatwaves top 40°C several times a season, so we plan siestas and beach evenings."
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, autumn cools from 26°C to 16°C (79–61°F) with little rain, delivering long park afternoons and winery trips."
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentValue": 9,
+      "alignmentText": "In Adelaide, winter highs near 15°C (59°F) and lows around 7°C (45°F) stay gentle, so rain jackets replace snow gear."
+    },
+    {
+      "key": "Beach Life",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, Glenelg, Henley, and Semaphore beaches have calm surf, jetties, and trams, giving us easy sandy outings."
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentValue": 5,
+      "alignmentText": "In Adelaide, Gulf St Vincent water peaks near 22°C (72°F) in February but dips to 15°C (59°F) in winter, keeping swims seasonal."
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, the family can reach Adelaide Hills hikes, Fleurieu Peninsula beaches, or Barossa vineyards within an hour."
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, the Fair Work Commission's 2024 national minimum wage of AUD 24.10 per hour keeps service roles viable, though Adelaide's rents still demand dual professional incomes."
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, senior engineers earn AUD 110–130k in defence, health, and government tech, stretching further thanks to lower housing costs."
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, .NET demand comes from defence primes, the SA government, and Lot Fourteen startups, offering steady roles with security clearances."
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentValue": 5,
+      "alignmentText": "In Adelaide, Ruby roles are boutique—think Uniti Wireless or small consultancies—so Sarah might combine local work with remote clients."
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, large employers use the Temporary Skill Shortage (subclass 482) pathway regularly, but sponsorship hinges on skill lists and benchmark salaries, so we plan backup visa strategies."
+    },
+    {
+      "key": "Economic Health",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, South Australia's economy grows steadily via defence, space, and renewables projects, though it's less diversified than Sydney or Melbourne."
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, shorter commutes and widespread NBN fibre-to-the-premise support remote weeks, and coworking hubs like Stone & Chalk cater to hybrid teams."
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, employers respect 37.5 hour weeks and the city's slower tempo keeps evenings open for family dinners."
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, tech teams stick close to 37.5 hours, and defence contractors track time precisely with RDOs built in."
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, national law grants four weeks of paid annual leave plus 10–13 public holidays, giving us reliable school-aligned downtime if we book early."
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, tech employers typically stick to the four-week standard with occasional leave loading, so long trips home need advance coordination but approvals rarely get blocked."
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, ten-minute commutes and uncrowded streets give us a calmer rhythm that fits Sarah's work-life goals."
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, schools run 8:45–3:15 with readily available OSHC, so synchronizing work and pickups is straightforward."
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, weekends mix Central Market trips, coastal bike rides, and Hills wineries with kid spaces—no need for heavy booking."
+    },
+    {
+      "key": "Family Life",
+      "alignmentValue": 9,
+      "alignmentText": "In Adelaide, child-friendly festivals, community sport clubs, and parenting groups make it simple to build a village."
+    },
+    {
+      "key": "Polyamory",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, queer-owned cafes and Feast Festival provide safe spaces, but poly families stay discreet in conservative pockets."
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, schools encourage balanced development and the community favours relaxed parenting over hyper-competition."
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, wide footpaths, new inclusive playgrounds, and minimal traffic keep city outings kid-friendly."
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, good public schools sit across the metro area, though top performers like Glenunga International require zoning or IB fees."
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, fees are lower (AUD 115–140 a day) and waitlists shorter than on the east coast, but we still apply early for preferred centres."
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, citizens pair the national subsidy with state-funded 15-hour preschool, keeping net costs more manageable than Sydney."
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, temporary visa holders pay more upfront but centres are flexible with casual days and employer EAPs sometimes offset fees."
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, citizens secure local public enrollment and can access language and STEM specialist programs, though choice narrows in outer suburbs."
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, most temporary visa families enroll in public schools without tuition, but some visa subclasses pay modest international levies, so we confirm ahead of time."
+    },
+    {
+      "key": "Private Education",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, independent schools like Scotch and Pulteney offer strong programs at AUD 15–25k, well below Sydney prices."
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, the federal Paid Parental Leave scheme funds 22 weeks of shared leave (expanding toward 26) and Medicare covers newborn care, easing pressure on local grandparents."
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "In Adelaide, temporary residents can access Parental Leave Pay only after meeting residency tests and usually miss Family Tax Benefits, so we budget to self-fund early months."
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, citizens tap subsidized Commonwealth-supported places and HECS-HELP loans at South Australia's universities, keeping degrees within reach for the boys later on."
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, international tuition routinely tops AUD 35k per year and HECS loans are off limits, so we only consider uni once permanent residency is secured."
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, dual-income households and dad-friendly leave make egalitarian parenting visible, though tech leadership still skews male."
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, pride festivals, inclusive clinics, and legal recognition support gender-diverse neighbors, yet many school forms remain binary by default."
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, federal and state anti-discrimination laws protect gender equity, even if pay gaps linger in executive suites."
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, women move between athleisure, suits, and beachwear freely, though media still favors a slim, sun-ready aesthetic."
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, hands-on dads are common and parental leave is normalized, yet blokey banter still surfaces in some offices."
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, festival season (Fringe, WOMAD), Lot Fourteen's space hub, and Kaurna cultural tours keep curiosity alive."
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentValue": 10,
+      "alignmentText": "In Adelaide, English dominates government, health, and schools, so integration is seamless while we add language exposure through community programs."
+    },
+    {
+      "key": "Progressivism",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, South Australia backs climate targets, voluntary assisted dying laws, and a strong arts sector, matching much of our progressive wish list."
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, Marxist ideas show up in campuses and arts circles, but mainstream politics treats them as niche thought experiments."
+    },
+    {
+      "key": "Atheism",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, nearly half of locals report no religion, making secular parenting easy even if civic ceremonies keep light spiritual nods."
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, frank media and comprehensive sex education normalize consent-focused conversations, though conservative commentators still stir periodic pushback."
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, Feast Festival, Pride March, and inclusive policies show warm LGBTQ+ support even as visibility thins outside the CBD."
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentValue": 9,
+      "alignmentText": "In Adelaide, neighbors chat over fences and community sport or makerspaces quickly weave newcomers into social circles."
+    },
+    {
+      "key": "View of self",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, locals lean into a modest 'big country town' identity that prizes creativity over ego."
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, people talk warmly about New Zealand and Pacific partners while staying cautious about Beijing's influence, keeping regional views mixed but respectful."
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, we sense neighbors appreciate Australia's disaster aid and universities yet critique offshore detention policies, landing us in the 'mostly positive' range."
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, nightlife clusters on Peel Street and Hindley but wraps earlier than Sydney, so we plan date nights accordingly."
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, men's fashion leans smart-casual—button-ups, chinos, and street sneakers—suiting Trey fine."
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, women mix festival flair with relaxed beachwear, keeping expectations friendly and low-pressure."
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, cycling the Linear Park, hiking Mount Lofty, wine appreciation, and indie game jams all have active communities."
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, Good Games Gouger Street, AVCon, and local libraries host regular tabletop sessions for adults and kids."
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, venues like The Gov, Lion Arts Factory, and festival pop-ups deliver a steady gig calendar even if scale is smaller than Melbourne."
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, Meetup groups, Lot Fourteen events, and Game Plus make it easy to find tech peers and parenting circles."
+    },
+    {
+      "key": "Nature Access",
+      "alignmentValue": 9,
+      "alignmentText": "In Adelaide, within 30 minutes we're in conservation parks, on coastal bike paths, or spotting koalas in Cleland Wildlife Park."
+    },
+    {
+      "key": "Political System",
+      "alignmentValue": 9,
+      "alignmentText": "In Adelaide, we vote under Australia's compulsory-preference system, backed by independent courts and a robust election commission."
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentValue": 9,
+      "alignmentText": "In Adelaide, policy debates stay largely secular even when faith-based MPs speak up, so evidence-driven lawmaking holds."
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, Fair Work Australia, award wages, and active unions give us leverage, though gig platforms still skirt some protections."
+    },
+    {
+      "key": "State Ideology",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, the South Australian government leans progressive on renewables, social services, and space-industry investments."
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, watchdog media, High Court review, and compulsory voting keep democratic erosion at bay, even as activists track metadata laws."
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, a market economy mixes competitive startups with strong consumer protections and superannuation savings."
+    },
+    {
+      "key": "Stability",
+      "alignmentValue": 9,
+      "alignmentText": "In Adelaide, peaceful transitions of power and AAA credit ratings keep political and economic volatility low."
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, public broadcasters, independent podcasts, and community media counterbalance tabloid spin, so we just stay mindful during elections."
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, official messaging leans patriotic during defence news but generally sticks to factual community updates."
+    },
+    {
+      "key": "Social Policies",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, Medicare, targeted family tax benefits, and rent assistance exist but means testing keeps us filling forms to qualify."
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, trust rebounds after pandemic missteps yet swings by state; transparency portals and ICAC hearings help but skepticism persists."
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, corruption cases surface occasionally in construction or pokies, but watchdogs investigate and convictions land."
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, when corruption appears it is mid-level procurement or donation scandals, not systemic graft."
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, median house prices around AUD 750k and rents near AUD 550 per week keep family homes attainable without bidding wars."
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, low violent crime and community policing keep neighborhoods comfortable; we mainly watch for bike theft in the CBD."
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, Medicare clinics and state-funded hospitals deliver solid care, though we plan private extras for elective specialist waitlists."
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, visa holders must carry Overseas Visitor Health Cover and may pay Medicare levies before reciprocity kicks in."
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, we stitch together the federal Child Care Subsidy, employer flexibility, and local parent groups rather than relying on extended family."
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, means-tested Family Tax Benefits, school supplies bonuses, and universal preschool hours lighten costs but require paperwork."
+    },
+    {
+      "key": "Education",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, NAPLAN results sit around national averages with standout STEM programs at schools like Glenunga International."
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, buses and limited tram/train lines work well in the inner suburbs, but outer areas rely on cars, so we plan a one-car household."
+    },
+    {
+      "key": "Economic System",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, Australia runs a mixed economy with strong services, resource exports, and safety nets that cushion downturns."
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, Pay-As-You-Go withholding and the myTax portal simplify filings, yet foreign income and grants will still send us to an accountant."
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, dual tech incomes land near a 30% effective tax rate once Medicare and super are included."
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, opening accounts with the big four banks is straightforward and tap-to-pay works on everything from trams to school canteens."
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, lower rents and groceries ease our budget, though flights to the US or Europe cost more than from Sydney."
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, compulsory superannuation plus the Age Pension and public healthcare give citizens a stable retirement baseline."
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, temporary residents can contribute to super but need permanent residency before counting on Age Pension access."
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, the skilled independent, state-nominated, and Global Talent visas remain the main ladders, each demanding points or employer backing."
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, Americans blend easily thanks to language and cultural overlap, though some locals assume expats are short-term."
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, temporary visas run two to four years with renewals, and permanent residency usually follows after three to four years of compliant stay."
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, citizenship requires four years of lawful residence (one as a permanent resident) plus an easy civics test and basic English."
+    },
+    {
+      "key": "Family Members",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, partner visas grant work rights and kids can enroll in public school once we clear health and character checks."
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentValue": 5,
+      "alignmentText": "In Adelaide, we budget AUD 10-15k for visa fees and health checks and expect 6-12 month processing timelines depending on backlog."
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, overstaying a visa or misreporting earnings quickly triggers bans, and the ATO watches worldwide income once we pass 183 days."
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentValue": 8,
+      "alignmentText": "In Adelaide, Australia permits dual citizenship, so we can keep US passports once naturalized."
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, some states levy international student fees for temporary residents and Medicare surcharges apply until PR, so we plan cash flow accordingly."
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, studios like Mighty Kingdom, Monkeystack, and Halfbrick's satellite team hire steadily, but the market remains smaller than the east coast."
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentValue": 6,
+      "alignmentText": "In Adelaide, Mighty Kingdom, Monkeystack, and Foxie Ventures anchor the local industry with growing teams."
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, Game Plus, AVCon, and local IGDA meetups create supportive networks for devs and artists."
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, South Australia's Games Innovation Fund, Lot Fourteen incubators, and lower overheads make indie studio launches realistic."
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentValue": 7,
+      "alignmentText": "In Adelaide, 10 Gigabit City fibre, smart lighting pilots, and Service SA's digital services keep infrastructure modern despite smaller scale."
+    }
+  ]
+}

--- a/reports/australia_hobart_report.json
+++ b/reports/australia_hobart_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "AU",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentValue": 9,
+      "alignmentText": "In Hobart, mountain-fed air, Derwent River breezes, and strict land-use keep air and water pristine for the family."
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, climate models show slower warming, yet bushfire smoke from the Midlands and heavier rain events mean we still prep for outages."
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, summers sit around 21°C (70°F) with crisp nights and winters stay chilly and windy, so we embrace layers year-round."
+    },
+    {
+      "key": "Air Quality",
+      "alignmentValue": 9,
+      "alignmentText": "In Hobart, AQI stays among Australia's cleanest readings except during occasional bushfire smoke, keeping outdoor play healthy."
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, major disasters are rare, though we watch for bushfires on kunanyi/Mt Wellington and coastal erosion in low-lying suburbs."
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, spring starts near 8–18°C (46–64°F) with sea breezes and frequent showers, so we plan indoor backup activities."
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, summer highs reach 22–24°C (72–75°F) with cool evenings, making outdoor adventures pleasant but never hot."
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, autumn quickly cools from 19°C to 12°C (66–54°F) with golden foliage, suiting hikes and markets if we pack jackets."
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, winters hover 3–12°C (37–54°F) with frosty mornings and brisk southerlies, so we invest in efficient heating."
+    },
+    {
+      "key": "Beach Life",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, family beaches like Kingston and Bellerive are spotless, but cold water limits long swims outside peak summer."
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentValue": 3,
+      "alignmentText": "In Hobart, Tasman Sea temps only reach 16°C (61°F) in February and sit near 12°C (54°F) in winter, so wetsuits are standard for more than a splash."
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentValue": 10,
+      "alignmentText": "In Hobart, we live beside kunanyi/Mt Wellington, Bruny Island, and Tasman Peninsula cliffs—world-class nature in every direction."
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, the Fair Work Commission's 2024 national minimum wage of AUD 24.10 per hour keeps service roles viable, though Hobart's rents still demand dual professional incomes."
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentValue": 5,
+      "alignmentText": "In Hobart, senior engineers earn AUD 100–120k in government, UTAS, or local SaaS firms, so remote contracts help boost income."
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, .NET roles cluster in Tasmanian government digital teams, utilities, and UTAS, providing stable but limited openings."
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentValue": 4,
+      "alignmentText": "In Hobart, Ruby jobs are rare—mainly small consultancies—so Sarah would rely on remote work or cross-train."
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, large employers use the Temporary Skill Shortage (subclass 482) pathway regularly, but sponsorship hinges on skill lists and benchmark salaries, so we plan backup visa strategies."
+    },
+    {
+      "key": "Economic Health",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, the economy leans on public service, Antarctic science, and tourism; it’s steady but sensitive to visitor downturns."
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, many professionals work hybrid for mainland firms and NBN fibre-served suburbs make remote work reliable."
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, employers value balance—commutes are short, and outdoors culture pulls everyone offline at day’s end."
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, standard 37.5-hour weeks hold firm and meetings rarely run late thanks to the small-city tempo."
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, national law grants four weeks of paid annual leave plus 10–13 public holidays, giving us reliable school-aligned downtime if we book early."
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, tech employers typically stick to the four-week standard with occasional leave loading, so long trips home need advance coordination but approvals rarely get blocked."
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, a 15-minute city feel keeps stress low; errands, school runs, and work all sit within a compact radius."
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, schools run roughly 8:55–3:00 with accessible after-school care, and short commutes let us handle pickups without scrambling."
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, weekends mean Salamanca Market, MONA ferry trips, and bushwalks; options are rich but smaller in scale than mainland capitals."
+    },
+    {
+      "key": "Family Life",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, community events, child-friendly museums, and supportive neighbours create a cozy family environment, albeit with fewer big-city amenities."
+    },
+    {
+      "key": "Polyamory",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, queer meetups and MONA’s sex-positive culture give poly families allies, though small-town visibility means we stay thoughtful about disclosure."
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, parenting culture is relaxed and outdoorsy, prioritizing nature play and community volunteering over academic grind."
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, safe streets, compact neighborhoods, and kid-centric festivals make exploring easy with toddlers and school-aged kids alike."
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, quality public schools exist but choices are limited; top options like Taroona High or Friends School require catchment or tuition planning."
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentValue": 5,
+      "alignmentText": "In Hobart, childcare centres are fewer with waitlists up to 12 months, so we join community cooperatives or use in-home carers."
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, subsidies reduce fees to around AUD 95–120 per day, but choice is limited so we grab spots quickly."
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "In Hobart, visa families pay full rates until eligibility kicks in, and fewer centres means less flexibility with schedules."
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, citizens access local public schools with small class sizes and strong pastoral care, though specialised programs are limited."
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, visa kids enroll easily but some international levies apply, so we confirm fees with the Tasmanian Department of Education."
+    },
+    {
+      "key": "Private Education",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, private options like Friends School or Fahan deliver strong academics at AUD 12–20k but choices are fewer than mainland capitals."
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, the federal Paid Parental Leave scheme funds 22 weeks of shared leave (expanding toward 26) and Medicare covers newborn care, easing pressure on local grandparents."
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "In Hobart, temporary residents can access Parental Leave Pay only after meeting residency tests and usually miss Family Tax Benefits, so we budget to self-fund early months."
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, citizens tap subsidized Commonwealth-supported places and HECS-HELP loans at Tasmania's universities, keeping degrees within reach for the boys later on."
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, international tuition routinely tops AUD 35k per year and HECS loans are off limits, so we only consider uni once permanent residency is secured."
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, dual-income households and dad-friendly leave make egalitarian parenting visible, though tech leadership still skews male."
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, pride festivals, inclusive clinics, and legal recognition support gender-diverse neighbors, yet many school forms remain binary by default."
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, federal and state anti-discrimination laws protect gender equity, even if pay gaps linger in executive suites."
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, women move between athleisure, suits, and beachwear freely, though media still favors a slim, sun-ready aesthetic."
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, hands-on dads are common and parental leave is normalized, yet blokey banter still surfaces in some offices."
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentValue": 9,
+      "alignmentText": "In Hobart, MONA’s avant-garde art, Antarctic research, and dark-sky reserves keep curiosity sparking even in a small city."
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentValue": 10,
+      "alignmentText": "In Hobart, English dominates government, health, and schools, so integration is seamless while we add language exposure through community programs."
+    },
+    {
+      "key": "Progressivism",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, Greens councillors and community climate action shape policy, though statewide politics can swing centrist."
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, Marxist ideas show up in campuses and arts circles, but mainstream politics treats them as niche thought experiments."
+    },
+    {
+      "key": "Atheism",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, nearly half of locals report no religion, making secular parenting easy even if civic ceremonies keep light spiritual nods."
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, frank media and comprehensive sex education normalize consent-focused conversations, though conservative commentators still stir periodic pushback."
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, Pride events, inclusive schools, and MONA FOMA show strong LGBTQ+ acceptance despite Tasmania’s conservative history."
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentValue": 9,
+      "alignmentText": "In Hobart, neighbours know each other, community gardens thrive, and joining a climbing gym or maker space quickly yields friendships."
+    },
+    {
+      "key": "View of self",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, locals relish their creative, nature-first identity and embrace being the gateway to Antarctica."
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, people talk warmly about New Zealand and Pacific partners while staying cautious about Beijing's influence, keeping regional views mixed but respectful."
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, we sense neighbors appreciate Australia's disaster aid and universities yet critique offshore detention policies, landing us in the 'mostly positive' range."
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentValue": 5,
+      "alignmentText": "In Hobart, nightlife centers on Salamanca bars and MONA events, but options taper early, so we schedule occasional mainland trips for big-city energy."
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, men blend outdoor gear with smart casual—think puffer jackets, flannels, and boots—suited to weather and creative offices."
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, women mix artisan pieces with practical layers, leaning toward sustainability over runway trends."
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, hiking, kayaking, permaculture, and indie art scenes flourish, giving us ample hobby communities."
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, the tabletop scene revolves around Area 52, Good Games Hobart, and monthly community meetups—smaller but welcoming."
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, live music lives at Altar, Republic Bar, and festival stages, delivering quality shows even if volume is limited."
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, meetup calendars are shorter, yet coworking hubs, MONA workshops, and university events help us find peers quickly."
+    },
+    {
+      "key": "Nature Access",
+      "alignmentValue": 10,
+      "alignmentText": "In Hobart, five minutes takes us from the CBD to mountain trails, and world-heritage wilderness sits a short ferry or drive away."
+    },
+    {
+      "key": "Political System",
+      "alignmentValue": 9,
+      "alignmentText": "In Hobart, we vote under Australia's compulsory-preference system, backed by independent courts and a robust election commission."
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentValue": 9,
+      "alignmentText": "In Hobart, policy debates stay largely secular even when faith-based MPs speak up, so evidence-driven lawmaking holds."
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, Fair Work Australia, award wages, and active unions give us leverage, though gig platforms still skirt some protections."
+    },
+    {
+      "key": "State Ideology",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, Tasmania's parliament is a mix of Labor, Liberal, and Greens, producing progressive wins on environment while still courting forestry interests."
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, watchdog media, High Court review, and compulsory voting keep democratic erosion at bay, even as activists track metadata laws."
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, a market economy mixes competitive startups with strong consumer protections and superannuation savings."
+    },
+    {
+      "key": "Stability",
+      "alignmentValue": 9,
+      "alignmentText": "In Hobart, peaceful transitions of power and AAA credit ratings keep political and economic volatility low."
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, public broadcasters, independent podcasts, and community media counterbalance tabloid spin, so we just stay mindful during elections."
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, official messaging leans patriotic during defence news but generally sticks to factual community updates."
+    },
+    {
+      "key": "Social Policies",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, Medicare, targeted family tax benefits, and rent assistance exist but means testing keeps us filling forms to qualify."
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, trust rebounds after pandemic missteps yet swings by state; transparency portals and ICAC hearings help but skepticism persists."
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, corruption cases surface occasionally in construction or pokies, but watchdogs investigate and convictions land."
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, when corruption appears it is mid-level procurement or donation scandals, not systemic graft."
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentValue": 5,
+      "alignmentText": "In Hobart, limited housing supply pushes median prices near AUD 700k and rents above AUD 550 per week, demanding quick action on listings."
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentValue": 9,
+      "alignmentText": "In Hobart, low crime rates and close-knit suburbs keep families feeling secure; we mainly lock bikes downtown."
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, Medicare clinics and state-funded hospitals deliver solid care, though we plan private extras for elective specialist waitlists."
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, visa holders must carry Overseas Visitor Health Cover and may pay Medicare levies before reciprocity kicks in."
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, we stitch together the federal Child Care Subsidy, employer flexibility, and local parent groups rather than relying on extended family."
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, means-tested Family Tax Benefits, school supplies bonuses, and universal preschool hours lighten costs but require paperwork."
+    },
+    {
+      "key": "Education",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, public schools deliver solid pastoral care but academic outcomes lag mainland averages, so enrichment falls to parents."
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentValue": 5,
+      "alignmentText": "In Hobart, Metro buses cover main corridors but frequencies drop at night and there’s no rail, so we plan on driving for many trips."
+    },
+    {
+      "key": "Economic System",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, Australia runs a mixed economy with strong services, resource exports, and safety nets that cushion downturns."
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, Pay-As-You-Go withholding and the myTax portal simplify filings, yet foreign income and grants will still send us to an accountant."
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, dual tech incomes land near a 30% effective tax rate once Medicare and super are included."
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, opening accounts with the big four banks is straightforward and tap-to-pay works on everything from trams to school canteens."
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentValue": 5,
+      "alignmentText": "In Hobart, everyday costs are moderate but limited competition keeps groceries and energy prices higher than mainland averages."
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, compulsory superannuation plus the Age Pension and public healthcare give citizens a stable retirement baseline."
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, temporary residents can contribute to super but need permanent residency before counting on Age Pension access."
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, the skilled independent, state-nominated, and Global Talent visas remain the main ladders, each demanding points or employer backing."
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, Americans blend easily thanks to language and cultural overlap, though some locals assume expats are short-term."
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, temporary visas run two to four years with renewals, and permanent residency usually follows after three to four years of compliant stay."
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentValue": 7,
+      "alignmentText": "In Hobart, citizenship requires four years of lawful residence (one as a permanent resident) plus an easy civics test and basic English."
+    },
+    {
+      "key": "Family Members",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, partner visas grant work rights and kids can enroll in public school once we clear health and character checks."
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentValue": 5,
+      "alignmentText": "In Hobart, we budget AUD 10-15k for visa fees and health checks and expect 6-12 month processing timelines depending on backlog."
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, overstaying a visa or misreporting earnings quickly triggers bans, and the ATO watches worldwide income once we pass 183 days."
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentValue": 8,
+      "alignmentText": "In Hobart, Australia permits dual citizenship, so we can keep US passports once naturalized."
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, some states levy international student fees for temporary residents and Medicare surcharges apply until PR, so we plan cash flow accordingly."
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentValue": 4,
+      "alignmentText": "In Hobart, game dev roles are scarce—mostly micro-studios and freelancers—so Trey's indie ambitions rely on remote clients."
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentValue": 4,
+      "alignmentText": "In Hobart, outfits like Secret Lab and Giant Margarita anchor a tiny scene, with most talent distributed among small collectives."
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentValue": 5,
+      "alignmentText": "In Hobart, Tas Game Makers meetups and events at Enterprize Coworking nurture a close but small dev network."
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentValue": 5,
+      "alignmentText": "In Hobart, limited local funding means we'd lean on federal grants (Screen Australia) and remote revenue to bootstrap an indie studio."
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentValue": 6,
+      "alignmentText": "In Hobart, NBN fibre covers much of the metro and Service Tasmania digitizes paperwork, but flights and freight schedules remind us we're on an island."
+    }
+  ]
+}

--- a/reports/australia_melbourne_report.json
+++ b/reports/australia_melbourne_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "AU",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, the Urban Forest Strategy, Yarra River parklands, and 480+ neighborhood reserves keep daily life green for the kids even if freeway corridors in the west add noise and runoff we monitor."
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, hotter summers, flash-flood episodes on the Maribyrnong, and regional bushfires that send smoke south mean we invest in air purifiers and heat plans despite low sea-level risk."
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, the family's 'four seasons in a day' meme is real—temperatures swing from 12°C drizzle to 28°C sun in hours—so layers stay by the door even if most days remain temperate."
+    },
+    {
+      "key": "Air Quality",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, EPA monitors usually keep PM2.5 below 20 µg/m³, but summer smoke and planned burns can push AQI to unhealthy levels, so we keep filters ready for the kids' lungs."
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, we rarely face cyclones or quakes, yet grassfire seasons on the outskirts and the occasional 1-in-100-year flood require insurance and alert apps."
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, September through November bounces between 8–20°C (46–68°F) with gusty squalls, so school runs demand layers and backup indoor activities."
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, summer afternoons average 26–28°C (79–82°F) with low humidity, but northerly blasts can spike above 40°C, so we schedule park time before lunch."
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, autumn starts at 24°C (75°F) and slides to 12°C (54°F), mixing crisp sunny days with sudden cold fronts that keep our weekends flexible."
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, winter highs around 13°C (55°F) and lows near 6°C (43°F) feel brisk yet rarely freeze, making damp mornings the bigger issue than snow."
+    },
+    {
+      "key": "Beach Life",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, Port Phillip Bay spots like St Kilda and Brighton offer family promenades and lifesavers, but post-storm murk and cooler water make beach days an occasional perk."
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentValue": 4,
+      "alignmentText": "In Melbourne, Port Phillip water peaks around 18–19°C (64–66°F) in February, so swims stay short or involve rashies for the boys."
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, weekend drives reach the Dandenong Ranges, Mornington Peninsula hot springs, or Great Ocean Road vistas within two hours, keeping nature refreshers abundant despite suburban sprawl."
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, the Fair Work Commission's 2024 national minimum wage of AUD 24.10 per hour keeps service roles viable, though Melbourne's rents still demand dual professional incomes."
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, senior engineers at banks, Atlassian's southern hub, and scale-ups like Culture Amp land AUD 130–160k plus super, covering high rents with careful budgeting."
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, .NET roles stay plentiful across NAB, ANZ, Telstra, and state digital teams, giving Trey a steady mix of enterprise paychecks and hybrid schedules."
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, Ruby gigs cluster around SaaS outfits such as Envato and Zendesk plus contract shops, so Sarah keeps networks warm even as demand sits behind JS and .NET."
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, large employers use the Temporary Skill Shortage (subclass 482) pathway regularly, but sponsorship hinges on skill lists and benchmark salaries, so we plan backup visa strategies."
+    },
+    {
+      "key": "Economic Health",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, Victoria's economy rebounds above pre-pandemic levels with unemployment near 4% and strong professional services, supporting ongoing tech hiring."
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, hybrid weeks of three office days are now standard, co-working like The Commons thrives, and Asia-Pacific time zones keep remote contracts viable."
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, awards cap full-time hours at 38 and managers respect school pickups, yet agency crunches and product launches still demand occasional late nights."
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, salaried tech teams largely honor 37.5–38 hour schedules, with time-in-lieu or RDOs when sprints spike workloads."
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, national law grants four weeks of paid annual leave plus 10–13 public holidays, giving us reliable school-aligned downtime if we book early."
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, tech employers typically stick to the four-week standard with occasional leave loading, so long trips home need advance coordination but approvals rarely get blocked."
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, the CBD hums at commuter speed while inner-north neighborhoods slow down with cafe culture, so we balance urban energy with suburban breathing room."
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, primary schools run roughly 8:45–3:30 and outside-school-hours care fills quickly, so we stagger remote mornings and book OSHC spots early."
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, Saturdays mean farmers markets, AFL clinics, and museum sessions, but popular attractions like Scienceworks require timed tickets to dodge crowds."
+    },
+    {
+      "key": "Family Life",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, the network of maternal-child health centers, adventure playgrounds, and library storytime keeps family life rich once we navigate waitlists for swim lessons."
+    },
+    {
+      "key": "Polyamory",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, queer-friendly suburbs such as Fitzroy and Brunswick host poly discussion groups and inclusive therapists, yet mainstream school forms still assume dyadic parents."
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, schools champion child-led learning and dads at drop-off are normal, though high-achieving suburbs nudge families toward extracurricular overload."
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, upgraded tram stops, 1,000+ playgrounds, and pram-accessible lanes make daily outings easy aside from CBD traffic noise."
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, strong zoned public schools, selective-entry academies, and international programs exist, but top choices like University High or Bialik demand living in catchment or early applications."
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, Victoria funds 15 hours of three- and four-year-old kinder, yet popular community centers post 12-18 month waitlists, so we join co-ops as backup."
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, citizens combine the federal subsidy (up to 90%) with state kinder credits, but daily fees of AUD 135–180 leave real out-of-pocket costs."
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "In Melbourne, temporary visa families pay full childcare fees until they satisfy residency tests, turning long-day care into a AUD 30k+ annual expense."
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, citizens secure a seat at their local school with strong literacy outcomes, and specialist programs for STEM and music are widely available."
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, temporary residents can enroll in public schools but Victoria's Temporary Residents Program charges roughly AUD 5–6k per child each year, so we budget accordingly."
+    },
+    {
+      "key": "Private Education",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, private schools from Wesley to Haileybury offer stellar programs but charge AUD 25–40k annually plus levies, keeping them a selective splurge."
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, the federal Paid Parental Leave scheme funds 22 weeks of shared leave (expanding toward 26) and Medicare covers newborn care, easing pressure on local grandparents."
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "In Melbourne, temporary residents can access Parental Leave Pay only after meeting residency tests and usually miss Family Tax Benefits, so we budget to self-fund early months."
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, citizens tap subsidized Commonwealth-supported places and HECS-HELP loans at Victoria's universities, keeping degrees within reach for the boys later on."
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, international tuition routinely tops AUD 35k per year and HECS loans are off limits, so we only consider uni once permanent residency is secured."
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, dual-income households and dad-friendly leave make egalitarian parenting visible, though tech leadership still skews male."
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, pride festivals, inclusive clinics, and legal recognition support gender-diverse neighbors, yet many school forms remain binary by default."
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, federal and state anti-discrimination laws protect gender equity, even if pay gaps linger in executive suites."
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, women move between athleisure, suits, and beachwear freely, though media still favors a slim, sun-ready aesthetic."
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, hands-on dads are common and parental leave is normalized, yet blokey banter still surfaces in some offices."
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, laneway street art, experimental theatre, and cutting-edge science precincts like the Melbourne Connect hub constantly feed our curiosity."
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentValue": 10,
+      "alignmentText": "In Melbourne, English dominates government, health, and schools, so integration is seamless while we add language exposure through community programs."
+    },
+    {
+      "key": "Progressivism",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, state politics lean left with climate targets, safe-injection pilots, and treaty talks with First Peoples, aligning with our values."
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, Marxist ideas show up in campuses and arts circles, but mainstream politics treats them as niche thought experiments."
+    },
+    {
+      "key": "Atheism",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, nearly half of locals report no religion, making secular parenting easy even if civic ceremonies keep light spiritual nods."
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, frank media and comprehensive sex education normalize consent-focused conversations, though conservative commentators still stir periodic pushback."
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, Pride March on Fitzroy Street, rainbow-ready schools, and anti-discrimination enforcement make queer life visible and safe for poly families."
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, neighbors wave but real bonds form through school councils, maker clubs, and climbing gyms where newcomers are welcomed once we show up consistently."
+    },
+    {
+      "key": "View of self",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, locals embrace a 'most livable city' identity blended with self-aware humor about weather and sports obsession, balancing pride with realism."
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, people talk warmly about New Zealand and Pacific partners while staying cautious about Beijing's influence, keeping regional views mixed but respectful."
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, we sense neighbors appreciate Australia's disaster aid and universities yet critique offshore detention policies, landing us in the 'mostly positive' range."
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, late-night trams connect cocktail bars, comedy clubs, and hidden laneway venues, though we still arrange sitters for 24-hour licenses like Section 8."
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, men's fashion mixes monochrome streetwear, tailored jackets, and beanies-with-beards aesthetics without raising eyebrows in tech offices."
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, women pair structured blazers with sneakers or vintage finds, and inclusive boutiques support diverse body types."
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, hobbies from bouldering at Northside to specialty coffee roasting and footy barracking have thriving communities ready to plug us in."
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, Good Games stores, Fortress Melbourne, and events like ConVic keep tabletop nights frequent for adults and kids alike."
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, the 'live music capital' reputation lives on through venues like the Corner Hotel and Forum plus late-night jazz, giving Trey plenty of gig options."
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, Meetup, ACMI-hosted labs, and neighborhood Slack groups make it easy to find parenting circles, tech talks, or poly-friendly socials weekly."
+    },
+    {
+      "key": "Nature Access",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, within an hour we can reach surf beaches, Healesville Sanctuary, or Lysterfield trails, keeping nature therapy on the calendar."
+    },
+    {
+      "key": "Political System",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, we vote under Australia's compulsory-preference system, backed by independent courts and a robust election commission."
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, policy debates stay largely secular even when faith-based MPs speak up, so evidence-driven lawmaking holds."
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, Fair Work Australia, award wages, and active unions give us leverage, though gig platforms still skirt some protections."
+    },
+    {
+      "key": "State Ideology",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, Victoria's Labor government pushes progressive taxation, public transport spend, and treaty talks with First Peoples, aligning with our civic values."
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, watchdog media, High Court review, and compulsory voting keep democratic erosion at bay, even as activists track metadata laws."
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, a market economy mixes competitive startups with strong consumer protections and superannuation savings."
+    },
+    {
+      "key": "Stability",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, peaceful transitions of power and AAA credit ratings keep political and economic volatility low."
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, public broadcasters, independent podcasts, and community media counterbalance tabloid spin, so we just stay mindful during elections."
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, official messaging leans patriotic during defence news but generally sticks to factual community updates."
+    },
+    {
+      "key": "Social Policies",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, Medicare, targeted family tax benefits, and rent assistance exist but means testing keeps us filling forms to qualify."
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, trust rebounds after pandemic missteps yet swings by state; transparency portals and ICAC hearings help but skepticism persists."
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, corruption cases surface occasionally in construction or pokies, but watchdogs investigate and convictions land."
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, when corruption appears it is mid-level procurement or donation scandals, not systemic graft."
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentValue": 5,
+      "alignmentText": "In Melbourne, median house prices near AUD 930k and family rentals above AUD 700 per week force us to eye middle-ring suburbs or townhouse living."
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, violent crime stays low and family suburbs feel safe, though car break-ins in inner neighborhoods remind us to lock up gear."
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, Medicare clinics and state-funded hospitals deliver solid care, though we plan private extras for elective specialist waitlists."
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, visa holders must carry Overseas Visitor Health Cover and may pay Medicare levies before reciprocity kicks in."
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, we stitch together the federal Child Care Subsidy, employer flexibility, and local parent groups rather than relying on extended family."
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, means-tested Family Tax Benefits, school supplies bonuses, and universal preschool hours lighten costs but require paperwork."
+    },
+    {
+      "key": "Education",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, Victorian Curriculum outcomes sit above OECD averages and specialist high schools like John Monash Science provide advanced pathways."
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, the tram and train grid, Myki fares, and expanding bike lanes let us rely less on cars, but outer suburbs still face 20+ minute headways."
+    },
+    {
+      "key": "Economic System",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, Australia runs a mixed economy with strong services, resource exports, and safety nets that cushion downturns."
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, Pay-As-You-Go withholding and the myTax portal simplify filings, yet foreign income and grants will still send us to an accountant."
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, dual tech incomes land near a 30% effective tax rate once Medicare and super are included."
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, opening accounts with the big four banks is straightforward and tap-to-pay works on everything from trams to school canteens."
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentValue": 4,
+      "alignmentText": "In Melbourne, family rents of AUD 700–900 per week plus rising groceries mean US-dollar income must stretch carefully despite free museums."
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, compulsory superannuation plus the Age Pension and public healthcare give citizens a stable retirement baseline."
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, temporary residents can contribute to super but need permanent residency before counting on Age Pension access."
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, the skilled independent, state-nominated, and Global Talent visas remain the main ladders, each demanding points or employer backing."
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, Americans blend easily thanks to language and cultural overlap, though some locals assume expats are short-term."
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, temporary visas run two to four years with renewals, and permanent residency usually follows after three to four years of compliant stay."
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentValue": 7,
+      "alignmentText": "In Melbourne, citizenship requires four years of lawful residence (one as a permanent resident) plus an easy civics test and basic English."
+    },
+    {
+      "key": "Family Members",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, partner visas grant work rights and kids can enroll in public school once we clear health and character checks."
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentValue": 5,
+      "alignmentText": "In Melbourne, we budget AUD 10-15k for visa fees and health checks and expect 6-12 month processing timelines depending on backlog."
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, overstaying a visa or misreporting earnings quickly triggers bans, and the ATO watches worldwide income once we pass 183 days."
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, Australia permits dual citizenship, so we can keep US passports once naturalized."
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentValue": 6,
+      "alignmentText": "In Melbourne, some states levy international student fees for temporary residents and Medicare surcharges apply until PR, so we plan cash flow accordingly."
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, the Games Hub supports hundreds of devs, and studios from Sledgehammer Games to League of Geeks hire across disciplines, keeping opportunities steady."
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, names like Sledgehammer, EA Firemonkeys, League of Geeks, and Hipster Whale create a dense studio cluster for Trey to tap."
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentValue": 9,
+      "alignmentText": "In Melbourne, GCAP, Freeplay Festival, and co-working spaces like The Arcade give us peer networks and mentorship year-round."
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, VicScreen grants, Screen Australia's Games Expansion Pack, and incubators like The Arcade lower the runway for launching an indie studio."
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentValue": 8,
+      "alignmentText": "In Melbourne, gigabit NBN fibre, contactless transit, and Service Victoria's digital IDs keep daily logistics modern, though legacy rail signalling still hiccups."
+    }
+  ]
+}

--- a/reports/australia_sydney_report.json
+++ b/reports/australia_sydney_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "AU",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, harbour breezes and coastal national parks deliver stunning daily scenery, yet motorway congestion and airport noise temper air and sound quality in inner suburbs."
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentValue": 5,
+      "alignmentText": "In Sydney, hotter summers, Black Summer bushfire smoke, and Hawkesbury-Nepean flood risk mean we budget for insurance, purifiers, and evacuation planning even near the coast."
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, the climate stays mostly mild—20°C spring days roll into humid 28°C summers—though muggy spells and east coast lows require flexible outdoor plans."
+    },
+    {
+      "key": "Air Quality",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, daily AQI sits in the good range but summer smoke, hazard reduction burns, and tunnel exhaust plumes can spike pollution, so we follow NSW Health alerts."
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, severe storms and riverine floods in the west, plus nearby bushfire corridors, keep natural-hazard risk higher than the CBD's postcard images suggest."
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, spring days hover 15–24°C (59–75°F) with bright skies, though southerly busters can drop temps quickly, so we carry light jackets."
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, average highs sit around 27°C (81°F) but humidity and the odd 40°C westerly blast make midday siestas and aircon maintenance essential."
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, autumn settles into 13–24°C (55–75°F) with warm water and crisp evenings, giving us prime family beach and hiking weather."
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, winter rarely drops below 8°C (46°F) and daytime highs near 17°C (63°F) keep playgrounds comfortable with a light sweater."
+    },
+    {
+      "key": "Beach Life",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, beaches from Manly to Cronulla combine surf lifesavers, coastal walks, and cafes, so the family can default to saltwater weekends year-round."
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, sea temps peak around 23°C (73°F) in late summer and dip to 18°C (64°F) in winter, keeping swims comfortable most of the year with short wetsuits."
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, we toggle between harbour lookouts, the Royal National Park, and Blue Mountains trails within 90 minutes, delivering constant wow moments for the kids."
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, the Fair Work Commission's 2024 national minimum wage of AUD 24.10 per hour keeps service roles viable, though Sydney's rents still demand dual professional incomes."
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, senior engineers at Atlassian, Canva, and fintechs earn AUD 150–180k plus equity, helping offset the country's priciest housing market."
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, banks, consultancies, and federal agencies keep .NET roles abundant, with sponsorship more common than in smaller cities."
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, Ruby thrives at Atlassian, SafetyCulture, and boutique agencies, though competition is stiff and many teams expect full-stack versatility."
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, large employers use the Temporary Skill Shortage (subclass 482) pathway regularly, but sponsorship hinges on skill lists and benchmark salaries, so we plan backup visa strategies."
+    },
+    {
+      "key": "Economic Health",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, New South Wales anchors Australia's GDP with finance, tech, and biotech growth, keeping unemployment low but costs high."
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, hybrid schedules (three office days) dominate and coworking from Fishburners to WOTSO is plentiful, though CBD employers still favour in-person collaboration."
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, award protections exist but global teams and start-up hustle often bleed into evenings, so we negotiate hard for boundaries."
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, tech professionals nominally work 38 hours, yet client calls and transport delays can stretch weeks toward 42 without disciplined planning."
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, national law grants four weeks of paid annual leave plus 10–13 public holidays, giving us reliable school-aligned downtime if we book early."
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, tech employers typically stick to the four-week standard with occasional leave loading, so long trips home need advance coordination but approvals rarely get blocked."
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, the CBD and inner east run at a clip—traffic, ferry timetables, and packed diaries—so Sarah leans on remote days to slow family rhythm."
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, primary schools (9:00–3:00) clash with long commutes, so we rely on before/after-school care waitlists and employer flexibility."
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, weekends swing between Bondi markets, Taronga Zoo, and ferry adventures, though parking and reservations demand early planning."
+    },
+    {
+      "key": "Family Life",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, playgroups, surf lifesaving clubs, and family-friendly museums abound, yet we juggle costs and waitlists to access them consistently."
+    },
+    {
+      "key": "Polyamory",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, Inner West venues host poly meetups and Mardi Gras celebrates queer kinship, but workplaces and school paperwork still presume monogamy."
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, communities support dual-career parenting yet lean competitive—tutors, selective school prep, and weekend sport rosters keep calendars busy."
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, waterfront playgrounds and fenced parks shine, though CBD sidewalks and crowded trains require vigilance with strollers."
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, high-quality public schools exist but zoning for top campuses and selective test prep mean strategic housing decisions."
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentValue": 5,
+      "alignmentText": "In Sydney, quality childcare centres command 12-24 month waitlists and AUD 170–200 daily fees, so we join community preschools early."
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, citizens rely on the Child Care Subsidy but high hourly caps mean even 90% coverage leaves hefty co-pays."
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "In Sydney, many temporary visa families pay sticker price for childcare until they clear residency hurdles, inflating costs beyond AUD 35k a year."
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, citizens are guaranteed a local public school seat, yet quality swings between suburbs and selective schools require exams."
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "In Sydney, NSW charges subclass 482 families roughly AUD 6–7k per child to attend public schools, so we reserve funds or seek employer reimbursement."
+    },
+    {
+      "key": "Private Education",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, elite private schools deliver strong outcomes but cost AUD 30–45k yearly plus levies and uniforms."
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, the federal Paid Parental Leave scheme funds 22 weeks of shared leave (expanding toward 26) and Medicare covers newborn care, easing pressure on local grandparents."
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "In Sydney, temporary residents can access Parental Leave Pay only after meeting residency tests and usually miss Family Tax Benefits, so we budget to self-fund early months."
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, citizens tap subsidized Commonwealth-supported places and HECS-HELP loans at New South Wales's universities, keeping degrees within reach for the boys later on."
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, international tuition routinely tops AUD 35k per year and HECS loans are off limits, so we only consider uni once permanent residency is secured."
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, dual-income households and dad-friendly leave make egalitarian parenting visible, though tech leadership still skews male."
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, pride festivals, inclusive clinics, and legal recognition support gender-diverse neighbors, yet many school forms remain binary by default."
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, federal and state anti-discrimination laws protect gender equity, even if pay gaps linger in executive suites."
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, women move between athleisure, suits, and beachwear freely, though media still favors a slim, sun-ready aesthetic."
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, hands-on dads are common and parental leave is normalized, yet blokey banter still surfaces in some offices."
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, the blend of Gadigal cultural tours, Vivid light shows, and world-class science hubs like Tech Central keeps curiosity fuelled."
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentValue": 10,
+      "alignmentText": "In Sydney, English dominates government, health, and schools, so integration is seamless while we add language exposure through community programs."
+    },
+    {
+      "key": "Progressivism",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, the city council and many suburbs back climate action and LGBTQ+ inclusion, even as statewide politics remains more centrist than Melbourne."
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, Marxist ideas show up in campuses and arts circles, but mainstream politics treats them as niche thought experiments."
+    },
+    {
+      "key": "Atheism",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, nearly half of locals report no religion, making secular parenting easy even if civic ceremonies keep light spiritual nods."
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, frank media and comprehensive sex education normalize consent-focused conversations, though conservative commentators still stir periodic pushback."
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, Mardi Gras, Oxford Street nightlife, and rainbow-flagged schools show strong LGBTQ+ acceptance for poly and queer families."
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, neighbors are cordial and communities coalesce through surf clubs, school P&Cs, or meetups, but relationships take effort amid busy schedules."
+    },
+    {
+      "key": "View of self",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, locals see themselves as Australia's global city—ambitious, outdoorsy, and unapologetically proud of harbour icons."
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, people talk warmly about New Zealand and Pacific partners while staying cautious about Beijing's influence, keeping regional views mixed but respectful."
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, we sense neighbors appreciate Australia's disaster aid and universities yet critique offshore detention policies, landing us in the 'mostly positive' range."
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, late-night venues rebounded after lockout laws, yet we still plan transport for nights out in Newtown or Barangaroo."
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, men pair tailored shirts with coastal casual—linen, sneakers, and surf brands—without office pushback."
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, women rotate between athleisure, designer resort wear, and polished corporate looks, embracing sun-smart accessories."
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, surfing, climbing, dragon boating, and foodie culture each have deep communities ready to adopt newcomers."
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, Good Games branches, Fortress Sydney, and regular meetup nights keep tabletop options steady though they disperse across suburbs."
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, Oxford Street clubs, Enmore Theatre gigs, and Carriageworks festivals fuel Trey's music cravings while we line up childcare."
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, Tech Central meetups, poly socials, and parenting groups happen nightly, offering endless chances to build community quickly."
+    },
+    {
+      "key": "Nature Access",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, we can snorkel at Shelly Beach, bushwalk the Coast Track, or ferry to national parks within an hour, keeping outdoor therapy easy."
+    },
+    {
+      "key": "Political System",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, we vote under Australia's compulsory-preference system, backed by independent courts and a robust election commission."
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, policy debates stay largely secular even when faith-based MPs speak up, so evidence-driven lawmaking holds."
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, Fair Work Australia, award wages, and active unions give us leverage, though gig platforms still skirt some protections."
+    },
+    {
+      "key": "State Ideology",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, NSW politics balances progressive city councils with a more centrist state government, so reforms arrive but slower than in Victoria."
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, watchdog media, High Court review, and compulsory voting keep democratic erosion at bay, even as activists track metadata laws."
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, a market economy mixes competitive startups with strong consumer protections and superannuation savings."
+    },
+    {
+      "key": "Stability",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, peaceful transitions of power and AAA credit ratings keep political and economic volatility low."
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, public broadcasters, independent podcasts, and community media counterbalance tabloid spin, so we just stay mindful during elections."
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, official messaging leans patriotic during defence news but generally sticks to factual community updates."
+    },
+    {
+      "key": "Social Policies",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, Medicare, targeted family tax benefits, and rent assistance exist but means testing keeps us filling forms to qualify."
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, trust rebounds after pandemic missteps yet swings by state; transparency portals and ICAC hearings help but skepticism persists."
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, corruption cases surface occasionally in construction or pokies, but watchdogs investigate and convictions land."
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, when corruption appears it is mid-level procurement or donation scandals, not systemic graft."
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentValue": 4,
+      "alignmentText": "In Sydney, family homes routinely exceed AUD 1.2 million and rents push AUD 900–1,100 per week, driving fierce competition and compromises on location."
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, violent crime remains low and beaches feel safe for kids, though property crime spikes in nightlife strips keep us vigilant."
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, Medicare clinics and state-funded hospitals deliver solid care, though we plan private extras for elective specialist waitlists."
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, visa holders must carry Overseas Visitor Health Cover and may pay Medicare levies before reciprocity kicks in."
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, we stitch together the federal Child Care Subsidy, employer flexibility, and local parent groups rather than relying on extended family."
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, means-tested Family Tax Benefits, school supplies bonuses, and universal preschool hours lighten costs but require paperwork."
+    },
+    {
+      "key": "Education",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, NAPLAN and HSC results keep NSW near the top nationally, with selective high schools and International Baccalaureate campuses for advanced learners."
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, trains, light rail, ferries, and the new Metro give solid coverage, but Opal fares and congestion mean we still plan for occasional driving."
+    },
+    {
+      "key": "Economic System",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, Australia runs a mixed economy with strong services, resource exports, and safety nets that cushion downturns."
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, Pay-As-You-Go withholding and the myTax portal simplify filings, yet foreign income and grants will still send us to an accountant."
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, dual tech incomes land near a 30% effective tax rate once Medicare and super are included."
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, opening accounts with the big four banks is straightforward and tap-to-pay works on everything from trams to school canteens."
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentValue": 3,
+      "alignmentText": "In Sydney, AUD 900+ weekly rents, $13 coffees in the CBD, and toll roads make it Australia's most expensive city, so USD income must stretch."
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, compulsory superannuation plus the Age Pension and public healthcare give citizens a stable retirement baseline."
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, temporary residents can contribute to super but need permanent residency before counting on Age Pension access."
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, the skilled independent, state-nominated, and Global Talent visas remain the main ladders, each demanding points or employer backing."
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, Americans blend easily thanks to language and cultural overlap, though some locals assume expats are short-term."
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, temporary visas run two to four years with renewals, and permanent residency usually follows after three to four years of compliant stay."
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, citizenship requires four years of lawful residence (one as a permanent resident) plus an easy civics test and basic English."
+    },
+    {
+      "key": "Family Members",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, partner visas grant work rights and kids can enroll in public school once we clear health and character checks."
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentValue": 5,
+      "alignmentText": "In Sydney, we budget AUD 10-15k for visa fees and health checks and expect 6-12 month processing timelines depending on backlog."
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, overstaying a visa or misreporting earnings quickly triggers bans, and the ATO watches worldwide income once we pass 183 days."
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, Australia permits dual citizenship, so we can keep US passports once naturalized."
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentValue": 6,
+      "alignmentText": "In Sydney, some states levy international student fees for temporary residents and Medicare surcharges apply until PR, so we plan cash flow accordingly."
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, studios like Wargaming, Riot, and Blowfish hire across engineering and art, though the scene is smaller than Melbourne's."
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, Wargaming Sydney, Riot Games, Not Doppler, and Blowfish give Trey anchor points in AAA and indie spaces."
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentValue": 8,
+      "alignmentText": "In Sydney, Game Plus, IGDA Sydney, and Screen NSW events foster active dev meetups and mentorship."
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentValue": 7,
+      "alignmentText": "In Sydney, Screen NSW's Games Funding, Startmate, and Fishburners provide grants and incubators, though commercial rents stay steep."
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentValue": 9,
+      "alignmentText": "In Sydney, Metro lines, digital Opal cards, and widespread fibre-to-the-premise keep infrastructure cutting-edge despite growing pains."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a comprehensive Melbourne city report covering climate, childcare, tech, and game development considerations
- add tailored Sydney, Adelaide, and Hobart city reports with city-specific scores and alignment guidance for the family profile
- register the four new city files under Australia in main.json so they appear in tooling

## Testing
- `for city in melbourne sydney adelaide hobart; do echo "Checking $city"; jq '.values | length' reports/australia_${city}_report.json; done`

------
https://chatgpt.com/codex/tasks/task_e_68e33e4a23348321af3cf1aed536d4cd