### PR TITLE
Add migration reports for major US cities

### DIFF
--- a/main.json
+++ b/main.json
@@ -541,6 +541,30 @@
         {
           "name": "Austin",
           "file": "reports/united_states_austin_report.json"
+        },
+        {
+          "name": "New York",
+          "file": "reports/united_states_new_york_report.json"
+        },
+        {
+          "name": "Chicago",
+          "file": "reports/united_states_chicago_report.json"
+        },
+        {
+          "name": "Salt Lake City",
+          "file": "reports/united_states_salt_lake_city_report.json"
+        },
+        {
+          "name": "Las Vegas",
+          "file": "reports/united_states_las_vegas_report.json"
+        },
+        {
+          "name": "San Francisco",
+          "file": "reports/united_states_san_francisco_report.json"
+        },
+        {
+          "name": "San Diego",
+          "file": "reports/united_states_san_diego_report.json"
         }
       ]
     },

--- a/reports/united_states_chicago_report.json
+++ b/reports/united_states_chicago_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "US",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentValue": 5,
+      "alignmentText": "The lakefront park system, riverwalk, and neighborhood greenways provide regular outdoor relief, though industry and winter road salt impact overall quality."
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentValue": 5,
+      "alignmentText": "Warming boosts heat waves and heavy rainstorms but inland geography avoids sea-level rise, keeping risk moderate with basement flood vigilance."
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentValue": 4,
+      "alignmentText": "Chicago delivers dramatic seasonal swings—glorious springs and falls sandwiched between humid summers and frigid, windy winters."
+    },
+    {
+      "key": "Air Quality",
+      "alignmentValue": 5,
+      "alignmentText": "Air has improved, yet ozone alerts and industrial corridors on the South and West Sides occasionally push PM2.5 into unhealthy territory."
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentValue": 5,
+      "alignmentText": "Severe thunderstorms, river flooding, and polar vortex cold snaps are the main threats; earthquakes and hurricanes are rare."
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentValue": 4,
+      "alignmentText": "March–May warms from 3–18 °C (37–65 °F) with unpredictable rain and late frosts that delay gardening."
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentValue": 5,
+      "alignmentText": "June–August averages 18–30 °C (65–86 °F); lake breezes cool downtown but humidity and heat indexes spike during Midwestern heat waves."
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentValue": 6,
+      "alignmentText": "September–November brings 7–21 °C (45–70 °F) days with crisp air, making it ideal for lakefront outings."
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentValue": 3,
+      "alignmentText": "Winters drop to −12–2 °C (10–35 °F), with lake-effect snow and bitter wind chills that require heavy gear and reliable heating."
+    },
+    {
+      "key": "Beach Life",
+      "alignmentValue": 6,
+      "alignmentText": "Lake Michigan beaches like North Avenue and Promontory Point offer clean sand and lifeguards in summer, though water stays cool and closes after Labor Day."
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentValue": 4,
+      "alignmentText": "Water peaks near 21 °C (70 °F) mid-summer but sits below 10 °C (50 °F) for much of the year, limiting the swim season to July–August."
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentValue": 6,
+      "alignmentText": "The lakefront trail, forest preserves, and nearby state parks provide ample biking and hiking, though drives are needed for more rugged terrain."
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentValue": 7,
+      "alignmentText": "Chicago’s $15.80+ city minimum and stronger enforcement elevate baseline wages, though inflation erodes purchasing power."
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentValue": 7,
+      "alignmentText": "Big employers like Google, Salesforce, and trading firms offer $140k–$190k packages; compensation trails the coasts but remains strong."
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentValue": 8,
+      "alignmentText": "Financial trading, manufacturing, and insurance firms rely on Microsoft stacks, sustaining robust demand for experienced developers."
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentValue": 6,
+      "alignmentText": "Rails shops and startups operate in the West Loop and River North, yet demand is thinner than JavaScript or Python roles."
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentValue": 6,
+      "alignmentText": "Major consultancies and tech firms sponsor visas, but fewer headquarters than New York mean competition for sponsorship slots."
+    },
+    {
+      "key": "Economic Health",
+      "alignmentValue": 6,
+      "alignmentText": "A diversified economy spans finance, logistics, and healthcare, offsetting fiscal stress from pension obligations and population stagnation."
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentValue": 7,
+      "alignmentText": "Coworking spaces, central time overlap, and a large remote workforce support hybrid arrangements, though some firms push office returns."
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentValue": 5,
+      "alignmentText": "Midwestern norms temper hustle culture, yet long commutes on Metra or the Kennedy Expressway can chip away at personal time."
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentValue": 5,
+      "alignmentText": "Standard 40-hour expectations hold, with crunch time during product launches or trading cycles."
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentValue": 3,
+      "alignmentText": "Federal leave laws remain minimal; Illinois recently added guaranteed paid leave days but coverage depends on employer size."
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentValue": 4,
+      "alignmentText": "Tech employers offer 15–20 PTO days, with easier scheduling outside summer when teams stagger travel."
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentValue": 5,
+      "alignmentText": "Downtown feels energetic, but neighborhoods like Lincoln Square and Hyde Park run at a calmer pace that suits family routines."
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentValue": 5,
+      "alignmentText": "Schools start around 8 a.m., offices 9–5, and after-school programs bridge to 6 p.m., with CTA and Metra supporting transit commutes."
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentValue": 6,
+      "alignmentText": "Weekends highlight farmers markets, museum visits, and neighborhood festivals, with manageable travel times."
+    },
+    {
+      "key": "Family Life",
+      "alignmentValue": 6,
+      "alignmentText": "Park District programming, libraries, and neighborhood block clubs support families, though winter cabin fever requires indoor planning."
+    },
+    {
+      "key": "Polyamory",
+      "alignmentValue": 5,
+      "alignmentText": "Queer and kink-friendly communities exist in neighborhoods like Rogers Park and Humboldt Park, but openness varies by social circle."
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentValue": 5,
+      "alignmentText": "Parents advocate for selective enrollment schools and extracurriculars, yet community schools and park programs keep pressure moderate."
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentValue": 6,
+      "alignmentText": "Playlots, family festivals, and car-free events are common, though crime perceptions lead some families to favor specific neighborhoods."
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentValue": 6,
+      "alignmentText": "Chicago Public Schools offer strong selective programs alongside uneven neighborhood schools; charters and Catholic schools add options."
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentValue": 5,
+      "alignmentText": "Universal pre-K expansion continues, yet supply gaps remain in certain wards and private daycare costs stay high."
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentValue": 4,
+      "alignmentText": "State subsidies assist lower-income families, but middle-income households shoulder high daycare or nanny expenses."
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentValue": 3,
+      "alignmentText": "Eligibility for subsidies can be limited, so visa holders often depend on employer stipends or private care."
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "Neighborhood enrollment is straightforward, but desired magnet or gifted seats require lotteries and testing strategies."
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "Schools enroll all resident children, though documentation proof and language support may require advocacy."
+    },
+    {
+      "key": "Private Education",
+      "alignmentValue": 5,
+      "alignmentText": "Catholic and independent schools cost $12k–$35k annually, more attainable than coastal cities but still a significant budget item."
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentValue": 5,
+      "alignmentText": "Illinois Paid Leave for All Workers and family leave laws provide job-protected time, though wage replacement depends on employer programs."
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentValue": 4,
+      "alignmentText": "Protections extend to qualifying employees, yet navigating benefits while maintaining visa status can add stress."
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "University of Illinois campuses, DePaul, Northwestern, and City Colleges offer abundant pathways with in-state tuition advantages."
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "International students find strong university options, but tuition is higher and scholarships competitive."
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentValue": 6,
+      "alignmentText": "Workplaces value dual-career households, though some corporate cultures remain male-dominated in leadership."
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentValue": 6,
+      "alignmentText": "Legal protections exist and queer communities are visible, yet inclusive facilities vary by neighborhood."
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentValue": 7,
+      "alignmentText": "State law safeguards reproductive rights and LGBTQ+ protections, aligning with progressive expectations."
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentValue": 5,
+      "alignmentText": "Professional attire trends toward polished but pragmatic looks, with less pressure for couture statements."
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentValue": 5,
+      "alignmentText": "Midwestern friendliness mixes with traditional sports culture, though creative scenes broaden expression."
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentValue": 6,
+      "alignmentText": "The blend of world-class arts, Midwest affordability, and civic activism offers rich experiences for the family."
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentValue": 9,
+      "alignmentText": "English dominates, with Spanish, Polish, and Mandarin communities adding multilingual opportunities."
+    },
+    {
+      "key": "Progressivism",
+      "alignmentValue": 6,
+      "alignmentText": "City governance is progressive on policing reform and climate, but statewide politics require compromise with moderates."
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentValue": 4,
+      "alignmentText": "Leftist organizing is visible, yet the broader civic climate leans pragmatic and market-oriented."
+    },
+    {
+      "key": "Atheism",
+      "alignmentValue": 6,
+      "alignmentText": "Secular households are common, though faith-based community work remains influential across neighborhoods."
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentValue": 6,
+      "alignmentText": "Sex-positive workshops and inclusive venues exist, yet Midwestern modesty can temper public conversations."
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentValue": 7,
+      "alignmentText": "Boystown, South Side collectives, and legal protections ensure strong support, though pockets of conservatism linger."
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentValue": 6,
+      "alignmentText": "Block clubs, neighborhood associations, and mutual aid groups foster connection, especially on the South and West Sides."
+    },
+    {
+      "key": "View of self",
+      "alignmentValue": 6,
+      "alignmentText": "Residents embrace a resilient, no-nonsense identity rooted in labor history and cultural pride."
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentValue": 6,
+      "alignmentText": "Proximity to Canada and immigrant heritage spark curiosity about global affairs without intense focus."
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentValue": 6,
+      "alignmentText": "Canadians and Midwestern neighbors view Chicago as cosmopolitan yet approachable, albeit with crime stereotypes."
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentValue": 7,
+      "alignmentText": "Jazz clubs, theater, breweries, and late-night dining thrive, though licensing laws quiet down earlier than New York."
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentValue": 6,
+      "alignmentText": "Style blends streetwear, athleisure, and office casual, allowing flexible self-expression."
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentValue": 6,
+      "alignmentText": "Layering for changing weather defines fashion, with independent designers gaining prominence."
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentValue": 6,
+      "alignmentText": "Residents enjoy lakefront biking, improv classes, sports fandom, and culinary exploration."
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentValue": 7,
+      "alignmentText": "Local game cafés like Bonus Round and robust meetup groups keep tabletop gaming lively."
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentValue": 7,
+      "alignmentText": "House music roots, blues clubs, and festival seasons deliver consistent live entertainment."
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentValue": 7,
+      "alignmentText": "1871, mHUB, and library spaces host tech, parenting, and creative meetups welcoming newcomers."
+    },
+    {
+      "key": "Nature Access",
+      "alignmentValue": 5,
+      "alignmentText": "Forest preserves and Indiana Dunes are within an hour’s drive, but car access is helpful for frequent escapes."
+    },
+    {
+      "key": "Political System",
+      "alignmentValue": 5,
+      "alignmentText": "City politics involve machine legacies and reform pushes, requiring awareness of aldermanic dynamics."
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentValue": 6,
+      "alignmentText": "Faith coalitions influence social services, yet state policy remains largely secular on core civil rights."
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentValue": 6,
+      "alignmentText": "Strong union presence and recent wins for rideshare and fast food workers improve labor leverage."
+    },
+    {
+      "key": "State Ideology",
+      "alignmentValue": 5,
+      "alignmentText": "Illinois balances progressive Chicago interests with conservative downstate voices, driving incremental policy change."
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentValue": 6,
+      "alignmentText": "Independent courts and active media watchdogs provide safeguards, though national polarization still looms."
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentValue": 5,
+      "alignmentText": "Corporate headquarters, private equity, and logistics hubs reinforce market-first economics alongside civic philanthropy."
+    },
+    {
+      "key": "Stability",
+      "alignmentValue": 6,
+      "alignmentText": "The metro weathers downturns with diverse industries, yet state pension debt and population loss require monitoring."
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentValue": 6,
+      "alignmentText": "Local news ecosystems and public radio remain strong, but national partisan media influences perceptions."
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentValue": 6,
+      "alignmentText": "Political messaging mixes reform rhetoric with tough-on-crime narratives, demanding media literacy."
+    },
+    {
+      "key": "Social Policies",
+      "alignmentValue": 6,
+      "alignmentText": "Progressive ordinances on housing and equity exist, yet implementation is uneven across wards."
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentValue": 4,
+      "alignmentText": "Residents voice skepticism about City Hall efficiency and corruption probes, even as they rely on municipal services."
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentValue": 4,
+      "alignmentText": "Historical patronage and recent bribery cases keep corruption concerns alive despite oversight reforms."
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentValue": 4,
+      "alignmentText": "Pay-to-play contracting, property tax appeals, and aldermanic power abuses are recurring issues."
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentValue": 5,
+      "alignmentText": "Compared to coastal cities, larger apartments are attainable, but rising taxes and gentrification pressure certain neighborhoods."
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentValue": 4,
+      "alignmentText": "Gun violence persists in specific areas, though targeted policing and community programs improve safety in many neighborhoods."
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "Top hospitals like Northwestern and University of Chicago offer excellent care, but navigating insurance networks is essential."
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "Employer coverage generally applies, yet out-of-pocket costs and network restrictions hit international families hard."
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentValue": 4,
+      "alignmentText": "Daycare averages $1,500–$2,000 per month; nanny shares reduce costs but require coordination."
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentValue": 5,
+      "alignmentText": "Employers increasingly offer parental leave and flex time, but benefits vary widely by company size."
+    },
+    {
+      "key": "Education",
+      "alignmentValue": 6,
+      "alignmentText": "Selective enrollment high schools and expanding STEM programs deliver strong outcomes, though district inequities remain."
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentValue": 6,
+      "alignmentText": "The CTA and Metra network enable car-light living, yet reliability dips in winter and some neighborhoods lack rapid service."
+    },
+    {
+      "key": "Economic System",
+      "alignmentValue": 4,
+      "alignmentText": "As part of the United States, Chicago experiences similar dynamics: A lightly regulated capitalist system prioritizes markets over social protections."
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentValue": 5,
+      "alignmentText": "Illinois’ flat income tax simplifies filings, but property taxes and city fees add paperwork and budgeting challenges."
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentValue": 5,
+      "alignmentText": "State income tax of 4.95% plus city sales and property taxes create an effective rate around 25–28% for dual tech incomes."
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentValue": 8,
+      "alignmentText": "Major banks, fintech startups, and contactless transit payments support frictionless finances."
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentValue": 5,
+      "alignmentText": "Housing remains cheaper than coastal peers, but childcare and property taxes narrow the affordability gap."
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentValue": 5,
+      "alignmentText": "Access to quality healthcare and cultural amenities supports aging in place if savings cover property taxes and utilities."
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentValue": 3,
+      "alignmentText": "Without Social Security access, long-term visa holders must prioritize private savings or eventual naturalization."
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, Chicago experiences similar dynamics: Diverse visa categories exist, but quotas, interviews, and sponsorship hurdles make immigration arduous for non-citizens."
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentValue": 7,
+      "alignmentText": "Chicago’s transplant culture and Midwestern friendliness make newcomers feel at home, especially in diverse neighborhoods."
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, Chicago experiences similar dynamics: Citizenship grants permanent residency rights nationwide, though state benefits depend on domicile."
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentValue": 10,
+      "alignmentText": "As part of the United States, Chicago experiences similar dynamics: Citizenship is automatic for the family and their children, eliminating naturalization concerns."
+    },
+    {
+      "key": "Family Members",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, Chicago experiences similar dynamics: Immediate relatives of citizens have streamlined sponsorship options, though backlogs affect extended family."
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentValue": 7,
+      "alignmentText": "As part of the United States, Chicago experiences similar dynamics: For citizens moves are immediate; sponsoring relatives involves fees and multi-year waits but predictable processes."
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentValue": 8,
+      "alignmentText": "As part of the United States, Chicago experiences similar dynamics: Legal compliance is straightforward for citizens, though regulated industries require diligent paperwork."
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, Chicago experiences similar dynamics: The U.S. tolerates dual citizenship, though obligations like taxes remain."
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, Chicago experiences similar dynamics: Visa holders must maintain employment, face travel restrictions, and manage complex paperwork to avoid status loss."
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentValue": 6,
+      "alignmentText": "Studios like NetherRealm, Iron Galaxy, and Jackbox offer roles, but the scene is smaller than coasts and focuses on specific niches."
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentValue": 6,
+      "alignmentText": "NetherRealm Studios, Iron Galaxy, Jackbox Games, and several VR startups anchor the local industry."
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentValue": 7,
+      "alignmentText": "IGDA Chicago, DePaul’s game program, and Bit Bash festival cultivate a collaborative developer community."
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentValue": 6,
+      "alignmentText": "Accelerators and indie showcases exist, but venture capital is thinner and founders often bootstrap or work remotely."
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentValue": 6,
+      "alignmentText": "Downtown boasts modern transit hubs and broadband, while aging roads, lead service lines, and legacy buildings require ongoing upgrades."
+    }
+  ]
+}

