### PR TITLE
Add Belgium city reports for Brussels, Ghent, Leuven, and Antwerp

### DIFF
--- a/main.json
+++ b/main.json
@@ -606,7 +606,25 @@
     },
     {
       "name": "Belgium",
-      "file": "reports/belgium_report.json"
+      "file": "reports/belgium_report.json",
+      "cities": [
+        {
+          "name": "Brussels",
+          "file": "reports/belgium_brussels_report.json"
+        },
+        {
+          "name": "Ghent",
+          "file": "reports/belgium_ghent_report.json"
+        },
+        {
+          "name": "Leuven",
+          "file": "reports/belgium_leuven_report.json"
+        },
+        {
+          "name": "Antwerp",
+          "file": "reports/belgium_antwerp_report.json"
+        }
+      ]
     },
     {
       "name": "Finland",

--- a/reports/belgium_antwerp_report.json
+++ b/reports/belgium_antwerp_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "BE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Port operators, insurance giants, and Cronos consultancies keep .NET demand high, mixing Dutch and English teams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Ring-road congestion and port industry push NO₂ above WHO targets, and while LEZ rules help, sensors still flag poor air on windless days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular society with residual cultural Catholicism.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Consensus coalitions, independent courts, and EU oversight keep illiberal drift minimal despite occasional nationalist rhetoric.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "SEPA/IBAN; contactless and instant payments; easy account opening with address ID.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Blankenberge and Zeeland beaches sit an hour away by train or car, so seaside escapes are regular but planned events.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Outpost Antwerp, board-game cafes, and multilingual clubs keep tabletop communities active and welcoming.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Regional family allowances, subsidized crèches, and income-based fees create robust support, though spots fill quickly so waitlists should be tackled before arrival.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Play streets, museums with children’s programming, and expanding school cycling plans support families despite urban density.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive monthly allowances, generous parental leave, and subsidized crèche places capped around €30 per day.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Non-EU residents enrolled in social security can access subsidies after registration, but timing varies by region and status.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Cycling, contemporary dance, climbing gyms, and maker spaces thrive, aligning with the family’s interests.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "International residents mix with long-time locals through cultural houses and school networks, though breaking into Dutch-speaking circles takes initiative.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "You must register within eight days, enroll in a mutualité, file annual Belgian taxes on worldwide income, and track integration courses if the region mandates them.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Overall costs land between Brussels and Ghent; rents and childcare require budgeting, but groceries and culture remain affordable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes—Belgium permits dual nationality.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Advanced EU economy; strong services/logistics; regional differences.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Social market economy with robust safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Antwerp schools offer strong arts, STEM, and multilingual tracks, though quality varies by network and requires research.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Available via Single Permit/EU Blue Card; larger firms and consultancies sponsor.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Antwerp blends Scheldt river promenades, green lungs like Park Spoor Noord, and dense port industry; urban greening projects soften the logistics-heavy landscape.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Mid-to-high effective rates depending on income/region; benefits offset for families.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn shifts from 18 °C (64 °F) highs in September to around 10 °C (50 °F) by November with breezy rains off the Scheldt.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Parks, zoo memberships, and cultural passes keep kids busy, though traffic-heavy boulevards require careful route planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouse/partner/dependents eligible under reunification rules; documentation required.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Parental leave allowances, family allowances, subsidized childcare; varies by region/employer.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "National frameworks broadly supportive; specifics vary by employer and regional delivery.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Residents with social security contributions access many supports; exact eligibility depends on status/region.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Practical chic; minimalist to casual; layered for weather.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart-casual with cycling/outdoor practicality; layers and quality footwear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Modern European fashion; weather-aware layering; practical chic.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Antwerp hosts VR and racing specialists like Cybernetic Walrus alongside Cronos’ game studios, offering steady though mid-sized hiring.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition; social acceptance rising in cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Strong legal protections and EU alignment.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Increasingly egalitarian; high female workforce participation; policy supports.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Commune registration, health insurance, bank/lease proofs; driver licence exchange; language admin in Dutch/French.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Increasing heatwaves and rainfall extremes; localized river/coastal flood risk; mitigation ongoing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Compulsory mutualité insurance reimburses 60–75% of costs and pediatric specialists are easy to access, with modest co-pays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Once registered, visa holders join the same mutualité system; newcomers often carry private insurance for the first months until residence paperwork clears.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Domestic tuition at public universities; grants/loans; strong networks in Leuven/Brussels/Ghent/Liege.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International tuition for most temporary visas; scholarships limited; improves with long-term residence/EU status.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Renovated townhouses and new-build flats run €1,400–€1,700, with energy upgrades required under tightening Flemish codes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "PAYE for employees; annual returns; progressive tax with social contributions; complex but well-documented.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Free public K-12; zoning applies; quality varies by network/region; strong language education.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children generally enroll in public schools; language support available; documentation required.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English is common in port, fashion, and hospitality jobs, but Dutch remains the default for paperwork and schooling.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Antwerp Pride, queer sports clubs, and active anti-discrimination enforcement create a welcoming scene for diverse families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Limited mainstream; present in academic/activist circles.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Smart-casual; focus on practicality and cycling/outdoor wear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "The Beacon tech hub, Start it @KBC, and creative clusters along Eilandje host frequent meetups for founders and developers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Statutory minimum wage with sectoral agreements; uprated periodically.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Port-driven investment keeps fiber, logistics tech, and public works modern, despite construction disruptions from the Oosterweel project.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Hobokense Polder wetlands, Middelheim sculpture park, and river ferries to Sint-Anneke strand add nature breaks amid the port skyline.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Low seismic risk; main hazards are floods, windstorms, and heatwaves.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Scheldt ferries to green left-bank suburbs, Rivierenhof park, and quick trains to Kempen forests keep nature within reach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "DeSingel, Sportpaleis, and Jazz Middelheim bring global acts alongside indie venues, giving constant live music choices.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Fashion bars, jazz clubs, and late-night dining make evenings lively; night buses and shared bikes cover the last mile.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "The Beacon, Cronos Game Lab meetups, and Flanders Game Hub partnerships connect developers across the port city.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Cybernetic Walrus (Antigraviator), MoonMonster Studios, and Polygoat highlight the city’s creative tech output.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Start it @KBC, City of Antwerp innovation grants, and Cronos game funds give Trey capital and mentors without leaving town.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "The port keeps weekdays brisk and traffic heavy, so families pick quieter districts like Zurenborg or Berchem for balance.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Balanced; extracurriculars common; emphasis on languages/sports.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Typically 5 years of legal residence plus integration and language proof.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Low by international standards; strong oversight.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Federal parliamentary monarchy with regional governments; complex but stable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Queer-friendly venues and private socials exist, yet mainstream workplaces stay discreet, so openness depends on chosen circles.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "City crèches and private daycare spots are subsidized yet fill quickly, so parents join waitlists early and lean on parental leave bridges.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Antwerp International School, St. Michael’s College, and nearby European School Mol offer English-language programs, though fees and commutes require planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "While city hall leans nationalist, grassroots groups push progressive mobility, climate, and housing agendas that often shape policy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Pluralistic media; state and private broadcasters; partisan framing exists.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Moderate; counterbalanced by public and independent outlets.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "De Lijn trams, pre-metro tunnels, and cross-border trains keep commutes manageable, even if construction for the Oosterweel project causes detours.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Limited direct influence; secular governance predominant.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Design studios, port tech, and media houses embraced hybrid setups, and coworking hubs like The Beacon support distributed projects.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "A-card residence permits; renewals leading to long-term residence (EU LTR).",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Pension via social insurance; adequacy depends on contributions/housing; private pillars helpful.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Eligibility/portability tied to contributions/status; bilateral treaties may help.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby gigs cluster in creative agencies and e-commerce startups; roles exist but often expect DevOps or JavaScript versatility.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Drug trafficking linked to the port raises headline risk, but day-to-day family life sees mostly petty theft; staying vigilant near transit hubs suffices.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Dutch-community schools, international programs, and arts academies offer variety; enrolment is centralised but competitive in popular districts.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "North Sea waters range from 7 °C (45 °F) in winter to about 19 °C (66 °F) late summer; short swims and wetsuits keep it fun.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Maritime air keeps temperatures moderate yet invites steady drizzle, so mild months alternate with damp spells.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Sex-positive nightlife and comprehensive health services coexist with slightly more traditional suburban sentiments.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Robust social security, healthcare, and family benefits systems.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Spring runs roughly 11–17 °C (52–63 °F) with lows near 4–8 °C (39–46 °F); showers accompany blooming quays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Stable but frequent coalition negotiations; daily life largely unaffected.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Social market economy; centrist coalitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Advanced mixed capitalist economy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summer highs hover 22–25 °C (72–77 °F) and nights 13–15 °C (55–59 °F), punctuated by the odd 30 °C (86 °F) heatwave.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing usually months; fees moderate; commune-level variation.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Moderate; coalition dynamics can lower trust during stalemates.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Low systemic corruption; occasional procurement/local issues.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Logistics, diamond, and media firms offer €52k–€68k packages, with port allowances and meal vouchers balancing city costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends feature MAS museum visits, ferry rides, bike loops along the Scheldt, and day trips to coastal dunes or nearby Dutch towns.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run 8:30–15:30 with extended opvang to 18:00; port employers may start earlier, so remote flexibility helps coordinate pickups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Legal minimum ~20 days for full-time plus public holidays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Often 25-30+ including seniority/sectoral additions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Positive/pragmatic engagement with NL/FR/DE/LU/UK.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Pragmatic, multilingual, community-focused, European.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Seen as cooperative EU partner; Brussels as administrative hub.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Single Permit and EU Blue Card routes hinge on employer sponsorship and salary thresholds; self-employed visas demand business plans reviewed by regional authorities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "International schools and port employers assist newcomers, yet Dutch integration courses remain mandatory to feel fully included.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Fashion academies, the diamond district, and the MAS museum’s global stories keep Antwerp full of discoveries.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters stay 1–6 °C (34–43 °F) with damp chill; snow is rare but freezing fog appears along the river.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Typically around 38 hours; flex/time-credit schemes exist.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "A 38-hour cap, time-credit schemes, and five-plus weeks of leave help Sarah maintain calmer rhythms, though bilingual offices can stretch meetings across time zones.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong protections, collective bargaining, workplace safety; unions influential.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/belgium_brussels_report.json
+++ b/reports/belgium_brussels_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "BE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "EU bodies, NATO contractors, and Belgian banks keep .NET shops hiring; multilingual consultancies line the EU quarter and expect security clearance but steady project pipelines.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Nitrogen dioxide remains elevated along the Petite Ceinture and tunnel approaches, and while the capital’s low-emission zone is phasing out older diesels, average PM2.5 still hovers in the mid-teens—better than many US metros but not pristine.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular society with residual cultural Catholicism.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Consensus coalitions, independent courts, and EU oversight keep illiberal drift minimal despite occasional nationalist rhetoric.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "SEPA/IBAN; contactless and instant payments; easy account opening with address ID.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Family beach days mean a 75–90 minute train to Ostend or De Panne: spotless boardwalks, dunes, and lifeguards await, but spontaneity gives way to planned excursions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Cafés like La Luck and Outpost host weekly board-game nights, and multilingual clubs welcome newcomers without gatekeeping.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Regional family allowances, subsidized crèches, and income-based fees create robust support, though spots fill quickly so waitlists should be tackled before arrival.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Compact neighborhoods, safe tram stops, and libraries with bilingual story hours make daily outings manageable even without a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive monthly allowances, generous parental leave, and subsidized crèche places capped around €30 per day.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Non-EU residents enrolled in social security can access subsidies after registration, but timing varies by region and status.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Cycling, bouldering gyms, language tandems, and maker spaces are mainstream, giving Trey and Sarah quick entry points for social play.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Locals can seem reserved until you join school parent councils or neighborhood compost groups; expat associations help bridge cultures.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "You must register within eight days, enroll in a mutualité, file annual Belgian taxes on worldwide income, and track integration courses if the region mandates them.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Expect Brussels budgets to absorb high rents, €0.30+/kWh electricity, and pricey bilingual childcare, trading savings for central convenience.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes—Belgium permits dual nationality.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Advanced EU economy; strong services/logistics; regional differences.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Social market economy with robust safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Brussels’ schools deliver strong academics and language immersion, yet quality varies between networks, so parents track inspection reports closely.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Available via Single Permit/EU Blue Card; larger firms and consultancies sponsor.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Brussels balances a compact capital core with the Sonian Forest, Parc du Cinquantenaire, and commune parks, while low-emission-zone rules and bike-first streets offset—but cannot erase—the ring-road traffic and noise.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Mid-to-high effective rates depending on income/region; benefits offset for families.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September starts mild around 18 °C (64 °F) before sliding to 10 °C (50 °F) by November, with lows from 5–10 °C (41–50 °F); expect blustery rains but plenty of museum weather.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Playgrounds dot every commune, the pedestrianised center hosts constant festivals, and family passes ease entry into science museums and pools.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouse/partner/dependents eligible under reunification rules; documentation required.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Parental leave allowances, family allowances, subsidized childcare; varies by region/employer.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "National frameworks broadly supportive; specifics vary by employer and regional delivery.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Residents with social security contributions access many supports; exact eligibility depends on status/region.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Practical chic; minimalist to casual; layered for weather.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart-casual with cycling/outdoor practicality; layers and quality footwear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Modern European fashion; weather-aware layering; practical chic.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Brussels hosts indie and serious-game studios backed by screen.brussels; while AAA roles sit in Flanders, publishing, VR, and ed-tech gigs stay active here.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition; social acceptance rising in cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Strong legal protections and EU alignment.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Increasingly egalitarian; high female workforce participation; policy supports.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Commune registration, health insurance, bank/lease proofs; driver licence exchange; language admin in Dutch/French.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Increasing heatwaves and rainfall extremes; localized river/coastal flood risk; mitigation ongoing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Compulsory mutualité insurance reimburses 60–75% of costs and pediatric specialists are easy to access, with modest co-pays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Once registered, visa holders join the same mutualité system; newcomers often carry private insurance for the first months until residence paperwork clears.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Domestic tuition at public universities; grants/loans; strong networks in Leuven/Brussels/Ghent/Liege.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International tuition for most temporary visas; scholarships limited; improves with long-term residence/EU status.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family apartments in Ixelles or Etterbeek run €1,700–€2,000, leases span nine years by default, and energy retrofits raise up-front costs.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "PAYE for employees; annual returns; progressive tax with social contributions; complex but well-documented.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Free public K-12; zoning applies; quality varies by network/region; strong language education.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children generally enroll in public schools; language support available; documentation required.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English flows easily in the EU bubble and service jobs, but administration stays bilingual French/Dutch, so the family needs language classes for school and healthcare depth.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Rainbow House Brussels anchors Pride, legal protections are enforced, and gender-inclusive policies are standard across public services.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Limited mainstream; present in academic/activist circles.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Smart-casual; focus on practicality and cycling/outdoor wear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech, climate, and gaming meetups fill the calendar via BeCentral and Brussels Games Festival, ensuring regular chances to plug in.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Statutory minimum wage with sectoral agreements; uprated periodically.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber blankets most communes, tram upgrades continue, and EU-backed smart city pilots keep utilities reliable despite aging tunnels.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "The UNESCO-listed Sonian Forest, canal greenways, and easy weekend rail escapes to the Ardennes keep nature close despite Brussels’ diplomatic skyline.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Low seismic risk; main hazards are floods, windstorms, and heatwaves.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "The Sonian Forest, canal towpaths, and easy trains to the Ardennes make weekend hikes and bikepacking simple without car ownership.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Ancienne Belgique, Botanique, and countless improv venues deliver constant live music, with late trams covering the ride home.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "From Saint-Géry’s late bars to Flagey’s jazz clubs, nightlife is varied and safe with night buses and shared bikes to get home.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Screen.brussels, BeNeLux Game Devs, and regular jams at BeCentral provide mentorship pipelines and publishing contacts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like eXiin (Ary and the Secret of Seasons), Ocellus, and Serious Game Academy operate in Brussels, with Larian’s Ghent HQ a one-hour train away.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "The Brussels Region offers interactive media grants, co-financing via the tax shelter, and affordable loft studios, ideal for Trey’s indie prototypes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Commuter crush around the EU quarter and tunnel congestion keep weekdays brisk, so the family schedules decompression time in calmer communes like Ixelles or Boitsfort.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Balanced; extracurriculars common; emphasis on languages/sports.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Typically 5 years of legal residence plus integration and language proof.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Low by international standards; strong oversight.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Federal parliamentary monarchy with regional governments; complex but stable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Progressive urban circles, queer bars, and Sex-Positive Belgium meetups offer discretion-friendly community, though schools and agencies still assume monogamous paperwork.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Crèches subsidize infant care yet popular communes fill fast; families join lists during pregnancy while bridging with licensed home daycares.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International School of Brussels, European School, and St. John’s in Waterloo provide full K-12 tracks, but tuition often tops €25k and admissions favor early applicants.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalitions led by greens and socialists steer city policy on climate, cycling, and housing, even if Flemish politics pulls national debates back toward the center.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Pluralistic media; state and private broadcasters; partisan framing exists.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Moderate; counterbalanced by public and independent outlets.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "STIB’s metro, tram, and bus grid plus SNCB trains make car-free living easy; delays crop up during infrastructure works but coverage is deep.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Limited direct influence; secular governance predominant.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid has stuck: EU agencies allow two to three telework days, Belgian tech firms lean async, and coworking spaces such as Silversquare give Trey reliable desks when clients insist on downtown facetime.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "A-card residence permits; renewals leading to long-term residence (EU LTR).",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Pension via social insurance; adequacy depends on contributions/housing; private pillars helpful.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Eligibility/portability tied to contributions/status; bilateral treaties may help.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles surface inside SaaS outfits like Proxyclick or Cowboy’s platform team and a handful of civic-tech startups, often paired with JavaScript frameworks, so networking in coworking hubs matters.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Petty theft around Gare du Midi and nightlife zones means staying alert, but violent crime rates remain moderate with visible policing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Brussels mixes French- and Dutch-community schools, European Schools, and bilingual immersion tracks, but enrolment runs through lotteries and waitlists that demand early paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "North Sea water sits near 7 °C (45 °F) in winter and only warms to about 18–19 °C (64–66 °F) in late August, so wetsuits stretch the swim season beyond a brief high-summer window.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Expect a temperate but grey cycle: roughly half the year stays in the comfortable 45-70°F band, yet frequent Atlantic drizzle and overcast skies make good rain gear essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex ed and a visible sex-positive nightlife keep conversations open, though Catholic school networks remain more restrained.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Robust social security, healthcare, and family benefits systems.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March–May brings highs around 12–17 °C (54–63 °F) and lows near 4–8 °C (39–46 °F); showers linger but daylight and green spaces wake up early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Stable but frequent coalition negotiations; daily life largely unaffected.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Social market economy; centrist coalitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Advanced mixed capitalist economy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "June–August typically runs 21–24 °C (70–75 °F) by day and 12–15 °C (54–59 °F) at night, with the occasional continental heatwave spiking above 30 °C (86 °F) for a few humid days.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing usually months; fees moderate; commune-level variation.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Moderate; coalition dynamics can lower trust during stalemates.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Low systemic corruption; occasional procurement/local issues.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Brussels salaries cluster around €55k–€70k for mid-to-senior devs, with EU institutions and consultancies layering meal vouchers, transit passes, and thirteenth-month bonuses to offset higher rents.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends revolve around neighborhood markets, kid-friendly museums like Train World, and tram rides to green belts; reservations matter for blockbuster exhibits but not for parks or cafes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Primary schools run roughly 8:30–15:30, hot lunches are common, and garderie aftercare stretches to 18:00, letting both parents cover a 9–17 workday with only occasional remote pivots.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Legal minimum ~20 days for full-time plus public holidays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Often 25-30+ including seniority/sectoral additions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Positive/pragmatic engagement with NL/FR/DE/LU/UK.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Pragmatic, multilingual, community-focused, European.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Seen as cooperative EU partner; Brussels as administrative hub.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Single Permit and EU Blue Card routes hinge on employer sponsorship and salary thresholds; self-employed visas demand business plans reviewed by regional authorities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "The expat-heavy capital guides newcomers through registration in English, yet communes still expect prompt language learning and paperwork precision.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "EU politics, Art Nouveau architecture, and surreal comic culture make Brussels a constant conversation starter for the whole family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters hover near 1–7 °C (34–45 °F) with damp chill; frost and light snow pop up a few times while heavier dumps stick to the Ardennes.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Typically around 38 hours; flex/time-credit schemes exist.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "A 38-hour cap, time-credit schemes, and five-plus weeks of leave help Sarah maintain calmer rhythms, though bilingual offices can stretch meetings across time zones.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong protections, collective bargaining, workplace safety; unions influential.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/belgium_ghent_report.json
+++ b/reports/belgium_ghent_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "BE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "North Sea Port logistics firms, Cronos consultancies, and city IT teams hire .NET talent regularly, though roles skew toward hybrid Dutch-speaking environments.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "The low-emission zone and citywide cycling cut traffic fumes, though port logistics and ammonia from surrounding farms occasionally nudge PM levels upward.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular society with residual cultural Catholicism.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Consensus coalitions, independent courts, and EU oversight keep illiberal drift minimal despite occasional nationalist rhetoric.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "SEPA/IBAN; contactless and instant payments; easy account opening with address ID.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Ostend’s wide beaches sit 40 minutes by train, making day trips easy once Flemish weather cooperates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Outpost Ghent and Spellenspektakel pop-ups host multilingual tabletop nights, and local designers test prototypes publicly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Regional family allowances, subsidized crèches, and income-based fees create robust support, though spots fill quickly so waitlists should be tackled before arrival.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Traffic-calmed woonerfs, dense playground coverage, and libraries with Dutch-English events keep outings easy for small kids.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive monthly allowances, generous parental leave, and subsidized crèche places capped around €30 per day.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Non-EU residents enrolled in social security can access subsidies after registration, but timing varies by region and status.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Cycling, canal kayaking, maker spaces, and language cafes are mainstream, matching the family’s interests.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Food co-ops, repair cafes, and civic labs make it easy to meet engaged neighbors once you show up regularly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "You must register within eight days, enroll in a mutualité, file annual Belgian taxes on worldwide income, and track integration courses if the region mandates them.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Daily costs run below Brussels—three-bedroom rentals hover €1,400 and dining is modest—helping savings grow while still enjoying culture.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes—Belgium permits dual nationality.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Advanced EU economy; strong services/logistics; regional differences.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Social market economy with robust safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Flemish schools score highly on PISA metrics, and Ghent adds arts-forward programs plus bilingual support for newcomers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Available via Single Permit/EU Blue Card; larger firms and consultancies sponsor.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Ghent’s car-lite medieval core, ring of canals, and nearby Bourgoyen-Ossemeersen wetlands deliver greenery without sacrificing urban energy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Mid-to-high effective rates depending on income/region; benefits offset for families.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September remains pleasant around 18 °C (64 °F) before sliding toward 10 °C (50 °F) and lows of 5–9 °C (41–48 °F) with mist over the canals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Car-free streets, neighborhood festivals, and family programming at Vooruit make raising kids feel woven into city life.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouse/partner/dependents eligible under reunification rules; documentation required.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Parental leave allowances, family allowances, subsidized childcare; varies by region/employer.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "National frameworks broadly supportive; specifics vary by employer and regional delivery.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Residents with social security contributions access many supports; exact eligibility depends on status/region.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Practical chic; minimalist to casual; layered for weather.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart-casual with cycling/outdoor practicality; layers and quality footwear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Modern European fashion; weather-aware layering; practical chic.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Ghent hosts Larian’s global HQ and multiple serious-game studios, so engineering roles span AAA RPGs, simulation, and support tech.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition; social acceptance rising in cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Strong legal protections and EU alignment.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Increasingly egalitarian; high female workforce participation; policy supports.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Commune registration, health insurance, bank/lease proofs; driver licence exchange; language admin in Dutch/French.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Increasing heatwaves and rainfall extremes; localized river/coastal flood risk; mitigation ongoing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Compulsory mutualité insurance reimburses 60–75% of costs and pediatric specialists are easy to access, with modest co-pays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Once registered, visa holders join the same mutualité system; newcomers often carry private insurance for the first months until residence paperwork clears.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Domestic tuition at public universities; grants/loans; strong networks in Leuven/Brussels/Ghent/Liege.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International tuition for most temporary visas; scholarships limited; improves with long-term residence/EU status.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Row houses and roomy apartments list around €1,400–€1,600 in family neighborhoods; competition exists but nine-year leases keep stability once secured.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "PAYE for employees; annual returns; progressive tax with social contributions; complex but well-documented.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Free public K-12; zoning applies; quality varies by network/region; strong language education.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children generally enroll in public schools; language support available; documentation required.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English proficiency is high in Ghent’s tech and student circles, yet municipal services expect Dutch, so dedicated language study smooths integration.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Ghent Pride, Casa Rosa community center, and inclusive youth work signal strong support with minimal backlash.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Limited mainstream; present in academic/activist circles.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Smart-casual; focus on practicality and cycling/outdoor wear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Hackerspace Ghent, Flanders Game Hub events, and Barcamp gather tech and creative folks weekly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Statutory minimum wage with sectoral agreements; uprated periodically.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fiber internet, district heating pilots, and ongoing tram upgrades keep infrastructure modern despite cobblestone aesthetics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Blaarmeersen recreation lake, the Leie river bends, and quick bike rides to Drongen’s meadows keep nature within pedal range.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Low seismic risk; main hazards are floods, windstorms, and heatwaves.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Bourgoyen nature reserve, the Leie cycling routes, and nearby forests like Kluisbos are simple weekend escapes by bike or train.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Arts center Vooruit, Gent Jazz, and intimate venues like Hot Club de Gand keep live music plentiful year-round.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Overpoort student bars and refined spots around Patershol keep nightlife lively yet walkable, with night buses on weekends.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Flanders Game Hub, DAE Studios meetups, and the Screenshake festival network connect developers with mentors and publishers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Larian Studios (Baldur’s Gate 3), PreviewLabs, and indie teams from Howest’s DAE alumni keep Ghent on the global radar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Flanders Game Hub’s accelerator, VAF/Gamefonds grants, and proximity to Hangar K in Kortrijk give Trey a supportive launchpad.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Cycling lanes, short commutes, and a compact center keep the rhythm relaxed even during Gentse Feesten.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Balanced; extracurriculars common; emphasis on languages/sports.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Typically 5 years of legal residence plus integration and language proof.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Low by international standards; strong oversight.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Federal parliamentary monarchy with regional governments; complex but stable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Leftist social clubs and queer-friendly bars create welcoming private circles, yet official paperwork still centers monogamous norms.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "City-run crèches and licensed onthaalouders are affordable but require early applications; Ghent offers bridging allowances if placement is delayed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International School Ghent covers primary years with small cohorts; older students often commute to Antwerp or Brussels internationals, so options are limited locally.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Green and socialist coalitions drive climate zones, social housing, and participatory budgeting, reflecting a solidly progressive city hall.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Pluralistic media; state and private broadcasters; partisan framing exists.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Moderate; counterbalanced by public and independent outlets.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "De Lijn trams and buses blanket the metro, though construction for new lines can slow commutes; trains to Brussels and Antwerp run twice hourly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Limited direct influence; secular governance predominant.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Coworking spaces like Bar d’Office and Watt Factory normalize hybrid schedules, and Ghent’s tech scene is comfortable with async collaboration.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "A-card residence permits; renewals leading to long-term residence (EU LTR).",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Pension via social insurance; adequacy depends on contributions/housing; private pillars helpful.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Eligibility/portability tied to contributions/status; bilateral treaties may help.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby appears inside SaaS outfits such as Teamleader and local agencies; opportunities exist but lean toward full-stack profiles.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Ghent stays calm with low violent crime; bike theft is the main nuisance, so good locks are mandatory.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Dutch-community schools dominate, supplemented by Steiner and international options; enrolment requires queueing through the central online system.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "North Sea surf lingers around 7 °C (45 °F) in winter and tops out near 19 °C (66 °F) in late summer—pleasant for quick dips or with wetsuits.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "North Sea breezes keep temperatures moderate but bring frequent drizzle, so half the year feels mild and the other half calls for waterproof layers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "University research centers and sex-positive education keep conversations open, though some suburban schools stay modest.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Robust social security, healthcare, and family benefits systems.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 11–17 °C (52–63 °F) highs by late spring with lows around 4–8 °C (39–46 °F); magnolias and canal walks kick in quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Stable but frequent coalition negotiations; daily life largely unaffected.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Social market economy; centrist coalitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Advanced mixed capitalist economy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Typical summer highs stay near 21–24 °C (70–75 °F) with 12–15 °C (54–59 °F) nights; heatwaves above 30 °C (86 °F) arrive a few times each season.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing usually months; fees moderate; commune-level variation.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Moderate; coalition dynamics can lower trust during stalemates.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Low systemic corruption; occasional procurement/local issues.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Scale-ups like Showpad and In The Pocket offer €50k–€65k salaries plus meal vouchers, making take-home comfortable in a mid-sized market.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends mix Blaarmeersen playgrounds, De Wereld van Kina science visits, and bike rides along the Leie, with spontaneous cafe stops easy.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run roughly 8:30–15:30 with hot lunches; naschoolse opvang aftercare bridges to 18:00 so parents can keep standard work hours.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Legal minimum ~20 days for full-time plus public holidays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Often 25-30+ including seniority/sectoral additions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Positive/pragmatic engagement with NL/FR/DE/LU/UK.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Pragmatic, multilingual, community-focused, European.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Seen as cooperative EU partner; Brussels as administrative hub.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Single Permit and EU Blue Card routes hinge on employer sponsorship and salary thresholds; self-employed visas demand business plans reviewed by regional authorities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Locals are warm once you attempt Dutch; city services help but still expect integration courses within the first year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Ghent’s blend of medieval towers, street art, and tech festivals keeps curiosity high for adults and kids alike.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters hover 1–6 °C (34–43 °F) with damp chill; frost shows up a handful of mornings and snowfall is light.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Typically around 38 hours; flex/time-credit schemes exist.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "A 38-hour cap, time-credit schemes, and five-plus weeks of leave help Sarah maintain calmer rhythms, though bilingual offices can stretch meetings across time zones.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong protections, collective bargaining, workplace safety; unions influential.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/belgium_leuven_report.json
+++ b/reports/belgium_leuven_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "BE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Hospital networks, imec partners, and regional government outsource .NET projects steadily, though many roles expect Dutch proficiency.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Lower traffic volumes and campus cycling lanes keep air quality respectable, though winter inversions can trap particulate matter briefly.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular society with residual cultural Catholicism.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Consensus coalitions, independent courts, and EU oversight keep illiberal drift minimal despite occasional nationalist rhetoric.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "SEPA/IBAN; contactless and instant payments; easy account opening with address ID.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Beach trips mean a 70–80 minute train ride to the North Sea, doable for planned weekends but not spur-of-the-moment swims.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Stores like Spellenhuis Leuven and university clubs host regular multilingual board-game nights.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Regional family allowances, subsidized crèches, and income-based fees create robust support, though spots fill quickly so waitlists should be tackled before arrival.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Compact neighborhoods, safe cycling routes, and abundant playgrounds help kids navigate easily.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive monthly allowances, generous parental leave, and subsidized crèche places capped around €30 per day.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Non-EU residents enrolled in social security can access subsidies after registration, but timing varies by region and status.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Cycling, climbing gyms, language exchanges, and brewing workshops are popular, giving the family ample hobby overlap.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighborhood festivals, MindGate volunteer projects, and school parent groups make it easy to plug into local life once you participate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "You must register within eight days, enroll in a mutualité, file annual Belgian taxes on worldwide income, and track integration courses if the region mandates them.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Living costs sit below Brussels but above rural Flanders; careful budgeting around rent and childcare keeps finances balanced.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes—Belgium permits dual nationality.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Advanced EU economy; strong services/logistics; regional differences.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Social market economy with robust safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Flemish schools here score highly, and KU Leuven partnerships feed STEM and language enrichment into the primary system.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Available via Single Permit/EU Blue Card; larger firms and consultancies sponsor.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Leuven pairs a compact university core with Heverlee Woods, Dijle river parks, and traffic-calmed streets that encourage biking.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Mid-to-high effective rates depending on income/region; benefits offset for families.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September averages 18 °C (64 °F) highs before drifting to 9–10 °C (48–50 °F) by November, with frequent misty mornings along the Dijle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Play streets, cultural passes, and KU Leuven’s family programming make parenting feel integrated into civic life.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouse/partner/dependents eligible under reunification rules; documentation required.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Parental leave allowances, family allowances, subsidized childcare; varies by region/employer.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "National frameworks broadly supportive; specifics vary by employer and regional delivery.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Residents with social security contributions access many supports; exact eligibility depends on status/region.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Practical chic; minimalist to casual; layered for weather.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart-casual with cycling/outdoor practicality; layers and quality footwear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Modern European fashion; weather-aware layering; practical chic.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Leuven’s scene is smaller but includes Happy Volcano and healthtech serious-game labs, with Brussels and Ghent roles within a 30-minute train ride.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition; social acceptance rising in cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Strong legal protections and EU alignment.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Increasingly egalitarian; high female workforce participation; policy supports.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Commune registration, health insurance, bank/lease proofs; driver licence exchange; language admin in Dutch/French.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Increasing heatwaves and rainfall extremes; localized river/coastal flood risk; mitigation ongoing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Compulsory mutualité insurance reimburses 60–75% of costs and pediatric specialists are easy to access, with modest co-pays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Once registered, visa holders join the same mutualité system; newcomers often carry private insurance for the first months until residence paperwork clears.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Domestic tuition at public universities; grants/loans; strong networks in Leuven/Brussels/Ghent/Liege.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International tuition for most temporary visas; scholarships limited; improves with long-term residence/EU status.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Student demand keeps rents near €1,400 for family flats, and competition is strongest in August, but long leases stabilize costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "PAYE for employees; annual returns; progressive tax with social contributions; complex but well-documented.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Free public K-12; zoning applies; quality varies by network/region; strong language education.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children generally enroll in public schools; language support available; documentation required.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Thanks to KU Leuven and imec, English is widely spoken in labs, cafes, and services, but official paperwork still arrives in Dutch.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Leuven Pride events, rainbow crossings, and university support services create a welcoming environment with minimal pushback.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Limited mainstream; present in academic/activist circles.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Smart-casual; focus on practicality and cycling/outdoor wear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Imec.istart, MindGate tech meetups, and language tandems provide recurring chances to meet founders and researchers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Statutory minimum wage with sectoral agreements; uprated periodically.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Smart city pilots, campus fiber, and reliable utilities keep Leuven technologically advanced despite its small size.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Heverlee and Meerdaal forests, Abbey Park, and the Hageland hills offer quick escapes with easy bike access.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Low seismic risk; main hazards are floods, windstorms, and heatwaves.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Heverlee Woods, Arenberg Park, and easy train rides to the Hageland hills put hiking and cycling on the weekend menu.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Het Depot, Leuven Jazz, and intimate venues at STUK supply steady live music without the crowds of larger cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife skews toward student bars and craft beer lounges; late buses and compact blocks keep evenings manageable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "MindGate meetups, Flanders Game Hub sessions, and university game jams connect students and professionals regularly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Happy Volcano (You Suck at Parking), LuGus Studios, and educational game teams at KU Leuven anchor the local ecosystem.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Imec.istart accelerators, Start it @KBC, and access to Flanders Game Hub mentors give Trey funding routes without relocating.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Student energy aside, Leuven runs on short commutes, extensive cycling, and relaxed cafe culture—ideal for Sarah’s slower rhythm.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Balanced; extracurriculars common; emphasis on languages/sports.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Typically 5 years of legal residence plus integration and language proof.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Low by international standards; strong oversight.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Federal parliamentary monarchy with regional governments; complex but stable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "University queer groups and private socials offer accepting spaces, yet mainstream family services remain politely curious rather than affirming.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "City crèches and university-affiliated daycare offer quality care with income-based fees, though waitlists run several months.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International School Leuven serves primary grades, while the British School of Brussels and European School are 30 minutes away, giving bilingual pathways at premium fees.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Green and liberal coalitions push climate targets, bike infrastructure, and inclusive housing policy, keeping the city’s politics progressive.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Pluralistic media; state and private broadcasters; partisan framing exists.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Moderate; counterbalanced by public and independent outlets.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "De Lijn buses plus a frequent IC train to Brussels and Antwerp keep the family mobile, though buses thin out late at night.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Limited direct influence; secular governance predominant.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "University and research employers embrace hybrid norms, and coworking spaces such as Leuven MindGate support distributed teams.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "A-card residence permits; renewals leading to long-term residence (EU LTR).",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Pension via social insurance; adequacy depends on contributions/housing; private pillars helpful.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Eligibility/portability tied to contributions/status; bilateral treaties may help.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby appears in niche SaaS outfits like Happy Volcano’s backend or university ventures; openings are infrequent and usually demand polyglot skills.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Leuven is calm with low violent crime; main concerns are bike theft and late-night student antics.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Leuven hosts strong Dutch-community schools, Catholic and municipal networks, plus an international school; admissions still require early lottery registration.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "North Sea water runs 7 °C (45 °F) in winter and peaks near 19 °C (66 °F) late summer, so short dips or wetsuits extend enjoyment.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "The town shares Belgium’s mild-but-moist seasons: comfortable springs and autumns balanced by grey, drizzly stretches in winter.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex ed and university research normalize open conversations, even if some suburban schools keep things modest.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Robust social security, healthcare, and family benefits systems.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Daytime temperatures rise from about 10 °C (50 °F) in March to 17 °C (63 °F) in May, with cool 3–7 °C (37–45 °F) mornings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Stable but frequent coalition negotiations; daily life largely unaffected.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Social market economy; centrist coalitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Advanced mixed capitalist economy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summers sit near 22–24 °C (72–75 °F) with nights around 12–14 °C (54–57 °F); occasional heat spikes above 30 °C (86 °F) prompt fans rather than A/C.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing usually months; fees moderate; commune-level variation.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Moderate; coalition dynamics can lower trust during stalemates.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Low systemic corruption; occasional procurement/local issues.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Local employers—imec spinoffs, KU Leuven labs, and healthtech scale-ups—pay around €48k–€60k with strong benefits but slightly lower cash than Brussels.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends revolve around farmers’ markets, Heverlee woods hikes, and family science workshops at M Leuven or Technopolis (15 minutes by train).",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools start near 8:30 and end by 15:30; afterschool opvang and university-affiliated childcare cover the late afternoon reliably.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Legal minimum ~20 days for full-time plus public holidays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Often 25-30+ including seniority/sectoral additions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Positive/pragmatic engagement with NL/FR/DE/LU/UK.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Pragmatic, multilingual, community-focused, European.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Seen as cooperative EU partner; Brussels as administrative hub.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Single Permit and EU Blue Card routes hinge on employer sponsorship and salary thresholds; self-employed visas demand business plans reviewed by regional authorities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "University international desks smooth registration in English, though integration courses still require Dutch study.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Medieval colleges, cutting-edge nanotech labs, and Belgian beer heritage create endless talking points for curious kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect 1–6 °C (34–43 °F) days and near-freezing nights; snow is light but damp chill is common.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Typically around 38 hours; flex/time-credit schemes exist.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "A 38-hour cap, time-credit schemes, and five-plus weeks of leave help Sarah maintain calmer rhythms, though bilingual offices can stretch meetings across time zones.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Strong protections, collective bargaining, workplace safety; unions influential.",
+      "alignmentValue": 8
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add city reports for Brussels, Ghent, Leuven, and Antwerp with city-specific alignment values and narratives across all evaluation keys
- tailor work, culture, services, and lifestyle scores to each city while keeping national policies aligned with the rating guides
- register the new city reports under Belgium in `main.json`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e33e6fca3483219f5182d404fd7bad