--- a/reports/united_states_las_vegas_report.json
+++ b/reports/united_states_las_vegas_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "US",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentValue": 4,
+      "alignmentText": "Desert landscaping, Red Rock Canyon views, and new parks add greenery, yet sprawl, heat islands, and limited tree cover reduce day-to-day environmental comfort."
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentValue": 4,
+      "alignmentText": "Extreme heat days and prolonged drought threaten water supplies despite conservation gains, while flash floods from monsoon storms remain a concern."
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentValue": 5,
+      "alignmentText": "Shoulder seasons are pleasant, summers are intensely hot, and winters are mild and sunny, aligning partially with the family’s climate goals if heat mitigation is prioritized."
+    },
+    {
+      "key": "Air Quality",
+      "alignmentValue": 5,
+      "alignmentText": "Desert dust and regional wildfire smoke occasionally spike AQI, though overall pollution remains moderate with few industrial sources."
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentValue": 5,
+      "alignmentText": "Flash flooding, extreme heat emergencies, and distant seismic risks require preparedness, but hurricanes and tornados are rare."
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentValue": 6,
+      "alignmentText": "March–May ranges 12–29 °C (55–85 °F) with low humidity and occasional windy dust events—ideal for outdoor exploration."
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentValue": 3,
+      "alignmentText": "June–August frequently exceed 38–43 °C (100–110 °F); evenings cool to 26 °C (78 °F), so activities shift to early mornings or indoors."
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentValue": 6,
+      "alignmentText": "September–November sits around 13–30 °C (55–86 °F), offering long patio seasons and pool weather without peak heat."
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "December–February stays near 4–18 °C (40–65 °F) with abundant sun and rare freezes, supporting outdoor play."
+    },
+    {
+      "key": "Beach Life",
+      "alignmentValue": 2,
+      "alignmentText": "Man-made lakes and pools dominate; real beaches require road trips to Southern California, limiting spontaneous seaside access."
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentValue": 2,
+      "alignmentText": "Lake Mead and local reservoirs warm enough for swimming mid-summer but are chilly in shoulder seasons and affected by receding water levels."
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentValue": 7,
+      "alignmentText": "Red Rock Canyon, Valley of Fire, and Mt. Charleston provide striking desert scenery within an hour, though shade and water planning are essential."
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentValue": 4,
+      "alignmentText": "Nevada’s minimum wage sits at $12/hr with modest increases; tips help hospitality workers but wage floors remain modest."
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentValue": 5,
+      "alignmentText": "Gaming, defense, and hospitality tech roles pay $110k–$150k, below major tech hubs but paired with lower taxes."
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentValue": 6,
+      "alignmentText": "Resorts, logistics firms, and defense contractors use Microsoft stacks, offering stable mid-level positions."
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentValue": 4,
+      "alignmentText": "Ruby roles are limited to select startups and remote-friendly companies, requiring national job searches."
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentValue": 4,
+      "alignmentText": "A few large casino corporations sponsor visas, but the tech ecosystem is small, leading to limited sponsorship volume."
+    },
+    {
+      "key": "Economic Health",
+      "alignmentValue": 6,
+      "alignmentText": "Tourism rebounded strongly, sports investments attract new business, and diversification into logistics and tech is underway."
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentValue": 6,
+      "alignmentText": "Many residents work remotely for out-of-state employers; coworking spaces and strong broadband support distributed teams."
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentValue": 6,
+      "alignmentText": "Shift work culture contrasts with daytime office roles, but flexible scheduling and abundant recreation help maintain balance for remote tech workers."
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentValue": 5,
+      "alignmentText": "Standard tech roles average 40–45 hours, while hospitality-driven firms may expect atypical hours during events."
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentValue": 3,
+      "alignmentText": "Nevada lacks mandated paid vacation, so benefits depend on employer policies aligned with national norms."
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentValue": 4,
+      "alignmentText": "Tech and corporate employers offer 15–18 days; hospitality roles can earn comp time based on seniority."
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentValue": 6,
+      "alignmentText": "Outside the Strip, suburban neighborhoods feel relaxed, though tourism surges can crowd infrastructure on weekends."
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentValue": 6,
+      "alignmentText": "Schools run roughly 7:30 a.m.–2 p.m.; remote roles allow midday errands before extracurriculars and evening desert walks."
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentValue": 6,
+      "alignmentText": "Families split time between hiking, splash pads, and occasional Strip shows, using early mornings or evenings to avoid heat."
+    },
+    {
+      "key": "Family Life",
+      "alignmentValue": 5,
+      "alignmentText": "New master-planned communities add parks and libraries, yet 24/7 service economy schedules complicate family routines for shift workers."
+    },
+    {
+      "key": "Polyamory",
+      "alignmentValue": 6,
+      "alignmentText": "Vegas hosts vibrant nightlife, kink, and poly communities with regular meetups, though suburban norms can be conservative."
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentValue": 5,
+      "alignmentText": "Parent groups value involvement but are less competitive than coastal metros, focusing on keeping kids active and safe."
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentValue": 5,
+      "alignmentText": "Splash pads, indoor playgrounds, and school events cater to kids, but car dependence and heat limit midday outdoor play."
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentValue": 4,
+      "alignmentText": "Clark County School District faces overcrowding and funding challenges; magnets and charters offer stronger academics with lotteries."
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentValue": 4,
+      "alignmentText": "Private daycare dominates and can be costly; state pre-K expansion is growing but not universal."
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentValue": 3,
+      "alignmentText": "Subsidies exist for qualifying families, yet middle-income households pay $1,200–$1,500 per month for quality care."
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentValue": 2,
+      "alignmentText": "Eligibility for subsidies is limited, making employer stipends or nanny shares crucial for non-citizens."
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentValue": 5,
+      "alignmentText": "Neighborhood enrollment is simple, yet families often move for better-rated schools or pursue magnet lotteries."
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "Schools accept resident children regardless of status, though documentation and immunization requirements demand preparation."
+    },
+    {
+      "key": "Private Education",
+      "alignmentValue": 4,
+      "alignmentText": "Independent and parochial schools range $10k–$18k annually; supply is growing but adds commute times."
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentValue": 3,
+      "alignmentText": "Nevada lacks statewide paid family leave; parents rely on employer PTO or unpaid FMLA protections."
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentValue": 2,
+      "alignmentText": "Without state leave programs, visa holders must negotiate private leave arrangements to maintain status and income."
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentValue": 5,
+      "alignmentText": "UNLV, UNR, and community colleges provide accessible degrees with in-state tuition and growing research programs."
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentValue": 4,
+      "alignmentText": "International tuition is higher, though hospitality and drone-tech programs offer OPT-friendly pathways."
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentValue": 5,
+      "alignmentText": "Service industry flexibility supports dual-income households, yet traditional gender expectations linger in some communities."
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentValue": 5,
+      "alignmentText": "Legal protections exist, and downtown arts districts host queer-friendly spaces, though acceptance varies in suburbs."
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentValue": 6,
+      "alignmentText": "State law protects reproductive rights and gender identity, aligning better with progressive expectations than neighboring states."
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentValue": 5,
+      "alignmentText": "Fashion swings from casual desert wear to glam nightlife outfits, allowing experimentation without constant pressure."
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentValue": 5,
+      "alignmentText": "Tourism, esports, and outdoor recreation diversify masculine norms beyond casino machismo."
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentValue": 6,
+      "alignmentText": "Access to entertainment, desert adventures, and lower taxes support entrepreneurial experimentation for Trey’s studio ideas."
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentValue": 9,
+      "alignmentText": "English dominates, with Spanish widely spoken across hospitality and community services."
+    },
+    {
+      "key": "Progressivism",
+      "alignmentValue": 5,
+      "alignmentText": "Local politics trend moderate; the city votes blue but shares governance with a purple state legislature."
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentValue": 3,
+      "alignmentText": "Labor unions influence casinos, yet broader socialist politics remain niche."
+    },
+    {
+      "key": "Atheism",
+      "alignmentValue": 6,
+      "alignmentText": "Secular lifestyles are common, and religious institutions have limited sway over local policy compared to other Western metros."
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentValue": 7,
+      "alignmentText": "Vegas’s adult entertainment industry normalizes sex-positive attitudes, though family neighborhoods keep discussions discreet."
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentValue": 6,
+      "alignmentText": "Pride events, inclusive ordinances, and LGBTQ-owned businesses create support, but suburban attitudes can be mixed."
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentValue": 5,
+      "alignmentText": "Master-planned communities host HOA events and block parties, yet transient populations can make deep friendships slower to form."
+    },
+    {
+      "key": "View of self",
+      "alignmentValue": 6,
+      "alignmentText": "Residents balance hospitality pride with efforts to grow tech and sports sectors, crafting a pragmatic civic identity."
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentValue": 5,
+      "alignmentText": "International outlook centers on tourism markets and cross-border travel to Mexico and Canada."
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentValue": 5,
+      "alignmentText": "Visitors see Vegas as entertainment-first, sometimes overlooking local family life."
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentValue": 9,
+      "alignmentText": "World-class shows, 24-hour dining, and club scenes offer endless adult entertainment options."
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentValue": 6,
+      "alignmentText": "Casual streetwear dominates by day, while nightlife encourages upscale tailoring and statement pieces."
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentValue": 7,
+      "alignmentText": "Evening wear, athleisure, and festival-inspired looks coexist, giving Sarah creative freedom."
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentValue": 6,
+      "alignmentText": "Residents embrace hiking, pool gatherings, esports, and culinary exploration beyond the Strip."
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentValue": 6,
+      "alignmentText": "Game stores like Little Shop of Magic and casino-adjacent conventions support tabletop communities."
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentValue": 8,
+      "alignmentText": "Residencies, touring acts, and local venues keep live music calendars full year-round."
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentValue": 6,
+      "alignmentText": "Tech meetups, coworking hubs, and parenting groups gather in Summerlin and Henderson, though turnover is frequent."
+    },
+    {
+      "key": "Nature Access",
+      "alignmentValue": 6,
+      "alignmentText": "Red Rock and Mount Charleston hikes are close, but shade and water logistics limit summer excursions."
+    },
+    {
+      "key": "Political System",
+      "alignmentValue": 5,
+      "alignmentText": "Clark County leans progressive but negotiates with a statewide government that swings between parties."
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentValue": 6,
+      "alignmentText": "Nevada maintains secular governance with limited religious lobbying compared to neighboring Utah or Arizona."
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentValue": 5,
+      "alignmentText": "Right-to-work laws constrain unions, but powerful culinary and hospitality unions deliver benefits and wage gains."
+    },
+    {
+      "key": "State Ideology",
+      "alignmentValue": 5,
+      "alignmentText": "Pro-business policies dominate, yet ballot initiatives and diverse voters moderate extremes."
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentValue": 6,
+      "alignmentText": "Independent courts, active unions, and competitive elections provide guardrails against democratic erosion."
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentValue": 5,
+      "alignmentText": "Low taxes and deregulation encourage entrepreneurship while sometimes underfunding social safety nets."
+    },
+    {
+      "key": "Stability",
+      "alignmentValue": 6,
+      "alignmentText": "Tourism volatility remains a risk, but new sports franchises and logistics investments broaden the economic base."
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentValue": 6,
+      "alignmentText": "Local media and alternative weeklies cover civic issues, though national partisan media still shapes narratives."
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentValue": 6,
+      "alignmentText": "Marketing emphasizes entertainment and growth, with political messaging split between pro-union and libertarian themes."
+    },
+    {
+      "key": "Social Policies",
+      "alignmentValue": 5,
+      "alignmentText": "Nevada expanded Medicaid and legalized cannabis, but housing and education investments lag rapid growth."
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentValue": 5,
+      "alignmentText": "Residents appreciate responsive city services but question state-level funding priorities and growth management."
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentValue": 5,
+      "alignmentText": "Casino regulation keeps scandals in check, yet campaign finance ties between developers and officials draw scrutiny."
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentValue": 5,
+      "alignmentText": "Concerns revolve around zoning favors, lobbying influence, and resort-driven policy decisions rather than overt bribery."
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentValue": 5,
+      "alignmentText": "New subdivisions offer modern homes, but rents and prices climb quickly and summer cooling bills add to costs."
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentValue": 4,
+      "alignmentText": "Tourist areas face property crime and occasional violence; suburban neighborhoods stay safer with standard precautions."
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentValue": 5,
+      "alignmentText": "Hospital quality has improved yet trails larger metros; complex care often requires trips to Los Angeles or Phoenix."
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentValue": 4,
+      "alignmentText": "Employer insurance is common, but plan networks can be narrow and out-of-pocket costs high for specialists."
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentValue": 3,
+      "alignmentText": "Daycare averages $1,000–$1,300 per month with long waitlists; in-home providers fill gaps for odd work schedules."
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentValue": 4,
+      "alignmentText": "Flexible remote work and extended family networks help manage childcare, but 24/7 shifts strain coordination."
+    },
+    {
+      "key": "Education",
+      "alignmentValue": 4,
+      "alignmentText": "State test scores lag national averages; reform efforts aim to boost literacy and STEM but results are uneven."
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentValue": 4,
+      "alignmentText": "RTC buses and limited BRT provide coverage, yet car dependence remains the norm and summer heat challenges walking."
+    },
+    {
+      "key": "Economic System",
+      "alignmentValue": 4,
+      "alignmentText": "As part of the United States, Las Vegas experiences similar dynamics: A lightly regulated capitalist system prioritizes markets over social protections."
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentValue": 6,
+      "alignmentText": "No state income tax simplifies filings; businesses handle sales and gaming taxes through streamlined online portals."
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentValue": 6,
+      "alignmentText": "Absence of state income tax keeps effective rates near 22–25%, though sales taxes and HOA fees add up."
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentValue": 7,
+      "alignmentText": "Major banks, online lenders, and hospitality-focused fintech make payments and small-business banking straightforward."
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentValue": 5,
+      "alignmentText": "Housing is cheaper than coastal hubs but rising quickly; utilities and transportation costs spike during extreme heat."
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "Sunshine, low taxes, and new healthcare facilities attract retirees who can manage heat and water use."
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentValue": 3,
+      "alignmentText": "Without Social Security, long-term visa holders must rely on savings or eventual naturalization to retire comfortably."
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, Las Vegas experiences similar dynamics: Diverse visa categories exist, but quotas, interviews, and sponsorship hurdles make immigration arduous for non-citizens."
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentValue": 7,
+      "alignmentText": "Relocation from California and the Midwest is common, so new arrivals find plenty of fellow transplants building community."
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, Las Vegas experiences similar dynamics: Citizenship grants permanent residency rights nationwide, though state benefits depend on domicile."
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentValue": 10,
+      "alignmentText": "As part of the United States, Las Vegas experiences similar dynamics: Citizenship is automatic for the family and their children, eliminating naturalization concerns."
+    },
+    {
+      "key": "Family Members",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, Las Vegas experiences similar dynamics: Immediate relatives of citizens have streamlined sponsorship options, though backlogs affect extended family."
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentValue": 7,
+      "alignmentText": "As part of the United States, Las Vegas experiences similar dynamics: For citizens moves are immediate; sponsoring relatives involves fees and multi-year waits but predictable processes."
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentValue": 8,
+      "alignmentText": "As part of the United States, Las Vegas experiences similar dynamics: Legal compliance is straightforward for citizens, though regulated industries require diligent paperwork."
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, Las Vegas experiences similar dynamics: The U.S. tolerates dual citizenship, though obligations like taxes remain."
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, Las Vegas experiences similar dynamics: Visa holders must maintain employment, face travel restrictions, and manage complex paperwork to avoid status loss."
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentValue": 5,
+      "alignmentText": "Esports, VR attractions, and casino game design offer roles, but AAA studios are scarce and many devs work remotely."
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentValue": 5,
+      "alignmentText": "Scientific Games, Aristocrat, and smaller VR/AR teams drive local hiring alongside esports organizations."
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentValue": 5,
+      "alignmentText": "Vegas IGDA meetups and UNLV’s game design program create a modest but enthusiastic community."
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentValue": 5,
+      "alignmentText": "Lower overhead and entertainment partnerships create niches, yet funding often comes from angel networks or remote investors."
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentValue": 6,
+      "alignmentText": "New master-planned suburbs, widespread fiber internet, and a modern airport contrast with aging water infrastructure and car-centric streets."
+    }
+  ]
+}

--- a/reports/united_states_new_york_report.json
+++ b/reports/united_states_new_york_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "US",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentValue": 4,
+      "alignmentText": "Central Park, waterfront promenades, and protected wetlands counter heavy density, but noise, traffic exhaust, and limited backyard space keep daily nature contact moderate."
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentValue": 4,
+      "alignmentText": "The city faces accelerating sea-level rise, storm surge threats like Sandy, and more frequent heat waves, so resilience projects help but don’t eliminate risk."
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentValue": 5,
+      "alignmentText": "Four true seasons deliver vibrant springs and falls, sticky summers, and chilly winters; the family must plan for humidity swings and nor’easter storms."
+    },
+    {
+      "key": "Air Quality",
+      "alignmentValue": 5,
+      "alignmentText": "Regional regulations have cut smog, yet traffic corridors and wildfire smoke plumes periodically push AQI into unhealthy ranges, making purifiers prudent."
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentValue": 4,
+      "alignmentText": "Hurricanes, nor’easters, and occasional coastal flooding combine with aging infrastructure to demand preparedness plans and renter’s insurance."
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentValue": 5,
+      "alignmentText": "Typical March–May days run 7–18 °C (45–65 °F) with frequent rain showers, great for park outings once pollen counts are managed."
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentValue": 4,
+      "alignmentText": "June–August averages 20–32 °C (68–90 °F) but humidity and heat index spikes above 35 °C (95 °F) drive reliance on air conditioning."
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentValue": 6,
+      "alignmentText": "September–November offers crisp 10–21 °C (50–70 °F) days, foliage trips upstate, and fewer storms, making it the most comfortable season."
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentValue": 4,
+      "alignmentText": "Winters hover around −3–7 °C (25–45 °F) with snowstorms and icy sidewalks that complicate stroller commutes."
+    },
+    {
+      "key": "Beach Life",
+      "alignmentValue": 5,
+      "alignmentText": "Rockaway, Coney Island, and Long Island beaches are subway or LIRR rides away, offering summer escapes albeit with crowds and chilly surf outside peak months."
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentValue": 3,
+      "alignmentText": "Atlantic water warms to ~22 °C (72 °F) briefly in late summer but sits near 10–16 °C (50–60 °F) for much of the year, limiting casual swimming."
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentValue": 6,
+      "alignmentText": "Beyond iconic skyline views, the Hudson Valley, Catskills, and state parks provide weekend hiking, though travel costs and time can add up."
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentValue": 8,
+      "alignmentText": "New York State’s $16/hr floor in the city and strong enforcement provide higher baseline wages compared to most U.S. metros."
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentValue": 8,
+      "alignmentText": "Fintech, media, and FAANG offices push senior developer salaries into the $160k–$220k range with equity, supporting the family’s earning goals."
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentValue": 8,
+      "alignmentText": "Finance, media, and enterprise teams rely heavily on .NET stacks, yielding steady openings across Midtown and Jersey City."
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentValue": 7,
+      "alignmentText": "Startups in Flatiron and Brooklyn plus legacy Rails shops keep Ruby demand solid, though competition from other languages is rising."
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentValue": 7,
+      "alignmentText": "Global banks, consultancies, and major tech firms regularly sponsor H-1B and O-1 visas, but lotteries remain competitive and legal fees high."
+    },
+    {
+      "key": "Economic Health",
+      "alignmentValue": 7,
+      "alignmentText": "A diversified metro GDP and post-pandemic recovery in tourism balance high costs and commercial real estate uncertainty."
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentValue": 8,
+      "alignmentText": "Coworking hubs, hybrid norms, and Eastern Time overlap with Europe support remote consulting and indie studio collaboration."
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentValue": 4,
+      "alignmentText": "Long commutes, competitive workplaces, and extended childcare logistics create pressure, so boundaries must be intentionally set."
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentValue": 4,
+      "alignmentText": "While statutory 40-hour weeks exist, many tech and finance roles expect 45+ hours and after-hours Slack monitoring."
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentValue": 3,
+      "alignmentText": "U.S. labor law sets no federal floor; many employers offer only 10 PTO days plus holidays without state mandates."
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentValue": 4,
+      "alignmentText": "Tech employers commonly provide 15–20 PTO days, but schedule coordination during busy release cycles is essential."
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentValue": 3,
+      "alignmentText": "Transit rush, dense neighborhoods, and 24/7 services keep energy high, which excites Trey but may fatigue Sarah’s slower preference."
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentValue": 4,
+      "alignmentText": "School runs start around 8 a.m., standard office days 9–6, and after-school pickups require coordinating subway rides or hired help."
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentValue": 5,
+      "alignmentText": "Weekends mix museum visits, park time, and neighborhood events, yet planning ahead is necessary to avoid crowds and transit delays."
+    },
+    {
+      "key": "Family Life",
+      "alignmentValue": 6,
+      "alignmentText": "Community centers, playgrounds, and cultural institutions cater to families, though space constraints demand creative living arrangements."
+    },
+    {
+      "key": "Polyamory",
+      "alignmentValue": 6,
+      "alignmentText": "Brooklyn and Manhattan host active consensual non-monogamy meetups and inclusive venues, but mainstream landlords may still have biases."
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentValue": 5,
+      "alignmentText": "Parents juggle rigorous school applications and enrichment activities; supportive networks exist but competition can feel intense."
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentValue": 5,
+      "alignmentText": "Playgrounds and car-free plazas abound, yet stroller access on older subway lines and cramped apartments challenge daily routines."
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentValue": 7,
+      "alignmentText": "Strong public magnet programs, charters, and private schools offer choice, though enrollment lotteries and tuition costs require strategy."
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentValue": 6,
+      "alignmentText": "Universal Pre-K and 3-K add coverage, yet waitlists and limited hours push families toward pricey private centers."
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentValue": 4,
+      "alignmentText": "State subsidies exist but income thresholds are tight, so middle-class families rely on private daycare or nannies."
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentValue": 3,
+      "alignmentText": "Non-citizens qualify for fewer subsidies, making employer-dependent childcare assistance important."
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "Zoned schools vary widely, but top districts and screened programs deliver excellent academics with proactive placement."
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentValue": 7,
+      "alignmentText": "Student enrollment is tied to residence regardless of status, though navigating paperwork requires persistence."
+    },
+    {
+      "key": "Private Education",
+      "alignmentValue": 5,
+      "alignmentText": "Elite private schools offer outstanding resources but charge $55k+ annually, limiting accessibility without high incomes or aid."
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentValue": 5,
+      "alignmentText": "New York State Paid Family Leave offers up to 12 weeks at partial pay, complementing employer benefits but not replacing full income."
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentValue": 4,
+      "alignmentText": "Visa holders can access state leave if employed long enough, yet immigration status anxiety and job security can complicate time off."
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "CUNY, SUNY, and private universities offer extensive programs plus in-state tuition for residents."
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "International tuition is higher but plentiful universities and optional practical training support career transitions."
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentValue": 7,
+      "alignmentText": "Professional households embrace egalitarian norms, though wage gaps persist across industries."
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentValue": 7,
+      "alignmentText": "New York’s legal protections and visible non-binary communities foster acceptance, with chosen-name policies in schools and agencies."
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentValue": 8,
+      "alignmentText": "State laws protect reproductive autonomy, LGBTQ+ rights, and gender identity, aligning with the family’s progressive values."
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentValue": 6,
+      "alignmentText": "Fashion-forward environments celebrate diverse expressions, yet corporate sectors still prize polished presentation."
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentValue": 6,
+      "alignmentText": "Creative industries and queer spaces broaden masculine norms, even as finance culture retains competitiveness."
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentValue": 7,
+      "alignmentText": "The city’s cultural density, progressive politics, and indie art scenes give the family endless inspiration and networking."
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentValue": 9,
+      "alignmentText": "English dominates daily life, while multilingual neighborhoods ease language learning for the children."
+    },
+    {
+      "key": "Progressivism",
+      "alignmentValue": 8,
+      "alignmentText": "City government and civic groups push progressive policies on housing, climate, and civil rights despite state-level negotiation."
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentValue": 5,
+      "alignmentText": "Leftist discourse thrives in academia and activism, though mainstream politics remain center-left and market-driven."
+    },
+    {
+      "key": "Atheism",
+      "alignmentValue": 7,
+      "alignmentText": "Secular life is common, and diverse faith communities coexist without dominating public policy."
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentValue": 7,
+      "alignmentText": "Sex-positive workshops, inclusive nightlife, and comprehensive sex education norms support open dialogue."
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentValue": 8,
+      "alignmentText": "New York’s Pride legacy, queer community centers, and anti-discrimination enforcement offer strong support for polyamory-positive families."
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentValue": 6,
+      "alignmentText": "Neighborhood associations and mutual aid networks foster belonging, yet transient renters can make friendships feel fleeting."
+    },
+    {
+      "key": "View of self",
+      "alignmentValue": 7,
+      "alignmentText": "Residents take pride in resilience, diversity, and hustle, shaping civic engagement and volunteerism."
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentValue": 6,
+      "alignmentText": "Global outlook is cosmopolitan, with curiosity about Canada, Latin America, and Europe through immigration ties."
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "International partners view NYC as open and influential, though U.S. politics can color perceptions."
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentValue": 9,
+      "alignmentText": "Late-night dining, Broadway, clubs, and live music run into the early morning, offering abundant adult social outlets."
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentValue": 8,
+      "alignmentText": "Menswear ranges from streetwear to tailored suits, encouraging experimentation without standing out."
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentValue": 8,
+      "alignmentText": "Women mix high fashion with practical layering; inclusive sizing and avant-garde designers abound."
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentValue": 7,
+      "alignmentText": "Residents embrace fitness studios, art classes, urban gardening, and esports lounges accessible by transit."
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentValue": 8,
+      "alignmentText": "Stores like Hex & Company and numerous meetup groups sustain a thriving tabletop community year-round."
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentValue": 9,
+      "alignmentText": "From jazz basements to arena shows, the live music scene is nonstop, making date nights easy to plan."
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentValue": 8,
+      "alignmentText": "Tech, parenting, and polyamory meetups populate coworking spaces and bars, easing newcomer integration."
+    },
+    {
+      "key": "Nature Access",
+      "alignmentValue": 5,
+      "alignmentText": "Prospect Park, the High Line, and weekend Metro-North rides give regular green breaks, though escaping the city requires planning."
+    },
+    {
+      "key": "Political System",
+      "alignmentValue": 6,
+      "alignmentText": "City politics skew progressive yet operate within New York State’s complex machine, requiring civic literacy to navigate."
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentValue": 7,
+      "alignmentText": "Secular governance dominates, with faith groups contributing to social services rather than legislation."
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentValue": 7,
+      "alignmentText": "Strong unions, just-cause protections for fast food workers, and salary transparency laws bolster employee leverage."
+    },
+    {
+      "key": "State Ideology",
+      "alignmentValue": 6,
+      "alignmentText": "New York combines progressive urban policies with moderate statewide coalitions, producing negotiation-heavy governance."
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentValue": 6,
+      "alignmentText": "Independent judiciary and active civil society keep checks in place, though national polarization remains a concern."
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentValue": 5,
+      "alignmentText": "High cost of living and wealth inequality coexist with vibrant entrepreneurship, demanding mindful budgeting."
+    },
+    {
+      "key": "Stability",
+      "alignmentValue": 7,
+      "alignmentText": "Diversified industries and robust institutions provide resilience despite budget debates and housing pressures."
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentValue": 6,
+      "alignmentText": "Media literacy is high with abundant independent outlets, yet sensational tabloids and algorithmic feeds require discernment."
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentValue": 6,
+      "alignmentText": "Political messaging spans progressive advocacy to national partisan echo chambers, so the family must curate information sources."
+    },
+    {
+      "key": "Social Policies",
+      "alignmentValue": 7,
+      "alignmentText": "The city advances sanctuary protections, rental assistance, and expanded healthcare access relative to most U.S. metros."
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentValue": 5,
+      "alignmentText": "Residents respect public services but express skepticism about bureaucracy, corruption probes, and subway reliability."
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentValue": 5,
+      "alignmentText": "Investigations into campaign fundraising and real estate dealings surface regularly, though reforms continue."
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentValue": 5,
+      "alignmentText": "Pay-to-play zoning, patronage, and misused nonprofit funds surface occasionally, necessitating civic vigilance."
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentValue": 3,
+      "alignmentText": "Sky-high rents, co-op boards, and limited family-sized units demand significant income or outer-borough compromises."
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentValue": 5,
+      "alignmentText": "Violent crime remains below 1990s levels, yet subway incidents and petty theft spikes require street smarts."
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "World-class hospitals and employer insurance networks offer excellent care, albeit with long wait times for specialists."
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "Access depends on employer coverage; uninsured care is costly but NYC Care and safety-net hospitals provide options."
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentValue": 4,
+      "alignmentText": "Daycare averages $2,000+ per month and nanny wages are high, but subsidies exist for qualifying families."
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentValue": 5,
+      "alignmentText": "Employer-paid leave varies; families rely on flex schedules, extended kin, or cooperative nanny shares to cope."
+    },
+    {
+      "key": "Education",
+      "alignmentValue": 7,
+      "alignmentText": "Top-tier public and private schools provide strong academic outcomes, though navigating admissions is intense."
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentValue": 8,
+      "alignmentText": "The subway, buses, and commuter rails offer car-free living despite occasional delays and accessibility gaps."
+    },
+    {
+      "key": "Economic System",
+      "alignmentValue": 4,
+      "alignmentText": "As part of the United States, New York experiences similar dynamics: A lightly regulated capitalist system prioritizes markets over social protections."
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentValue": 4,
+      "alignmentText": "NYC residents juggle federal, state, and city taxes; online portals help but quarterly payments and local surcharges add complexity."
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentValue": 4,
+      "alignmentText": "High earners in the city face combined marginal rates near 35% when factoring city income tax and elevated property levies."
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentValue": 8,
+      "alignmentText": "Global banks, fintech apps, and abundant credit options support entrepreneurial ventures and daily transactions."
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentValue": 3,
+      "alignmentText": "Housing, childcare, and dining push budgets far above national averages, demanding high salaries to stay comfortable."
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentValue": 4,
+      "alignmentText": "Public transit and healthcare access support aging in place, but retirees need substantial savings or a downsized borough move."
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentValue": 3,
+      "alignmentText": "Non-citizens must rely on employer savings plans and personal investments to offset high living costs in retirement."
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, New York experiences similar dynamics: Diverse visa categories exist, but quotas, interviews, and sponsorship hurdles make immigration arduous for non-citizens."
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentValue": 7,
+      "alignmentText": "Transplants from across the country are common, and the city’s diversity makes Midwestern arrivals feel typical rather than exotic."
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, New York experiences similar dynamics: Citizenship grants permanent residency rights nationwide, though state benefits depend on domicile."
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentValue": 10,
+      "alignmentText": "As part of the United States, New York experiences similar dynamics: Citizenship is automatic for the family and their children, eliminating naturalization concerns."
+    },
+    {
+      "key": "Family Members",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, New York experiences similar dynamics: Immediate relatives of citizens have streamlined sponsorship options, though backlogs affect extended family."
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentValue": 7,
+      "alignmentText": "As part of the United States, New York experiences similar dynamics: For citizens moves are immediate; sponsoring relatives involves fees and multi-year waits but predictable processes."
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentValue": 8,
+      "alignmentText": "As part of the United States, New York experiences similar dynamics: Legal compliance is straightforward for citizens, though regulated industries require diligent paperwork."
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, New York experiences similar dynamics: The U.S. tolerates dual citizenship, though obligations like taxes remain."
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, New York experiences similar dynamics: Visa holders must maintain employment, face travel restrictions, and manage complex paperwork to avoid status loss."
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentValue": 8,
+      "alignmentText": "Large publishers, media companies, and VR studios like Rockstar, Take-Two, and Resolution Games keep game dev hiring active."
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentValue": 8,
+      "alignmentText": "Rockstar Games, Take-Two Interactive, Avalanche Studios, and numerous indie teams operate across Manhattan and Brooklyn."
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentValue": 8,
+      "alignmentText": "NYC Gamedev Meetups, Playcrafting, and NYU Game Center events create frequent collaboration opportunities."
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentValue": 7,
+      "alignmentText": "Access to venture capital, incubators like NYU Game Center Incubator, and talent pipelines support studios, though costs are high."
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentValue": 7,
+      "alignmentText": "Reliable subways, broadband competition, and smart-city pilots coexist with aging public housing and occasional service disruptions."
+    }
+  ]
+}

--- a/reports/united_states_salt_lake_city_report.json
+++ b/reports/united_states_salt_lake_city_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "US",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentValue": 7,
+      "alignmentText": "Mountain vistas, access to the Wasatch foothills, and an extensive parks network deliver daily nature, though the valley inversion layer requires winter air alerts."
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentValue": 5,
+      "alignmentText": "Rising temperatures intensify drought and wildfire smoke, while Great Salt Lake shrinkage threatens dust storms, yet the area avoids hurricanes and sea-level rise."
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentValue": 6,
+      "alignmentText": "Dry summers, snowy winters, and shoulder seasons that shift quickly make for a varied but generally sunny climate aligned with the family’s mild-weather goals."
+    },
+    {
+      "key": "Air Quality",
+      "alignmentValue": 4,
+      "alignmentText": "Winter inversions trap particulates and summer wildfire smoke drifts in, prompting regular mask or purifier use despite clean days between events."
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentValue": 5,
+      "alignmentText": "Earthquake risk from the Wasatch Fault and wildfire evacuations coexist with robust emergency planning and building codes."
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentValue": 6,
+      "alignmentText": "March–May swings from 5–22 °C (41–72 °F) with rapid warm-ups and late snow squalls, ideal for early hikes when storms are monitored."
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentValue": 6,
+      "alignmentText": "June–August averages 15–33 °C (60–92 °F) with low humidity; occasional heat waves above 38 °C (100 °F) are mitigated by cool desert nights."
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "September–November brings crisp 5–24 °C (41–75 °F) days, golden aspens, and comfortable outdoor conditions."
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentValue": 5,
+      "alignmentText": "Temperatures hover between −5–6 °C (23–43 °F); snow days are frequent but manageable with good gear and transit planning."
+    },
+    {
+      "key": "Beach Life",
+      "alignmentValue": 3,
+      "alignmentText": "Nearby reservoirs and the Great Salt Lake offer limited swimming due to cold water and salinity; families rely on pools or short trips to Bear Lake for beach days."
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentValue": 2,
+      "alignmentText": "Most lakes remain below 20 °C (68 °F) even in summer, and the Great Salt Lake is often cooler, limiting enjoyable swim windows."
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentValue": 9,
+      "alignmentText": "Minutes to canyons, national parks within a few hours, and world-class skiing deliver exceptional outdoor scenery for weekend adventures."
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentValue": 3,
+      "alignmentText": "Utah follows the federal $7.25/hr rate, leaving low-wage workers reliant on tight labor markets rather than policy."
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentValue": 6,
+      "alignmentText": "Growing tech firms along the Silicon Slopes corridor offer $120k–$160k packages, below coastal levels but coupled with lower taxes."
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentValue": 8,
+      "alignmentText": "Microsoft ecosystems dominate enterprise and church-affiliated organizations, keeping .NET roles plentiful."
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentValue": 5,
+      "alignmentText": "Ruby shops exist among startups, yet the market favors JavaScript, Java, and .NET, so opportunities require networking."
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentValue": 4,
+      "alignmentText": "Some large tech companies sponsor visas, but overall volume is limited; many firms prefer citizens or permanent residents."
+    },
+    {
+      "key": "Economic Health",
+      "alignmentValue": 7,
+      "alignmentText": "A booming tech sector, low unemployment, and steady population growth fuel economic resilience despite housing pressures."
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentValue": 7,
+      "alignmentText": "Remote work is common in the tech corridor, with coworking spaces and time zone alignment that eases collaboration with both coasts."
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentValue": 7,
+      "alignmentText": "Outdoor culture and family-centric employers encourage flexible schedules, though crunch time can appear in high-growth startups."
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentValue": 6,
+      "alignmentText": "Most roles respect 40-hour weeks, yet startup teams occasionally push longer hours during product launches."
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentValue": 3,
+      "alignmentText": "Federal norms apply; Utah law does not mandate paid vacation, so benefits depend on employer generosity."
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentValue": 5,
+      "alignmentText": "Tech employers often offer 15–20 days plus flexible remote options, making time off easier to schedule outside ski season."
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentValue": 7,
+      "alignmentText": "Downtown remains relaxed compared to coastal metros, and suburbs offer quiet neighborhoods with easy commutes."
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentValue": 6,
+      "alignmentText": "Schools start around 8 a.m., office hours 9–5, and after-school programs or outdoor activities fill late afternoons."
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentValue": 7,
+      "alignmentText": "Weekends feature hiking, skiing, farmers markets, and community events that wrap early, fitting family routines."
+    },
+    {
+      "key": "Family Life",
+      "alignmentValue": 7,
+      "alignmentText": "Large families are common, parks are plentiful, and recreation centers support kid-friendly outings year-round."
+    },
+    {
+      "key": "Polyamory",
+      "alignmentValue": 4,
+      "alignmentText": "While there are poly-friendly groups and decriminalized cohabitation, prevailing conservative norms mean discretion is often necessary."
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentValue": 6,
+      "alignmentText": "Parent involvement in schools and extracurriculars is high, yet community support networks help share responsibilities."
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentValue": 7,
+      "alignmentText": "Safe neighborhoods, nature access, and family-focused amenities make daily life easy for children, aside from inversion pollution days."
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentValue": 6,
+      "alignmentText": "Public schools range from solid to excellent in suburbs, with charter and dual-immersion programs expanding choice."
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentValue": 4,
+      "alignmentText": "Availability lags demand and full-day programs can be scarce, pushing families to coordinate part-time care or relatives."
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentValue": 3,
+      "alignmentText": "State subsidies focus on lower-income households, leaving middle-income families to pay rising daycare rates."
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentValue": 2,
+      "alignmentText": "Access to subsidies is limited for non-citizens, so employer benefits or private arrangements become essential."
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "Enrollment is straightforward with neighborhood assignment, though magnet options require early planning."
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "Districts enroll resident children regardless of status, but paperwork and cultural acclimation may need advocacy."
+    },
+    {
+      "key": "Private Education",
+      "alignmentValue": 4,
+      "alignmentText": "Religious and independent schools cost $8k–$15k annually, offering alternative pedagogy but adding expense."
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentValue": 3,
+      "alignmentText": "Utah offers limited paid family leave; many families rely on short-term disability and accrued PTO for births or adoption."
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentValue": 2,
+      "alignmentText": "Without mandated leave, visa holders depend heavily on employer generosity and risk job insecurity during extended absences."
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "The University of Utah and regional colleges provide quality options with in-state tuition for residents."
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "International tuition is higher, but OPT pipelines and tech internships support longer-term prospects."
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentValue": 4,
+      "alignmentText": "Traditional gender norms remain influential, particularly in faith communities, though urban professionals push for parity."
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentValue": 4,
+      "alignmentText": "Legal protections exist, yet public comfort with non-binary identities varies, and rural areas can feel less accepting."
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentValue": 5,
+      "alignmentText": "Reproductive rights are constrained by state policy debates, but anti-discrimination laws still protect LGBTQ+ residents in housing and employment."
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentValue": 4,
+      "alignmentText": "Expectations tilt toward modest dress in many communities, though downtown scenes showcase broader expression."
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentValue": 5,
+      "alignmentText": "Outdoor recreation culture broadens masculinity beyond corporate roles, but conservative values shape social expectations."
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentValue": 6,
+      "alignmentText": "Access to national parks, a supportive indie tech scene, and manageable costs make the city appealing despite cultural conservatism."
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentValue": 9,
+      "alignmentText": "English dominates; Spanish-speaking communities are growing and offer bilingual opportunities for the children."
+    },
+    {
+      "key": "Progressivism",
+      "alignmentValue": 4,
+      "alignmentText": "Local politics lean moderate-conservative, with progressive gains mostly inside Salt Lake City proper."
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentValue": 3,
+      "alignmentText": "Leftist politics exist on university campuses but remain niche in mainstream civic discourse."
+    },
+    {
+      "key": "Atheism",
+      "alignmentValue": 4,
+      "alignmentText": "Secular residents are increasing, yet LDS influence permeates culture and expectations, requiring navigation for nonreligious families."
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentValue": 4,
+      "alignmentText": "Sex education is improving but still conservative; sex-positive communities exist but are discreet."
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentValue": 5,
+      "alignmentText": "Salt Lake City has visible queer communities and Pride events, though statewide attitudes remain mixed."
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentValue": 6,
+      "alignmentText": "Neighborhood councils, outdoor clubs, and maker spaces foster friendships, especially among transplants."
+    },
+    {
+      "key": "View of self",
+      "alignmentValue": 6,
+      "alignmentText": "Residents balance pride in outdoor lifestyles with civic goals to diversify the economy beyond the church."
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentValue": 5,
+      "alignmentText": "Interest in global affairs is modest, though missionary experiences create international awareness in many households."
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentValue": 6,
+      "alignmentText": "Canadians and international partners see Utah as friendly but conservative, noting its outdoor tourism draw."
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentValue": 4,
+      "alignmentText": "Bars close early, alcohol laws remain restrictive, and nightlife is modest compared to larger metros."
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentValue": 4,
+      "alignmentText": "Casual outdoor wear and business-casual styles dominate, with limited avant-garde scenes."
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentValue": 4,
+      "alignmentText": "Functional layering and modest trends prevail, though urban districts see more expressive fashion."
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentValue": 7,
+      "alignmentText": "Hiking, skiing, climbing gyms, and maker spaces are mainstream hobbies that align with the family’s interests."
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentValue": 6,
+      "alignmentText": "Game stores and convention events like SaltCON support tabletop play, though scenes are smaller than coastal cities."
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentValue": 5,
+      "alignmentText": "Local music venues and breweries provide entertainment, but major tours skip the city more than Denver or Seattle."
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentValue": 7,
+      "alignmentText": "Silicon Slopes events, tech meetups, and parenting groups welcome newcomers and foster collaboration."
+    },
+    {
+      "key": "Nature Access",
+      "alignmentValue": 9,
+      "alignmentText": "Trailheads start within 15 minutes of downtown, and ski resorts are a short drive, making spontaneous outdoor adventures easy."
+    },
+    {
+      "key": "Political System",
+      "alignmentValue": 4,
+      "alignmentText": "State government is dominated by conservatives, while the city leans progressive, creating policy friction on social issues."
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentValue": 3,
+      "alignmentText": "LDS leadership influences legislation on alcohol, education, and reproductive policy, requiring secular families to stay informed."
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentValue": 4,
+      "alignmentText": "Right-to-work laws and limited union presence reduce worker leverage, though tech talent demand raises wages."
+    },
+    {
+      "key": "State Ideology",
+      "alignmentValue": 4,
+      "alignmentText": "Utah prioritizes pro-business regulation and traditional values, pushing progressive reforms to local initiatives."
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentValue": 6,
+      "alignmentText": "Institutions remain stable with active civic groups, though one-party dominance and gerrymandering merit monitoring."
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentValue": 6,
+      "alignmentText": "A pro-business climate, low taxes, and startup support attract investment but can underfund social safety nets."
+    },
+    {
+      "key": "Stability",
+      "alignmentValue": 7,
+      "alignmentText": "Population growth and fiscal surpluses keep budgets healthy, offsetting concerns about water scarcity and housing costs."
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentValue": 5,
+      "alignmentText": "Statewide media is relatively balanced, yet church-owned outlets and conservative talk radio influence narratives."
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentValue": 5,
+      "alignmentText": "Messaging emphasizes family values and growth, with progressive counterpoints mostly concentrated in city media."
+    },
+    {
+      "key": "Social Policies",
+      "alignmentValue": 4,
+      "alignmentText": "Medicaid expansion and housing initiatives exist, but social services remain lean compared to progressive states."
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentValue": 6,
+      "alignmentText": "Residents generally trust local officials, with high civic engagement in city government despite state-level disagreements."
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentValue": 6,
+      "alignmentText": "Corruption cases are rare, and transparency laws keep most dealings in public view."
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentValue": 6,
+      "alignmentText": "Issues tend toward conflicts of interest or lobbying influence rather than overt bribery."
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentValue": 6,
+      "alignmentText": "New townhomes and suburbs offer family-sized housing, yet prices and rents have climbed rapidly with in-migration."
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentValue": 7,
+      "alignmentText": "Violent crime rates are low compared to national averages, though property crime and car break-ins require precautions."
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "Intermountain Healthcare and University of Utah hospitals deliver quality care, albeit with longer waits for specialists."
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "Employer coverage is common, but standalone plans are pricey and networks narrower for non-citizens."
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentValue": 3,
+      "alignmentText": "Full-time daycare averages $1,100–$1,400 per month, with long waitlists prompting early planning."
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentValue": 4,
+      "alignmentText": "Flexible schedules and remote work options help, but families often piece together support from neighbors and faith communities."
+    },
+    {
+      "key": "Education",
+      "alignmentValue": 6,
+      "alignmentText": "State test scores are average-to-good with strong STEM magnets, though per-pupil funding remains low nationally."
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentValue": 5,
+      "alignmentText": "TRAX light rail, FrontRunner commuter trains, and expanding bike lanes offer alternatives to driving, though coverage is limited outside the core."
+    },
+    {
+      "key": "Economic System",
+      "alignmentValue": 4,
+      "alignmentText": "As part of the United States, Salt Lake City experiences similar dynamics: A lightly regulated capitalist system prioritizes markets over social protections."
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentValue": 6,
+      "alignmentText": "Utah’s flat 4.65% income tax and efficient online systems simplify filings, though self-employment quarterly payments require attention."
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentValue": 6,
+      "alignmentText": "Combined state and federal taxes land near 23–26%, aided by lower property taxes relative to coasts."
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentValue": 7,
+      "alignmentText": "Regional banks, credit unions, and strong fintech adoption support easy digital banking and lending."
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentValue": 6,
+      "alignmentText": "Housing is cheaper than coastal markets, but recent price hikes and childcare costs require careful budgeting."
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "Outdoor amenities and low taxes appeal to retirees if they can manage healthcare costs and winter inversions."
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentValue": 3,
+      "alignmentText": "Without Social Security, long-term visa holders must rely on 401(k)s and savings or plan to naturalize."
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, Salt Lake City experiences similar dynamics: Diverse visa categories exist, but quotas, interviews, and sponsorship hurdles make immigration arduous for non-citizens."
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentValue": 6,
+      "alignmentText": "Transplants are common in the tech sector, though cultural adjustment is needed for families outside LDS traditions."
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, Salt Lake City experiences similar dynamics: Citizenship grants permanent residency rights nationwide, though state benefits depend on domicile."
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentValue": 10,
+      "alignmentText": "As part of the United States, Salt Lake City experiences similar dynamics: Citizenship is automatic for the family and their children, eliminating naturalization concerns."
+    },
+    {
+      "key": "Family Members",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, Salt Lake City experiences similar dynamics: Immediate relatives of citizens have streamlined sponsorship options, though backlogs affect extended family."
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentValue": 7,
+      "alignmentText": "As part of the United States, Salt Lake City experiences similar dynamics: For citizens moves are immediate; sponsoring relatives involves fees and multi-year waits but predictable processes."
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentValue": 8,
+      "alignmentText": "As part of the United States, Salt Lake City experiences similar dynamics: Legal compliance is straightforward for citizens, though regulated industries require diligent paperwork."
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, Salt Lake City experiences similar dynamics: The U.S. tolerates dual citizenship, though obligations like taxes remain."
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, Salt Lake City experiences similar dynamics: Visa holders must maintain employment, face travel restrictions, and manage complex paperwork to avoid status loss."
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentValue": 5,
+      "alignmentText": "Avalanche, WB Games, and educational VR studios offer roles, but the scene is modest and many devs work remotely."
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentValue": 5,
+      "alignmentText": "Avalanche Studios Group, WB Games Salt Lake, and indie outfits like The Void provide local anchors."
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentValue": 5,
+      "alignmentText": "Utah Games Guild and university programs host meetups, though events are less frequent than bigger metros."
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentValue": 5,
+      "alignmentText": "Lower costs and state innovation grants help, yet limited investor networks push founders to seek capital in California or online."
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentValue": 6,
+      "alignmentText": "New transit lines, fiber internet in many neighborhoods, and modern suburbs contrast with aging water systems tied to the shrinking Great Salt Lake."
+    }
+  ]
+}

--- a/reports/united_states_san_diego_report.json
+++ b/reports/united_states_san_diego_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "US",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentValue": 7,
+      "alignmentText": "Coastal breezes, canyon greenbelts, and extensive parks make daily life outdoorsy, though sprawl and freeway corridors still influence air quality."
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentValue": 5,
+      "alignmentText": "Sea-level rise threatens low-lying beaches, drought persists, and wildfire seasons are intensifying despite regional resilience planning."
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentValue": 8,
+      "alignmentText": "Mediterranean conditions deliver mild temperatures year-round with abundant sun, aligning strongly with the family’s climate preferences."
+    },
+    {
+      "key": "Air Quality",
+      "alignmentValue": 6,
+      "alignmentText": "Air quality is generally good, yet wildfire smoke and Santa Ana wind events can bring short-term unhealthy days."
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentValue": 5,
+      "alignmentText": "Wildfires, earthquakes, and occasional flooding require readiness, but strong building codes and alert systems mitigate risk."
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "March–May runs 12–22 °C (54–72 °F) with marine layer mornings and sunny afternoons ideal for park outings."
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "June–August stays 18–27 °C (65–80 °F); coastal fog cools mornings while inland valleys see mid-80s with low humidity."
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "September–November hovers around 16–27 °C (60–80 °F), though Santa Ana winds can spike heat briefly."
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentValue": 8,
+      "alignmentText": "December–February maintains 10–20 °C (50–68 °F) with limited rain and comfortable outdoor conditions."
+    },
+    {
+      "key": "Beach Life",
+      "alignmentValue": 8,
+      "alignmentText": "Miles of accessible beaches, surf schools, and family-friendly coves like La Jolla Shores provide consistent seaside recreation."
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentValue": 5,
+      "alignmentText": "Pacific waters range from 15 °C (59 °F) in winter to 21 °C (70 °F) in late summer, workable with short wetsuits."
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentValue": 8,
+      "alignmentText": "Torrey Pines, Cabrillo National Monument, and nearby mountains deliver diverse landscapes for hiking and weekend adventures."
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentValue": 7,
+      "alignmentText": "California’s $16 statewide minimum and local enforcement protect low-wage workers, though costs remain high."
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentValue": 7,
+      "alignmentText": "Defense, biotech, and SaaS firms offer $140k–$190k compensation, solid though below Bay Area levels."
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentValue": 7,
+      "alignmentText": "Defense contractors, Qualcomm, and healthcare companies maintain steady demand for .NET engineers."
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentValue": 5,
+      "alignmentText": "Ruby roles exist in startups and digital agencies, but the market leans toward JavaScript and Python."
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentValue": 5,
+      "alignmentText": "Large firms sponsor visas, yet the ecosystem is smaller than the Bay Area, making sponsorship competitive."
+    },
+    {
+      "key": "Economic Health",
+      "alignmentValue": 7,
+      "alignmentText": "Biotech, defense, tourism, and cross-border trade diversify the economy, cushioning downturns."
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentValue": 7,
+      "alignmentText": "Remote work is common; coworking spaces and cross-border collaboration support distributed teams."
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentValue": 7,
+      "alignmentText": "Outdoor culture and flexible tech employers encourage reasonable hours, though defense projects can impose rigid schedules."
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentValue": 6,
+      "alignmentText": "Standard 40-hour weeks prevail, with occasional overtime tied to defense deadlines or product releases."
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentValue": 3,
+      "alignmentText": "California lacks mandated vacation time, so policies follow national norms despite worker-friendly rhetoric."
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentValue": 5,
+      "alignmentText": "Employers often grant 15–20 PTO days plus floating holidays; taking full time is culturally acceptable."
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentValue": 7,
+      "alignmentText": "Neighborhoods feel relaxed and community-oriented, balancing city amenities with beach-town energy."
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentValue": 6,
+      "alignmentText": "Schools start around 8 a.m., commute times are manageable, and afternoon surf or park outings help with decompression."
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentValue": 8,
+      "alignmentText": "Weekends feature beach trips, Balboa Park museums, and hikes, with mild traffic compared to LA."
+    },
+    {
+      "key": "Family Life",
+      "alignmentValue": 7,
+      "alignmentText": "Family-friendly neighborhoods, playground density, and outdoor programs support active lifestyles."
+    },
+    {
+      "key": "Polyamory",
+      "alignmentValue": 6,
+      "alignmentText": "Progressive social circles in Hillcrest and North Park host poly meetups, though suburban areas may be less familiar with consensual non-monogamy."
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentValue": 6,
+      "alignmentText": "Parents engage with PTA and enrichment, but the atmosphere stays collaborative rather than cutthroat."
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentValue": 7,
+      "alignmentText": "Parks, zoos, and kid-friendly beaches make the city welcoming, though car reliance requires booster-seat logistics."
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentValue": 6,
+      "alignmentText": "San Diego Unified offers language immersion and STEM magnets; charters and private schools expand choice amid varying neighborhood quality."
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentValue": 5,
+      "alignmentText": "High demand keeps daycare costs around $1,600–$2,000 per month; state preschool slots help but fill quickly."
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentValue": 4,
+      "alignmentText": "California subsidies assist lower-income families, yet middle-income households rely on employer benefits or nanny shares."
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentValue": 3,
+      "alignmentText": "Visa holders face limited access to subsidies, making private solutions and employer support important."
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "Neighborhood schools are accessible, but families often apply for magnets or move for higher-performing clusters."
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "Enrollment for resident children is straightforward; documentation and vaccination records must be managed carefully."
+    },
+    {
+      "key": "Private Education",
+      "alignmentValue": 5,
+      "alignmentText": "Independent schools cost $20k–$35k annually, offering smaller classes and specialized programs."
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "California Paid Family Leave covers partial wages for eight weeks, supplemented by employer policies in many sectors."
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "Most visa holders qualify for state leave benefits, though job security concerns may limit duration taken."
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "UC San Diego, SDSU, and community colleges provide excellent in-state higher-ed pathways with strong STEM offerings."
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "International students benefit from UCSD’s research network and OPT options, though tuition is higher."
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentValue": 7,
+      "alignmentText": "Dual-career households are common, and military influence coexists with progressive tech and academic communities."
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentValue": 7,
+      "alignmentText": "Legal protections, Pride events, and inclusive schools foster acceptance of non-binary identities."
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentValue": 8,
+      "alignmentText": "State laws protect reproductive and LGBTQ+ rights, matching the family’s expectations."
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentValue": 6,
+      "alignmentText": "Beach casual mixes with professional attire; individuality is welcomed without heavy judgment."
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentValue": 6,
+      "alignmentText": "Surf culture and military presence create diverse masculine expressions, from athletic to traditional."
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentValue": 7,
+      "alignmentText": "A blend of outdoor adventure, cross-border culture, and emerging startups offers inspiration for both partners."
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentValue": 9,
+      "alignmentText": "English is dominant, while proximity to Mexico ensures abundant Spanish exposure for the children."
+    },
+    {
+      "key": "Progressivism",
+      "alignmentValue": 7,
+      "alignmentText": "City politics lean progressive on climate and housing, though regional governance balances with more moderate county voices."
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentValue": 4,
+      "alignmentText": "Leftist activism exists in universities and community groups but remains niche citywide."
+    },
+    {
+      "key": "Atheism",
+      "alignmentValue": 6,
+      "alignmentText": "Secular residents and interfaith cooperation keep religion influential but not dominant in policy."
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentValue": 6,
+      "alignmentText": "Sex-positive events and open communication are present in urban neighborhoods, though military communities can be conservative."
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentValue": 8,
+      "alignmentText": "Historic LGBTQ+ districts, inclusive schools, and city policies support queer and poly families."
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentValue": 7,
+      "alignmentText": "Neighborhood farmers markets, volunteer beach cleanups, and maker spaces foster strong community ties."
+    },
+    {
+      "key": "View of self",
+      "alignmentValue": 6,
+      "alignmentText": "Residents take pride in coastal lifestyle and innovation while juggling concerns about housing and transit."
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "Cross-border ties with Tijuana encourage binational awareness and travel."
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "Mexican and international visitors see San Diego as welcoming and collaborative, though high costs are noted."
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentValue": 6,
+      "alignmentText": "Craft breweries, live music, and beach bars offer variety, albeit with earlier closing times than LA or Vegas."
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentValue": 6,
+      "alignmentText": "Casual surf-inspired looks mix with military precision and tech casual attire."
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentValue": 6,
+      "alignmentText": "Athleisure, bohemian beachwear, and professional styles coexist comfortably."
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentValue": 7,
+      "alignmentText": "Surfing, climbing gyms, craft beer culture, and tabletop gaming are popular pastimes."
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentValue": 7,
+      "alignmentText": "Game stores like At Ease Games and strong meetup scenes keep tabletop communities active."
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentValue": 6,
+      "alignmentText": "Local venues, festivals, and nearby cross-border concerts provide steady entertainment options."
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentValue": 7,
+      "alignmentText": "Startup San Diego, biotech meetups, and parenting groups create welcoming networks for newcomers."
+    },
+    {
+      "key": "Nature Access",
+      "alignmentValue": 8,
+      "alignmentText": "Beaches, Torrey Pines, and mountains within two hours support frequent outdoor exploration."
+    },
+    {
+      "key": "Political System",
+      "alignmentValue": 6,
+      "alignmentText": "City council leans progressive, yet regional agencies require collaboration with moderate suburban governments."
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentValue": 7,
+      "alignmentText": "Secular governance dominates, with faith groups focusing on social services rather than legislation."
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentValue": 7,
+      "alignmentText": "California labor protections, gig-worker regulations, and union activity in education and healthcare bolster worker leverage."
+    },
+    {
+      "key": "State Ideology",
+      "alignmentValue": 7,
+      "alignmentText": "Statewide progressive policies on climate and equity shape local initiatives despite occasional regional pushback."
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentValue": 7,
+      "alignmentText": "Independent courts, active media, and civic engagement maintain democratic stability even amid national polarization."
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentValue": 5,
+      "alignmentText": "High costs and venture capital opportunities coexist, demanding careful budgeting to enjoy the region’s benefits."
+    },
+    {
+      "key": "Stability",
+      "alignmentValue": 7,
+      "alignmentText": "Diverse industries and military investment support economic stability despite tourism fluctuations."
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentValue": 6,
+      "alignmentText": "Local journalism and public radio remain strong, but national media narratives still influence perceptions."
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentValue": 6,
+      "alignmentText": "Messaging mixes sustainability, tourism promotion, and defense industry narratives, necessitating media literacy."
+    },
+    {
+      "key": "Social Policies",
+      "alignmentValue": 7,
+      "alignmentText": "San Diego advances climate action, transit investments, and affordable housing bonds, though progress is gradual."
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentValue": 6,
+      "alignmentText": "Residents appreciate city services and parks yet critique slow housing approvals and transit expansion."
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentValue": 6,
+      "alignmentText": "Corruption cases are infrequent, with most concerns tied to development lobbying or contracting oversight."
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentValue": 6,
+      "alignmentText": "Issues involve influence from developers and defense contractors rather than systemic bribery."
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentValue": 4,
+      "alignmentText": "Housing costs remain high, especially near good schools; ADU policies and suburban options help but require long commutes."
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentValue": 6,
+      "alignmentText": "Violent crime rates are lower than many U.S. metros, though property crime and car break-ins require vigilance in tourist areas."
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentValue": 7,
+      "alignmentText": "UCSD Health, Scripps, and Kaiser provide high-quality care, with strong pediatric services for families."
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "Employer insurance is robust, but premiums and network restrictions still demand budgeting for non-citizens."
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentValue": 4,
+      "alignmentText": "Daycare and preschool costs are high, but cooperative preschools and employer stipends can soften the burden."
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentValue": 6,
+      "alignmentText": "Flexible tech schedules, remote work options, and extended family networks ease daily logistics despite costs."
+    },
+    {
+      "key": "Education",
+      "alignmentValue": 7,
+      "alignmentText": "STEM magnets, language immersion programs, and proximity to research institutions drive strong outcomes for engaged families."
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentValue": 5,
+      "alignmentText": "Trolley expansion and commuter rail offer alternatives to driving, yet coverage remains limited outside core corridors."
+    },
+    {
+      "key": "Economic System",
+      "alignmentValue": 4,
+      "alignmentText": "As part of the United States, San Diego experiences similar dynamics: A lightly regulated capitalist system prioritizes markets over social protections."
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentValue": 5,
+      "alignmentText": "California’s progressive taxes add paperwork, but digital systems and withholding help manage compliance; self-employed work requires quarterly payments."
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentValue": 4,
+      "alignmentText": "High state income taxes push combined effective rates around 30–32%, mitigated by mortgage and childcare deductions."
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentValue": 8,
+      "alignmentText": "Major banks, credit unions, and cross-border fintech services support seamless payments and entrepreneurial finance."
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentValue": 4,
+      "alignmentText": "Housing and childcare remain expensive, though lower than San Francisco; energy and food costs are moderate."
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentValue": 5,
+      "alignmentText": "Climate and healthcare attract retirees, but property taxes and living costs require sizable savings or Proposition 13 advantages."
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentValue": 3,
+      "alignmentText": "Without Social Security access, visa holders need aggressive savings plans or eventual naturalization to retire locally."
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, San Diego experiences similar dynamics: Diverse visa categories exist, but quotas, interviews, and sponsorship hurdles make immigration arduous for non-citizens."
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentValue": 7,
+      "alignmentText": "Transplants from across the country are common, and communities embrace newcomers involved in outdoor and tech scenes."
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, San Diego experiences similar dynamics: Citizenship grants permanent residency rights nationwide, though state benefits depend on domicile."
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentValue": 10,
+      "alignmentText": "As part of the United States, San Diego experiences similar dynamics: Citizenship is automatic for the family and their children, eliminating naturalization concerns."
+    },
+    {
+      "key": "Family Members",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, San Diego experiences similar dynamics: Immediate relatives of citizens have streamlined sponsorship options, though backlogs affect extended family."
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentValue": 7,
+      "alignmentText": "As part of the United States, San Diego experiences similar dynamics: For citizens moves are immediate; sponsoring relatives involves fees and multi-year waits but predictable processes."
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentValue": 8,
+      "alignmentText": "As part of the United States, San Diego experiences similar dynamics: Legal compliance is straightforward for citizens, though regulated industries require diligent paperwork."
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, San Diego experiences similar dynamics: The U.S. tolerates dual citizenship, though obligations like taxes remain."
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, San Diego experiences similar dynamics: Visa holders must maintain employment, face travel restrictions, and manage complex paperwork to avoid status loss."
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentValue": 6,
+      "alignmentText": "Studios like Sony San Diego, Psyonix, and indie VR shops provide opportunities, complemented by remote roles."
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentValue": 6,
+      "alignmentText": "Sony San Diego Studio, Psyonix, Rockstar’s San Diego office, and High Moon Studios anchor local development."
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentValue": 6,
+      "alignmentText": "IGDA San Diego, UCSD game programs, and local meetups host regular events, though smaller than Bay Area gatherings."
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentValue": 6,
+      "alignmentText": "Lower costs than San Francisco and access to cross-border talent aid startups, yet funding often comes from angel networks or remote investors."
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentValue": 7,
+      "alignmentText": "Upgraded trolley lines, cross-border smart port initiatives, and widespread fiber internet balance against older water systems in legacy neighborhoods."
+    }
+  ]
+}

--- a/reports/united_states_san_francisco_report.json
+++ b/reports/united_states_san_francisco_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "US",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentValue": 6,
+      "alignmentText": "Bay breezes, urban parks, and easy escapes to Marin deliver frequent nature contact, though dense housing and limited yard space temper daily greenery."
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentValue": 5,
+      "alignmentText": "Sea-level rise threatens Embarcadero neighborhoods, wildfire smoke invades each autumn, and drought cycles require water conservation."
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentValue": 6,
+      "alignmentText": "Cool summers, mild winters, and microclimates yield comfortable if unpredictable weather; foggy afternoons contrast with sunny inland excursions."
+    },
+    {
+      "key": "Air Quality",
+      "alignmentValue": 5,
+      "alignmentText": "Most days are clean, but wildfire smoke drives AQI above 150 in late summer, demanding air purifiers and flexible indoor plans."
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentValue": 4,
+      "alignmentText": "Earthquake preparedness and wildfire evacuation routes are essential; city infrastructure continues seismic retrofits but risk remains tangible."
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentValue": 6,
+      "alignmentText": "March–May ranges 9–18 °C (48–65 °F) with mixed sun and mist, ideal for layered park outings."
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentValue": 5,
+      "alignmentText": "June–August averages 12–20 °C (54–68 °F); Karl the Fog keeps many neighborhoods cool while inland heat beckons weekend escapes."
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentValue": 7,
+      "alignmentText": "September–November offers the city’s warmest, sunniest weather at 13–23 °C (55–73 °F), perfect for beach or hiking days."
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentValue": 6,
+      "alignmentText": "December–February stays 8–16 °C (46–61 °F) with light rain and rare frost, supporting year-round outdoor play."
+    },
+    {
+      "key": "Beach Life",
+      "alignmentValue": 5,
+      "alignmentText": "Ocean Beach and Baker Beach provide dramatic coastlines, though cold surf and rip currents limit casual swimming; Crissy Field suits family picnics."
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentValue": 2,
+      "alignmentText": "Pacific waters hover 11–15 °C (52–59 °F) year-round, making wetsuits essential for extended swimming."
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentValue": 9,
+      "alignmentText": "Golden Gate Park, Marin Headlands, and redwood forests sit minutes away, offering exceptional natural beauty despite urban density."
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentValue": 8,
+      "alignmentText": "San Francisco’s $18+ minimum wage and strong enforcement create higher baselines, though costs of living remain high."
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentValue": 9,
+      "alignmentText": "Major tech employers offer $180k–$260k base plus equity, supporting significant earning potential for both Trey and Sarah."
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentValue": 7,
+      "alignmentText": "While the Bay Area leans toward open-source stacks, fintech, enterprise SaaS, and cloud teams still hire experienced .NET engineers."
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentValue": 8,
+      "alignmentText": "Rails-centric startups and legacy tech firms maintain strong demand, with remote-friendly options across the region."
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentValue": 8,
+      "alignmentText": "Large tech companies, startups, and research labs regularly sponsor visas, though competition and H-1B lotteries remain intense."
+    },
+    {
+      "key": "Economic Health",
+      "alignmentValue": 7,
+      "alignmentText": "Tech resilience, biotech growth, and AI investment offset downtown office vacancies and affordability-driven outmigration."
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentValue": 9,
+      "alignmentText": "Hybrid work is the norm, with co-living spaces, coworking hubs, and asynchronous-friendly teams supporting remote entrepreneurship."
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentValue": 6,
+      "alignmentText": "Progressive employers emphasize flexibility, yet product launch cycles and startup hustle can intrude without boundaries."
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentValue": 6,
+      "alignmentText": "Most tech roles aim for 40–45 hours, though crunch periods demand extra effort, especially in venture-backed environments."
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentValue": 3,
+      "alignmentText": "California mandates paid sick leave but not vacation; policies rely on employer standards despite progressive rhetoric."
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentValue": 5,
+      "alignmentText": "Tech firms often offer unlimited or 15–20 days PTO; culture encourages taking time off, though high performers still feel pressure."
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentValue": 5,
+      "alignmentText": "Neighborhood life feels relaxed, yet startup intensity and high costs create background stress that requires mindful pacing."
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentValue": 6,
+      "alignmentText": "Schools run roughly 8 a.m.–2:30 p.m.; remote work allows afternoon breaks for park trips before evening events."
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentValue": 7,
+      "alignmentText": "Weekends blend farmers markets, museum visits, and hikes in Marin or the East Bay, with manageable transit times."
+    },
+    {
+      "key": "Family Life",
+      "alignmentValue": 6,
+      "alignmentText": "Compact homes and high childcare costs challenge families, but playground density, libraries, and cultural programming provide rich experiences."
+    },
+    {
+      "key": "Polyamory",
+      "alignmentValue": 7,
+      "alignmentText": "Queer-friendly neighborhoods, consent-focused communities, and established poly meetups support the family’s relationship style."
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentValue": 5,
+      "alignmentText": "Parents pursue enrichment and language immersion, yet co-ops and community schools emphasize collaboration over competition."
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentValue": 6,
+      "alignmentText": "Car-light streets, playgrounds, and family cycling culture help kids thrive, though hills and older transit stations can complicate stroller use."
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentValue": 6,
+      "alignmentText": "SFUSD offers language immersion and STEM magnets, but assignment lotteries and enrollment unpredictability require planning; private schools are competitive."
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentValue": 4,
+      "alignmentText": "Limited supply and $2,500+/month tuition make childcare difficult; city subsidies exist but have long waitlists."
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentValue": 3,
+      "alignmentText": "San Francisco’s Early Learning Scholarship assists lower-income families, yet middle-income households face steep costs."
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentValue": 2,
+      "alignmentText": "Subsidy eligibility narrows for visa holders, pushing reliance on employer benefits or shared nannies."
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "Assignment lotteries provide equity but limit parental control; proactive strategies can secure strong programs."
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "Documentation requirements are manageable, though supporting services for newcomers may need advocacy."
+    },
+    {
+      "key": "Private Education",
+      "alignmentValue": 4,
+      "alignmentText": "Independent schools cost $35k–$55k annually with competitive admissions, making them feasible only with high incomes."
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentValue": 6,
+      "alignmentText": "California Paid Family Leave and short-term disability provide partial wage replacement for up to 8 weeks, supplemented by progressive employer benefits."
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentValue": 5,
+      "alignmentText": "Eligibility extends to most employees, yet visa considerations and job security may influence how much leave families take."
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "UC and CSU systems, plus Stanford and private universities, offer world-class education with in-state advantages for residents."
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "International tuition is steep, but abundant universities, OPT opportunities, and research labs benefit foreign students."
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentValue": 7,
+      "alignmentText": "Egalitarian norms are standard in tech and creative sectors, though venture capital leadership remains male-heavy."
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentValue": 8,
+      "alignmentText": "Legal protections and visible non-binary communities make name/pronoun respect common across workplaces and schools."
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentValue": 8,
+      "alignmentText": "California safeguards reproductive health, gender-affirming care, and LGBTQ+ rights, matching the family’s priorities."
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentValue": 6,
+      "alignmentText": "Style ranges from athleisure to avant-garde; individuality is celebrated without rigid expectations."
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentValue": 6,
+      "alignmentText": "Tech and arts scenes support expressive masculinity, though startup competitiveness persists."
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentValue": 8,
+      "alignmentText": "Access to cutting-edge tech, progressive activism, and arts culture aligns strongly with the family’s interests and entrepreneurial goals."
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentValue": 9,
+      "alignmentText": "English dominates, while Cantonese, Mandarin, and Spanish communities offer bilingual exposure for the children."
+    },
+    {
+      "key": "Progressivism",
+      "alignmentValue": 9,
+      "alignmentText": "City policies champion climate action, equity, and LGBTQ+ protections, though debates on public safety and housing remain intense."
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentValue": 5,
+      "alignmentText": "Leftist thought is visible in academic and activist circles, but mainstream governance stays pragmatic-progressive."
+    },
+    {
+      "key": "Atheism",
+      "alignmentValue": 7,
+      "alignmentText": "Secularism is common, and diverse faith communities coexist without steering policy."
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentValue": 7,
+      "alignmentText": "Sex-positive workshops, inclusive healthcare, and open dialogue about consent are mainstream in many communities."
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentValue": 9,
+      "alignmentText": "Historic queer neighborhoods, robust protections, and inclusive schools create a welcoming environment for poly and LGBTQ+ families."
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentValue": 6,
+      "alignmentText": "Co-ops, neighborhood associations, and activism foster community, but high turnover and housing costs can disrupt long-term bonds."
+    },
+    {
+      "key": "View of self",
+      "alignmentValue": 7,
+      "alignmentText": "Residents take pride in innovation, diversity, and social justice leadership, even amid critiques of affordability."
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentValue": 6,
+      "alignmentText": "International awareness is high through immigration ties and tech’s global reach, fostering curiosity and travel."
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentValue": 7,
+      "alignmentText": "The Bay Area is seen as progressive and innovative, though criticized for cost of living and political debates."
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentValue": 7,
+      "alignmentText": "Live music, speakeasies, and arts events thrive, though nightlife winds down earlier than New York or Vegas."
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentValue": 6,
+      "alignmentText": "Tech casual mixes with avant-garde streetwear; experimentation is welcomed without rigid dress codes."
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentValue": 7,
+      "alignmentText": "Layered looks, sustainable fashion, and gender-fluid styles dominate, offering expressive freedom."
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentValue": 7,
+      "alignmentText": "Residents embrace rock climbing gyms, urban gardening, creative coding, and activism alongside outdoor sports."
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentValue": 8,
+      "alignmentText": "Cafés like Game Parlour, local conventions, and vibrant meetup scenes sustain a robust tabletop community."
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentValue": 7,
+      "alignmentText": "Indie venues, jazz clubs, and festivals like Outside Lands deliver consistent entertainment."
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentValue": 9,
+      "alignmentText": "Tech meetups, co-housing groups, and social justice collectives occur nightly, easing integration for newcomers."
+    },
+    {
+      "key": "Nature Access",
+      "alignmentValue": 8,
+      "alignmentText": "Muir Woods, Point Reyes, and coastal trails are within an hour, though traffic and parking require planning."
+    },
+    {
+      "key": "Political System",
+      "alignmentValue": 6,
+      "alignmentText": "City politics are participatory yet fragmented, requiring navigation of neighborhood groups and ballot initiatives."
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentValue": 8,
+      "alignmentText": "Secular governance dominates; faith-based groups focus on social services rather than policy control."
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentValue": 8,
+      "alignmentText": "Strong labor laws, contractor protections, and salary transparency reinforce worker leverage."
+    },
+    {
+      "key": "State Ideology",
+      "alignmentValue": 7,
+      "alignmentText": "California’s progressive legislature advances climate action and civil rights, though budget trade-offs can slow implementation."
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentValue": 7,
+      "alignmentText": "Robust institutions, civic engagement, and an independent judiciary limit democratic erosion despite national polarization."
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentValue": 5,
+      "alignmentText": "Venture capital and wealth inequality coexist with ambitious social programs; affordability remains a key tension."
+    },
+    {
+      "key": "Stability",
+      "alignmentValue": 6,
+      "alignmentText": "Economic diversity provides resilience, yet housing costs and downtown commercial vacancies demand monitoring."
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentValue": 6,
+      "alignmentText": "Independent journalism and public media thrive, though tech platforms amplify misinformation requiring media literacy."
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentValue": 6,
+      "alignmentText": "Political messaging spans progressive campaigns and tech-industry narratives, requiring balanced information diets."
+    },
+    {
+      "key": "Social Policies",
+      "alignmentValue": 8,
+      "alignmentText": "Expanded healthcare access, tenant protections, and climate investments align with progressive priorities, albeit with implementation challenges."
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentValue": 5,
+      "alignmentText": "Residents appreciate services like public transit and libraries but critique bureaucratic delays and homelessness response."
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentValue": 6,
+      "alignmentText": "Ethics scandals are infrequent but revolve around permitting and nonprofit oversight, prompting ongoing reforms."
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentValue": 6,
+      "alignmentText": "Issues stem from pay-to-play contracting or nonprofit mismanagement rather than systemic bribery."
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentValue": 3,
+      "alignmentText": "Sky-high rents, limited single-family homes, and competitive bidding make housing a major hurdle for families."
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentValue": 5,
+      "alignmentText": "Property crime and car break-ins are common, yet violent crime rates remain moderate and community policing efforts continue."
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentValue": 8,
+      "alignmentText": "Top-tier hospitals like UCSF provide excellent care, with robust employer insurance and progressive public health programs."
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentValue": 6,
+      "alignmentText": "Employer coverage is strong, but out-of-network costs and dependent premiums remain high for non-citizens."
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentValue": 3,
+      "alignmentText": "Daycare costs exceed $2,500 per month; nanny shares lighten loads but require coordination."
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentValue": 6,
+      "alignmentText": "Flexible work culture, support groups, and family-friendly employers help balance obligations despite high costs."
+    },
+    {
+      "key": "Education",
+      "alignmentValue": 7,
+      "alignmentText": "Public magnet and private schools offer rigorous academics; inequality across neighborhoods demands proactive engagement."
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentValue": 7,
+      "alignmentText": "Muni, BART, and ferries enable car-light living, although reliability and cleanliness fluctuate."
+    },
+    {
+      "key": "Economic System",
+      "alignmentValue": 4,
+      "alignmentText": "As part of the United States, San Francisco experiences similar dynamics: A lightly regulated capitalist system prioritizes markets over social protections."
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentValue": 5,
+      "alignmentText": "State income taxes are progressive and complex, but digital filing and employer withholding streamline compliance; city business taxes add paperwork for entrepreneurs."
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentValue": 4,
+      "alignmentText": "High state brackets push combined effective rates near 32–35%, though deductions for childcare and mortgage interest help."
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentValue": 9,
+      "alignmentText": "Fintech adoption, contactless transit, and abundant venture banking services support modern financial needs."
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentValue": 2,
+      "alignmentText": "Housing, childcare, and everyday expenses are among the nation’s highest, demanding significant income to maintain comfort."
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentValue": 4,
+      "alignmentText": "Quality healthcare and transit support aging in place, but retirees need substantial assets or relocation plans to manage costs."
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentValue": 3,
+      "alignmentText": "Non-citizens must rely on employer savings plans and consider naturalization to access Social Security benefits."
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, San Francisco experiences similar dynamics: Diverse visa categories exist, but quotas, interviews, and sponsorship hurdles make immigration arduous for non-citizens."
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentValue": 8,
+      "alignmentText": "Transplants from across the U.S. blend with global newcomers, creating inclusive communities for new arrivals."
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, San Francisco experiences similar dynamics: Citizenship grants permanent residency rights nationwide, though state benefits depend on domicile."
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentValue": 10,
+      "alignmentText": "As part of the United States, San Francisco experiences similar dynamics: Citizenship is automatic for the family and their children, eliminating naturalization concerns."
+    },
+    {
+      "key": "Family Members",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, San Francisco experiences similar dynamics: Immediate relatives of citizens have streamlined sponsorship options, though backlogs affect extended family."
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentValue": 7,
+      "alignmentText": "As part of the United States, San Francisco experiences similar dynamics: For citizens moves are immediate; sponsoring relatives involves fees and multi-year waits but predictable processes."
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentValue": 8,
+      "alignmentText": "As part of the United States, San Francisco experiences similar dynamics: Legal compliance is straightforward for citizens, though regulated industries require diligent paperwork."
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentValue": 9,
+      "alignmentText": "As part of the United States, San Francisco experiences similar dynamics: The U.S. tolerates dual citizenship, though obligations like taxes remain."
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentValue": 3,
+      "alignmentText": "As part of the United States, San Francisco experiences similar dynamics: Visa holders must maintain employment, face travel restrictions, and manage complex paperwork to avoid status loss."
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentValue": 8,
+      "alignmentText": "Studios like Double Fine, Ubisoft, and numerous indie and VR teams provide opportunities alongside remote-first roles."
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentValue": 8,
+      "alignmentText": "Double Fine, Niantic, Sanzaru Games, and Riot’s Bay Area offices anchor a robust developer ecosystem."
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentValue": 9,
+      "alignmentText": "GDC, Bay Area Dev Collective, and incubators like GameNest deliver year-round events and networking."
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentValue": 8,
+      "alignmentText": "Access to investors, accelerators, and seasoned talent makes launching a studio feasible if costs are budgeted carefully."
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentValue": 8,
+      "alignmentText": "Gigabit internet, electric buses, and smart-city pilots coexist with aging downtown buildings, creating a mix of cutting-edge and legacy systems."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add detailed versioned reports for New York City, Chicago, Salt Lake City, Las Vegas, San Francisco, and San Diego that align with the family profile and rating guides
- expand the United States city list in main.json so the new destinations appear in the navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e33ed5b5c48321988cd04b0b00532f