### PR TITLE
Add UK city reports for Bristol, Brighton & Hove, Edinburgh, Manchester, Richmond, and Walthamstow

### DIFF
--- a/main.json
+++ b/main.json
@@ -676,7 +676,33 @@
     },
     {
       "name": "United Kingdom",
-      "file": "reports/united_kingdom_report.json"
+      "file": "reports/united_kingdom_report.json",
+      "cities": [
+        {
+          "name": "Brighton & Hove",
+          "file": "reports/united_kingdom_brighton_and_hove_report.json"
+        },
+        {
+          "name": "Bristol",
+          "file": "reports/united_kingdom_bristol_report.json"
+        },
+        {
+          "name": "Edinburgh",
+          "file": "reports/united_kingdom_edinburgh_report.json"
+        },
+        {
+          "name": "Manchester",
+          "file": "reports/united_kingdom_manchester_report.json"
+        },
+        {
+          "name": "Richmond",
+          "file": "reports/united_kingdom_richmond_report.json"
+        },
+        {
+          "name": "Walthamstow",
+          "file": "reports/united_kingdom_walthamstow_report.json"
+        }
+      ]
     },
     {
       "name": "Belgium",

--- a/reports/united_kingdom_brighton_and_hove_report.json
+++ b/reports/united_kingdom_brighton_and_hove_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "GB",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "For families based in Brighton & Hove, Enterprise, fintech, and public-sector demand keeps .NET roles plentiful in London, Manchester, and Leeds, giving Trey steady options.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "WHO targets are usually met thanks to coastal winds, though North Street and the A23 corridor still see NO2 spikes on busy weekends.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "For families based in Brighton & Hove, Secularism is common and religion rarely intrudes on workplaces or schools, matching the family’s secular preference.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "For families based in Brighton & Hove, Independent courts, free media, and active civil society keep backsliding low despite occasional executive-overreach debates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "For families based in Brighton & Hove, Contactless, Faster Payments, and open banking apps make cashless living seamless for daily errands and business invoices.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Pebble beaches, the Undercliff Walk, and quick trains to the Seven Sisters cliffs make seaside living part of everyday life even if we save swimming for warm spells.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Dice Saloon, Loading Brighton, and regular clubs at the Komedia provide varied tabletop nights.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "For families based in Brighton & Hove, Tax-free childcare accounts and funded hours help once both parents work, but under-three costs remain steep.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "For families based in Brighton & Hove, Most cities prioritise pram access, family lanes on transit, and museums geared to kids, though older infrastructure can add stairs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "For families based in Brighton & Hove, Citizens tap shared parental leave, child benefit, and expanded free-hours rollouts, though out-of-pocket nursery costs stay high for under-threes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "For families based in Brighton & Hove, Temporary visas unlock 30 funded hours once both parents work, but NRPF rules block child benefit so we’d budget extra cash flow.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "For families based in Brighton & Hove, Football, hiking, gaming, and pub quizzes keep plenty of overlap with the family’s interests.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "For families based in Brighton & Hove, Local councils, clubs, and neighborhood WhatsApp groups help newcomers plug in quickly, which suits their search for community.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "For families based in Brighton & Hove, We must track absences for ILR, register for taxes promptly, and update digital status, but rules are transparent.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "High rents and energy bills mirror London levels, so Trey's indie runway would require strict budgeting or remote salary top-ups.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "For families based in Brighton & Hove, The UK allows dual nationality, so the family can retain US passports without complications.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "For families based in Brighton & Hove, The UK services economy is mature but slow-growing, with inflation aftershocks and regional inequality to watch.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "For families based in Brighton & Hove, A regulated market economy with social safety nets supports entrepreneurship while cushioning healthcare and schooling costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "For families based in Brighton & Hove, Quality varies by local authority, so we’d target strong Ofsted areas or consider academy chains with robust STEM tracks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "For families based in Brighton & Hove, Thousands of licensed sponsors exist, but high fees and salary thresholds mean we must target shortage-list employers early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Sea breezes sweep pollution off Brighton's compact core, but narrow streets and tourist traffic keep us mindful of air quality alerts.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "For families based in Brighton & Hove, Combined tech salaries fall into 40% higher-rate bands, so we’d lean on pension contributions and child benefit clawback planning.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn holds around 10–16 °C (50–61 °F) with blustery days that call for windbreakers on seafront walks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "For families based in Brighton & Hove, Libraries, museums, and free festivals give the boys endless weekend options, and most towns offer playgrounds within a short walk.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "For families based in Brighton & Hove, Dependents can work or study freely once visas are issued, but NHS surcharge and school admissions timelines require upfront planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "For families based in Brighton & Hove, Statutory leave plus flexible working rights back up Sarah’s work-life goals, even if benefit levels lag Nordic standards.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "For families based in Brighton & Hove, Middle-class families often mix statutory leave with part-time returns and grandparents, a pattern we could mirror with hybrid roles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "For families based in Brighton & Hove, Many leave rights apply, but means-tested benefits exclude most work visas, so we’d rely on employer top-ups.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "For families based in Brighton & Hove, Women pair athleisure with tailored coats, making it easy for Sarah to stay comfortable and polished.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "For families based in Brighton & Hove, Smart-casual layers and weatherproof outerwear dominate, so Trey’s tech wardrobe fits right in.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "For families based in Brighton & Hove, Women comfortably mix professional and casual styles, and weather-ready layers keep expectations practical for Sarah.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Electric Square, Studio Gobo, and FuturLab create steady hiring, supplemented by remote roles across the south coast.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "For families based in Brighton & Hove, Legal recognition of non-binary identities is emerging and urban schools teach inclusion, though rural areas can be conservative.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "For families based in Brighton & Hove, The Equality Act and active advocacy groups deliver strong protections, even if pay gaps persist in some sectors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "For families based in Brighton & Hove, Dual-career households are normal and dads taking leave is increasingly accepted, aligning with the family’s egalitarian approach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "For families based in Brighton & Hove, BRP-to-eVisa transitions, proof-of-address hurdles, and credit history building take effort during the first year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "For families based in Brighton & Hove, Climate models flag more heavy rain and coastal flood risk, so we'd budget for flood-aware housing and insurance while still seeing the islands as relatively safe from extreme heat.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "For families based in Brighton & Hove, The NHS covers care without bills, but specialty waits and GP backlogs mean we’d pair it with occasional private visits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "For families based in Brighton & Hove, Paying the Immigration Health Surcharge grants full NHS access, though first-year GP registration and wait times require patience.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "For families based in Brighton & Hove, Domestic tuition caps and income-based loans keep university feasible for the boys if we settle long term.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "For families based in Brighton & Hove, Until indefinite leave, the kids would face international fees, so permanent residency becomes key before university age.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Victorian terraces near good schools trigger bidding wars; we may need to consider Portslade or Worthing for family space.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "For families based in Brighton & Hove, PAYE handles most income tax automatically, and digital self-assessment tools make side projects manageable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "For families based in Brighton & Hove, State schools are free with decent secular options; we just need to pick catchments with strong Ofsted reports.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "For families based in Brighton & Hove, Children on dependent visas can enroll easily, yet proof of address and NHS numbers add upfront paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "For families based in Brighton & Hove, English dominates daily life and services, so integration is frictionless while the kids still meet Welsh or Gaelic at school for enrichment.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "For families based in Brighton & Hove, Legal equality and visible Pride events keep queer families supported, with only isolated pushback outside cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "For families based in Brighton & Hove, Leftist movements stay mostly academic or activist; mainstream parties frame them as fringe.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "For families based in Brighton & Hove, Modern fatherhood and flexible work are increasingly celebrated, though pub and sport culture still prize stoicism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Queer-friendly tech meetups, parenting groups, and arts collectives make it easy to plug into inclusive networks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "For families based in Brighton & Hove, The National Living Wage rises annually and covers core expenses outside London, though big-city rents would still push the family toward dual tech incomes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "CityFibre gigabit, 5G coverage, and smart-city pilots keep daily logistics modern despite Victorian streets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "The South Downs National Park and chalk cliffs sit on our doorstep for weekend hikes and paragliding adventures.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Storm surges and cliff erosion require respect, yet Brighton is largely sheltered from catastrophic events.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Car-free day trips on the Breeze Bus into the Downs and coastal bike lanes keep outdoor plans easy without a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Live music venues from Chalk to the Dome plus year-round club nights deliver festival energy without London travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Late buses and compact streets keep nights manageable for parents, though licensing wraps most events by 2 a.m.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Develop:Brighton, Unity meetups, and local coworking hubs keep knowledge-sharing lively.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Electric Square, Studio Gobo, and Hangar 13's presence underscore Brighton's AAA-to-indie mix.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Digital Catapult Brighton, Wired Sussex, and proximity to London investors give Trey's studio credible funding pathways.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Weekdays move briskly with commuters to London, yet weekends slow to promenade strolls and beach picnics that fit Sarah's tempo.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "For families based in Brighton & Hove, Parents juggle school runs, sports clubs, and homework but the schedule is manageable with wraparound care and plentiful parks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "For families based in Brighton & Hove, Five years on a qualifying visa plus 12 months ILR, Life in the UK, and language tests make the process structured yet paperwork-heavy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "For families based in Brighton & Hove, Transparency laws and watchdog journalism keep corruption low, with sleaze stories typically triggering resignations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "For families based in Brighton & Hove, A parliamentary democracy with devolved nations offers checks and civic engagement channels the family appreciates.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "For families based in Brighton & Hove, Major cities host polyamory meetups and sex-positive therapists, yet the legal framework stays monogamy-only so we would stay discreet with schools.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "For families based in Brighton & Hove, Funded 15–30 hour nursery slots help at ages 3–4, yet infant care has waitlists and high fees in London.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "For families based in Brighton & Hove, Independent schools offer strong academics but fees rival US colleges, so we’d treat them as backup rather than plan A.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "For families based in Brighton & Hove, Cities lean progressive with protections for LGBTQ+ residents, though national politics swing between centrist parties.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "For families based in Brighton & Hove, Campaigns lean on patriotic framing and culture-war headlines, but plural media lets the family curate calmer sources.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "For families based in Brighton & Hove, Public broadcasters provide balance, yet tabloids and partisan social media keep spin in the daily mix.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The dense Brighton & Hove bus network and Thameslink/GWR trains make daily life car-light, though strike days require flexibility.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "For families based in Brighton & Hove, Religion is mostly private nationally, yet Northern Ireland and some school policies keep faith voices visible.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "For families based in Brighton & Hove, Hybrid weeks and coworking hubs are normal in tech, letting Sarah secure a low-stress remote role while Trey taps London meetings as needed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "For families based in Brighton & Hove, Most work visas run 2–5 years with clear upgrade paths to Indefinite Leave to Remain if we track absence limits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "For families based in Brighton & Hove, The state pension supplements workplace schemes, but comfortable retirement still depends on private savings and housing equity.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "For families based in Brighton & Hove, Access hinges on National Insurance years and keeping UK pensions portable, so we’d maintain US savings as backup.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "For families based in Brighton & Hove, Ruby is niche but active across London and Edinburgh startups, so Sarah would need networking yet still find remote or hybrid teams.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Nightlife-driven petty crime and seasonal crowds demand vigilance, but violent crime remains low.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "For families based in Brighton & Hove, State, academy, and a smattering of secular private schools give us choice, but grammar and faith admissions require careful catchment planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Sea surface temperatures climb from ~8 °C in spring to 18 °C (64 °F) in August, giving late-summer swimming windows with wetsuits for the boys.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Brighton's maritime climate brings mild temperatures with frequent gusts; layering keeps the family comfortable even when showers roll off the Channel.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "For families based in Brighton & Hove, Comprehensive sex education and liberal norms in metros support the family’s sex-positive outlook, even if rural areas stay discreet.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "For families based in Brighton & Hove, Universal healthcare and benefits exist, yet austerity-era cuts mean we’d verify local delivery before committing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Spring ranges 8–14 °C (46–57 °F); the Downs bloom early but sea breezes make light jackets essential.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "For families based in Brighton & Hove, Institutions are steady but Brexit-era leadership churn shows politics can be noisy every few years.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "For families based in Brighton & Hove, Politics oscillates between centrist Conservatives and Labour, so policy swings require periodic recalibration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "For families based in Brighton & Hove, A mature mixed economy balances free markets with public services like the NHS, matching the family’s preference for safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summer highs near 19–23 °C (66–73 °F) stay comfortable with low humidity, hitting 27 °C only during rare heat spikes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "For families based in Brighton & Hove, Visa fees, NHS surcharges, and biometrics push costs into the thousands per adult, and processing can stretch to several months.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "For families based in Brighton & Hove, Surveys show middling trust after scandals, so expect lively political debate at the school gate.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "For families based in Brighton & Hove, Issues surface around procurement or lobbying rather than day-to-day bribery, so it rarely touches family life.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "For families based in Brighton & Hove, Senior dev pay trails US hubs, so Trey and Sarah would lean on remote-friendly roles or equity to balance London-area costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "For families based in Brighton & Hove, Weekends mix kids’ clubs, museums, and park time; Sunday trading rules leave ample family windows even without a car.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "For families based in Brighton & Hove, Schools run roughly 08:30–15:00 and offices 09:00–17:30, so we’d lean on wraparound care or flex hours to bridge commutes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "For families based in Brighton & Hove, Statutory 28 days including bank holidays beats US norms and lets the family plan regular school-break trips.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "For families based in Brighton & Hove, Tech employers often offer 30–33 days plus buy/sell schemes, keeping family adventures aligned with school calendars.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "For families based in Brighton & Hove, Opinions on the EU and Ireland are mixed post-Brexit, so dinner-table talk can get political.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "For families based in Brighton & Hove, The UK balances pride in institutions with a pragmatic streak, making locals confident yet approachable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "For families based in Brighton & Hove, Neighbors respect UK culture but criticise Brexit-era politics, which the family should expect to hear while travelling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "For families based in Brighton & Hove, Skilled Worker and Global Talent routes are viable but expensive, and Innovator Founder demands robust business plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "For families based in Brighton & Hove, Shared language and cultural ties make Americans broadly welcome, especially in cosmopolitan cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "A fiercely progressive seaside city with quick train access to London aligns with the family's values and work ambitions.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters average 3–8 °C (37–46 °F); damp winds off the Channel make it feel cooler, so we plan indoor play cafes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "For families based in Brighton & Hove, Contracts target 37.5–40 hours and flex arrangements are common, yet finance and game studios still expect overtime around launches.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "For families based in Brighton & Hove, Hybrid norms, 28+ days of leave, and cultural respect for evenings help Sarah secure calmer schedules, though crunch remains in some London studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "For families based in Brighton & Hove, Holiday pay, sick leave, and union protections exceed US baselines, though zero-hour contracts linger in retail and hospitality.",
+      "alignmentValue": 7
+    }
+  ]
+}

--- a/reports/united_kingdom_bristol_report.json
+++ b/reports/united_kingdom_bristol_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "GB",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "For families based in Bristol, Enterprise, fintech, and public-sector demand keeps .NET roles plentiful in London, Manchester, and Leeds, giving Trey steady options.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Bristol still breaches NO2 limits along the M32 and inner ring roads, so we'd follow the Clean Air Zone alerts before cycling with the kids.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "For families based in Bristol, Secularism is common and religion rarely intrudes on workplaces or schools, matching the family’s secular preference.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "For families based in Bristol, Independent courts, free media, and active civil society keep backsliding low despite occasional executive-overreach debates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "For families based in Bristol, Contactless, Faster Payments, and open banking apps make cashless living seamless for daily errands and business invoices.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Weston-super-Mare, Clevedon, and the Gower coast sit within weekend distance, yet tidal mudflats and chilly water keep true beach days to late summer getaways.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Chance & Counters, The Lazy Frog, and regular Bristol Board Gamers meetups keep tabletop nights lively for Trey and Sarah.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "For families based in Bristol, Tax-free childcare accounts and funded hours help once both parents work, but under-three costs remain steep.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "For families based in Bristol, Most cities prioritise pram access, family lanes on transit, and museums geared to kids, though older infrastructure can add stairs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "For families based in Bristol, Citizens tap shared parental leave, child benefit, and expanded free-hours rollouts, though out-of-pocket nursery costs stay high for under-threes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "For families based in Bristol, Temporary visas unlock 30 funded hours once both parents work, but NRPF rules block child benefit so we’d budget extra cash flow.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "For families based in Bristol, Football, hiking, gaming, and pub quizzes keep plenty of overlap with the family’s interests.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "For families based in Bristol, Local councils, clubs, and neighborhood WhatsApp groups help newcomers plug in quickly, which suits their search for community.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "For families based in Bristol, We must track absences for ILR, register for taxes promptly, and update digital status, but rules are transparent.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and childcare undercut London, yet energy bills and rising rents still force us to budget carefully during studio-building years.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "For families based in Bristol, The UK allows dual nationality, so the family can retain US passports without complications.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "For families based in Bristol, The UK services economy is mature but slow-growing, with inflation aftershocks and regional inequality to watch.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "For families based in Bristol, A regulated market economy with social safety nets supports entrepreneurship while cushioning healthcare and schooling costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "For families based in Bristol, Quality varies by local authority, so we’d target strong Ofsted areas or consider academy chains with robust STEM tracks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "For families based in Bristol, Thousands of licensed sponsors exist, but high fees and salary thresholds mean we must target shortage-list employers early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Bristol's harbourside density is balanced by city-funded woodland like Ashton Court and Leigh Woods, so the boys still get breathable outdoor time even if road noise is nearby.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "For families based in Bristol, Combined tech salaries fall into 40% higher-rate bands, so we’d lean on pension contributions and child benefit clawback planning.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn sits near 9–16 °C (48–61 °F); Atlantic fronts bring windy rain but not the temperature whiplash we flee in the Midwest.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "For families based in Bristol, Libraries, museums, and free festivals give the boys endless weekend options, and most towns offer playgrounds within a short walk.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "For families based in Bristol, Dependents can work or study freely once visas are issued, but NHS surcharge and school admissions timelines require upfront planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "For families based in Bristol, Statutory leave plus flexible working rights back up Sarah’s work-life goals, even if benefit levels lag Nordic standards.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "For families based in Bristol, Middle-class families often mix statutory leave with part-time returns and grandparents, a pattern we could mirror with hybrid roles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "For families based in Bristol, Many leave rights apply, but means-tested benefits exclude most work visas, so we’d rely on employer top-ups.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "For families based in Bristol, Women pair athleisure with tailored coats, making it easy for Sarah to stay comfortable and polished.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "For families based in Bristol, Smart-casual layers and weatherproof outerwear dominate, so Trey’s tech wardrobe fits right in.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "For families based in Bristol, Women comfortably mix professional and casual styles, and weather-ready layers keep expectations practical for Sarah.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Auroch Digital, Yogscast Games, and Opposable VR offer steady roles, but Trey would mix local gigs with remote contracts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "For families based in Bristol, Legal recognition of non-binary identities is emerging and urban schools teach inclusion, though rural areas can be conservative.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "For families based in Bristol, The Equality Act and active advocacy groups deliver strong protections, even if pay gaps persist in some sectors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "For families based in Bristol, Dual-career households are normal and dads taking leave is increasingly accepted, aligning with the family’s egalitarian approach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "For families based in Bristol, BRP-to-eVisa transitions, proof-of-address hurdles, and credit history building take effort during the first year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "For families based in Bristol, Climate models flag more heavy rain and coastal flood risk, so we'd budget for flood-aware housing and insurance while still seeing the islands as relatively safe from extreme heat.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "For families based in Bristol, The NHS covers care without bills, but specialty waits and GP backlogs mean we’d pair it with occasional private visits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "For families based in Bristol, Paying the Immigration Health Surcharge grants full NHS access, though first-year GP registration and wait times require patience.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "For families based in Bristol, Domestic tuition caps and income-based loans keep university feasible for the boys if we settle long term.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "For families based in Bristol, Until indefinite leave, the kids would face international fees, so permanent residency becomes key before university age.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family terraces in Bishopston or Southville run pricey and competitive, but moving slightly outward toward Nailsea or Portishead keeps the search manageable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "For families based in Bristol, PAYE handles most income tax automatically, and digital self-assessment tools make side projects manageable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "For families based in Bristol, State schools are free with decent secular options; we just need to pick catchments with strong Ofsted reports.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "For families based in Bristol, Children on dependent visas can enroll easily, yet proof of address and NHS numbers add upfront paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "For families based in Bristol, English dominates daily life and services, so integration is frictionless while the kids still meet Welsh or Gaelic at school for enrichment.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "For families based in Bristol, Legal equality and visible Pride events keep queer families supported, with only isolated pushback outside cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "For families based in Bristol, Leftist movements stay mostly academic or activist; mainstream parties frame them as fringe.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "For families based in Bristol, Modern fatherhood and flexible work are increasingly celebrated, though pub and sport culture still prize stoicism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "TechSpark, Bristol Games Hub, and community workshops at Knowle West Media Centre make rebuilding friend networks straightforward.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "For families based in Bristol, The National Living Wage rises annually and covers core expenses outside London, though big-city rents would still push the family toward dual tech incomes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fibre is rolling out citywide and 5G covers the core, though we’d still plan around patchy MetroWest rail upgrades.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "The Mendip Hills, Wye Valley, and Clifton Gorge give us dramatic hikes and climbing within an hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Aside from localized Avon flooding and strong Channel winds, Bristol avoids major disaster exposure so resilience prep is straightforward.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Car-free rights of way like the Bristol-Bath Railway Path plus National Trust estates make it easy to plan weekend rambles with the boys.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Colston Hall's reboot, Thekla, and motion club nights sustain Bristol's trip-hop legacy without overwhelming crowds.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Late-night buses and compact neighborhoods mean we can enjoy gigs yet still get home before the kids' breakfast routine.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Bristol Games Hub coworking and Bristol Unreal Meetup supply the collaborative energy Trey thrives on.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Auroch Digital, Ground Shatter, and indie VR outfits headline the local scene, backed by publishing connections up the rail line.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "The Bristol Games Hub incubator, SETsquared, and West of England Creative Business grants give Trey's indie studio a realistic launchpad.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Creative quarters buzz on weekends while neighborhoods like Totterdown stay relaxed, giving Sarah the slower cadence she wants without sacrificing culture.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "For families based in Bristol, Parents juggle school runs, sports clubs, and homework but the schedule is manageable with wraparound care and plentiful parks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "For families based in Bristol, Five years on a qualifying visa plus 12 months ILR, Life in the UK, and language tests make the process structured yet paperwork-heavy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "For families based in Bristol, Transparency laws and watchdog journalism keep corruption low, with sleaze stories typically triggering resignations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "For families based in Bristol, A parliamentary democracy with devolved nations offers checks and civic engagement channels the family appreciates.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "For families based in Bristol, Major cities host polyamory meetups and sex-positive therapists, yet the legal framework stays monogamy-only so we would stay discreet with schools.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "For families based in Bristol, Funded 15–30 hour nursery slots help at ages 3–4, yet infant care has waitlists and high fees in London.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "For families based in Bristol, Independent schools offer strong academics but fees rival US colleges, so we’d treat them as backup rather than plan A.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "For families based in Bristol, Cities lean progressive with protections for LGBTQ+ residents, though national politics swing between centrist parties.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "For families based in Bristol, Campaigns lean on patriotic framing and culture-war headlines, but plural media lets the family curate calmer sources.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "For families based in Bristol, Public broadcasters provide balance, yet tabloids and partisan social media keep spin in the daily mix.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Frequent First Bus routes and the MetroBus help, but reliability dips at rush hour so we'd keep a car-share membership for backups.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "For families based in Bristol, Religion is mostly private nationally, yet Northern Ireland and some school policies keep faith voices visible.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "For families based in Bristol, Hybrid weeks and coworking hubs are normal in tech, letting Sarah secure a low-stress remote role while Trey taps London meetings as needed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "For families based in Bristol, Most work visas run 2–5 years with clear upgrade paths to Indefinite Leave to Remain if we track absence limits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "For families based in Bristol, The state pension supplements workplace schemes, but comfortable retirement still depends on private savings and housing equity.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "For families based in Bristol, Access hinges on National Insurance years and keeping UK pensions portable, so we’d maintain US savings as backup.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "For families based in Bristol, Ruby is niche but active across London and Edinburgh startups, so Sarah would need networking yet still find remote or hybrid teams.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Property crime and bike theft around the Centre are noticeable, so we'd favour well-lit streets and secure storage for gear.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "For families based in Bristol, State, academy, and a smattering of secular private schools give us choice, but grammar and faith admissions require careful catchment planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Bristol Channel waters average 8 °C in spring and peak near 17 °C (63 °F) in August, so wetsuits stay essential for more than a quick dip.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "The Severn Estuary keeps Bristol winters and summers mild, but lingering drizzle and occasional humid spells mean we plan indoor backups for family outings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "For families based in Bristol, Comprehensive sex education and liberal norms in metros support the family’s sex-positive outlook, even if rural areas stay discreet.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "For families based in Bristol, Universal healthcare and benefits exist, yet austerity-era cuts mean we’d verify local delivery before committing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March–May typically run 7–15 °C (45–59 °F); layers and rain shells keep school runs comfortable despite showers.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "For families based in Bristol, Institutions are steady but Brexit-era leadership churn shows politics can be noisy every few years.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "For families based in Bristol, Politics oscillates between centrist Conservatives and Labour, so policy swings require periodic recalibration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "For families based in Bristol, A mature mixed economy balances free markets with public services like the NHS, matching the family’s preference for safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summer highs around 19–24 °C (66–75 °F) feel gentle, with only the odd humid week when we break out fans for upstairs bedrooms.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "For families based in Bristol, Visa fees, NHS surcharges, and biometrics push costs into the thousands per adult, and processing can stretch to several months.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "For families based in Bristol, Surveys show middling trust after scandals, so expect lively political debate at the school gate.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "For families based in Bristol, Issues surface around procurement or lobbying rather than day-to-day bribery, so it rarely touches family life.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "For families based in Bristol, Senior dev pay trails US hubs, so Trey and Sarah would lean on remote-friendly roles or equity to balance London-area costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "For families based in Bristol, Weekends mix kids’ clubs, museums, and park time; Sunday trading rules leave ample family windows even without a car.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "For families based in Bristol, Schools run roughly 08:30–15:00 and offices 09:00–17:30, so we’d lean on wraparound care or flex hours to bridge commutes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "For families based in Bristol, Statutory 28 days including bank holidays beats US norms and lets the family plan regular school-break trips.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "For families based in Bristol, Tech employers often offer 30–33 days plus buy/sell schemes, keeping family adventures aligned with school calendars.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "For families based in Bristol, Opinions on the EU and Ireland are mixed post-Brexit, so dinner-table talk can get political.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "For families based in Bristol, The UK balances pride in institutions with a pragmatic streak, making locals confident yet approachable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "For families based in Bristol, Neighbors respect UK culture but criticise Brexit-era politics, which the family should expect to hear while travelling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "For families based in Bristol, Skilled Worker and Global Talent routes are viable but expensive, and Innovator Founder demands robust business plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "For families based in Bristol, Shared language and cultural ties make Americans broadly welcome, especially in cosmopolitan cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Street art culture, harborside festivals, and quick escapes to the countryside deliver the creative-yet-grounded lifestyle we want.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters hover 3–8 °C (37–46 °F) with damp chill and early sunsets, so we budget for dehumidifiers and indoor play zones.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "For families based in Bristol, Contracts target 37.5–40 hours and flex arrangements are common, yet finance and game studios still expect overtime around launches.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "For families based in Bristol, Hybrid norms, 28+ days of leave, and cultural respect for evenings help Sarah secure calmer schedules, though crunch remains in some London studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "For families based in Bristol, Holiday pay, sick leave, and union protections exceed US baselines, though zero-hour contracts linger in retail and hospitality.",
+      "alignmentValue": 7
+    }
+  ]
+}

--- a/reports/united_kingdom_edinburgh_report.json
+++ b/reports/united_kingdom_edinburgh_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "GB",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "For families based in Edinburgh, Enterprise, fintech, and public-sector demand keeps .NET roles plentiful in London, Manchester, and Leeds, giving Trey steady options.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Air quality generally meets WHO guidance, with only brief NO2 spikes along Princes Street and the city bypass.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "For families based in Edinburgh, Secularism is common and religion rarely intrudes on workplaces or schools, matching the family’s secular preference.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "For families based in Edinburgh, Independent courts, free media, and active civil society keep backsliding low despite occasional executive-overreach debates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "For families based in Edinburgh, Contactless, Faster Payments, and open banking apps make cashless living seamless for daily errands and business invoices.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Portobello Beach and East Lothian coastlines are close, yet cold North Sea water keeps swims to hardy summer dips.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Shops like Black Lion Games and clubs at Summerhall sustain regular tabletop nights.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "For families based in Edinburgh, Tax-free childcare accounts and funded hours help once both parents work, but under-three costs remain steep.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "For families based in Edinburgh, Most cities prioritise pram access, family lanes on transit, and museums geared to kids, though older infrastructure can add stairs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "For families based in Edinburgh, Citizens tap shared parental leave, child benefit, and expanded free-hours rollouts, though out-of-pocket nursery costs stay high for under-threes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "For families based in Edinburgh, Temporary visas unlock 30 funded hours once both parents work, but NRPF rules block child benefit so we’d budget extra cash flow.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "For families based in Edinburgh, Football, hiking, gaming, and pub quizzes keep plenty of overlap with the family’s interests.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "For families based in Edinburgh, Local councils, clubs, and neighborhood WhatsApp groups help newcomers plug in quickly, which suits their search for community.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "For families based in Edinburgh, We must track absences for ILR, register for taxes promptly, and update digital status, but rules are transparent.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Rents and childcare sit below London yet above northern England, requiring mindful budgeting during festival season surges.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "For families based in Edinburgh, The UK allows dual nationality, so the family can retain US passports without complications.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "For families based in Edinburgh, The UK services economy is mature but slow-growing, with inflation aftershocks and regional inequality to watch.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "For families based in Edinburgh, A regulated market economy with social safety nets supports entrepreneurship while cushioning healthcare and schooling costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "For families based in Edinburgh, Quality varies by local authority, so we’d target strong Ofsted areas or consider academy chains with robust STEM tracks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "For families based in Edinburgh, Thousands of licensed sponsors exist, but high fees and salary thresholds mean we must target shortage-list employers early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Edinburgh's compact core sits between Arthur's Seat and the Firth of Forth, giving us clean air and everyday access to green volcanic hills.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "For families based in Edinburgh, Combined tech salaries fall into 40% higher-rate bands, so we’d lean on pension contributions and child benefit clawback planning.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn sits near 8–14 °C (46–57 °F) with brisk winds off the Forth, so we plan more indoor cultural outings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "For families based in Edinburgh, Libraries, museums, and free festivals give the boys endless weekend options, and most towns offer playgrounds within a short walk.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "For families based in Edinburgh, Dependents can work or study freely once visas are issued, but NHS surcharge and school admissions timelines require upfront planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "For families based in Edinburgh, Statutory leave plus flexible working rights back up Sarah’s work-life goals, even if benefit levels lag Nordic standards.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "For families based in Edinburgh, Middle-class families often mix statutory leave with part-time returns and grandparents, a pattern we could mirror with hybrid roles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "For families based in Edinburgh, Many leave rights apply, but means-tested benefits exclude most work visas, so we’d rely on employer top-ups.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "For families based in Edinburgh, Women pair athleisure with tailored coats, making it easy for Sarah to stay comfortable and polished.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "For families based in Edinburgh, Smart-casual layers and weatherproof outerwear dominate, so Trey’s tech wardrobe fits right in.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "For families based in Edinburgh, Women comfortably mix professional and casual styles, and weather-ready layers keep expectations practical for Sarah.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Rockstar North, Build A Rocket Boy, and Ubisoft Reflections satellites keep engineering roles abundant.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "For families based in Edinburgh, Legal recognition of non-binary identities is emerging and urban schools teach inclusion, though rural areas can be conservative.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "For families based in Edinburgh, The Equality Act and active advocacy groups deliver strong protections, even if pay gaps persist in some sectors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "For families based in Edinburgh, Dual-career households are normal and dads taking leave is increasingly accepted, aligning with the family’s egalitarian approach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "For families based in Edinburgh, BRP-to-eVisa transitions, proof-of-address hurdles, and credit history building take effort during the first year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "For families based in Edinburgh, Climate models flag more heavy rain and coastal flood risk, so we'd budget for flood-aware housing and insurance while still seeing the islands as relatively safe from extreme heat.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "For families based in Edinburgh, The NHS covers care without bills, but specialty waits and GP backlogs mean we’d pair it with occasional private visits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "For families based in Edinburgh, Paying the Immigration Health Surcharge grants full NHS access, though first-year GP registration and wait times require patience.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "For families based in Edinburgh, Domestic tuition caps and income-based loans keep university feasible for the boys if we settle long term.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "For families based in Edinburgh, Until indefinite leave, the kids would face international fees, so permanent residency becomes key before university age.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Tenement flats in Morningside or Leith move fast, but expanding searches to Liberton or Portobello opens more family-sized options.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "For families based in Edinburgh, PAYE handles most income tax automatically, and digital self-assessment tools make side projects manageable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "For families based in Edinburgh, State schools are free with decent secular options; we just need to pick catchments with strong Ofsted reports.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "For families based in Edinburgh, Children on dependent visas can enroll easily, yet proof of address and NHS numbers add upfront paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "For families based in Edinburgh, English dominates daily life and services, so integration is frictionless while the kids still meet Welsh or Gaelic at school for enrichment.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "For families based in Edinburgh, Legal equality and visible Pride events keep queer families supported, with only isolated pushback outside cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "For families based in Edinburgh, Leftist movements stay mostly academic or activist; mainstream parties frame them as fringe.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "For families based in Edinburgh, Modern fatherhood and flexible work are increasingly celebrated, though pub and sport culture still prize stoicism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "CodeBase, Edinburgh Games Meetup, and rich arts communities make networking across tech and culture effortless.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "For families based in Edinburgh, The National Living Wage rises annually and covers core expenses outside London, though big-city rents would still push the family toward dual tech incomes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Citywide fibre, 5G, and modern trams keep infrastructure strong, though cobbled closes limit cycling speeds.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Access to the Pentlands, Highlands rail links, and dramatic coastline make world-class scenery part of regular family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Flood mitigation along the Water of Leith keeps risk low; earthquakes and extreme heat are essentially absent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "City buses reach hill trails, and ScotRail weekend tickets put Cairngorms hikes within easy reach.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "From jazz at The Voodoo Rooms to festival venues, there's plenty of evening culture without London-scale chaos.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Licensing keeps most venues closed by midnight outside festival weeks, which suits early parenting schedules.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Scottish Games Network events, InGAME, and university-led meetups foster collaboration.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Rockstar North, Build A Rocket Boy, and Outplay’s nearby Dundee studio highlight Scotland's AAA credentials.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "InGAME vouchers, Scottish Enterprise grants, and access to university talent give Trey's startup a supportive launchpad.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Festival months feel bustling, but the rest of the year retains a measured pace suited to family routines.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "For families based in Edinburgh, Parents juggle school runs, sports clubs, and homework but the schedule is manageable with wraparound care and plentiful parks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "For families based in Edinburgh, Five years on a qualifying visa plus 12 months ILR, Life in the UK, and language tests make the process structured yet paperwork-heavy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "For families based in Edinburgh, Transparency laws and watchdog journalism keep corruption low, with sleaze stories typically triggering resignations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "For families based in Edinburgh, A parliamentary democracy with devolved nations offers checks and civic engagement channels the family appreciates.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "For families based in Edinburgh, Major cities host polyamory meetups and sex-positive therapists, yet the legal framework stays monogamy-only so we would stay discreet with schools.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "For families based in Edinburgh, Funded 15–30 hour nursery slots help at ages 3–4, yet infant care has waitlists and high fees in London.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "For families based in Edinburgh, Independent schools offer strong academics but fees rival US colleges, so we’d treat them as backup rather than plan A.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "For families based in Edinburgh, Cities lean progressive with protections for LGBTQ+ residents, though national politics swing between centrist parties.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "For families based in Edinburgh, Campaigns lean on patriotic framing and culture-war headlines, but plural media lets the family curate calmer sources.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "For families based in Edinburgh, Public broadcasters provide balance, yet tabloids and partisan social media keep spin in the daily mix.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Lothian Buses, the tram to the airport, and frequent ScotRail links create a reliable car-light lifestyle.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "For families based in Edinburgh, Religion is mostly private nationally, yet Northern Ireland and some school policies keep faith voices visible.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "For families based in Edinburgh, Hybrid weeks and coworking hubs are normal in tech, letting Sarah secure a low-stress remote role while Trey taps London meetings as needed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "For families based in Edinburgh, Most work visas run 2–5 years with clear upgrade paths to Indefinite Leave to Remain if we track absence limits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "For families based in Edinburgh, The state pension supplements workplace schemes, but comfortable retirement still depends on private savings and housing equity.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "For families based in Edinburgh, Access hinges on National Insurance years and keeping UK pensions portable, so we’d maintain US savings as backup.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "For families based in Edinburgh, Ruby is niche but active across London and Edinburgh startups, so Sarah would need networking yet still find remote or hybrid teams.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime stays low; we mostly watch for late-night disorder near the Royal Mile during tourist peaks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "For families based in Edinburgh, State, academy, and a smattering of secular private schools give us choice, but grammar and faith admissions require careful catchment planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "North Sea temps hover 6–14 °C (43–57 °F); wetsuits are mandatory for more than a splash.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Cool, breezy summers and long winter nights demand good rain gear and light therapy to keep family morale high.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "For families based in Edinburgh, Comprehensive sex education and liberal norms in metros support the family’s sex-positive outlook, even if rural areas stay discreet.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "For families based in Edinburgh, Universal healthcare and benefits exist, yet austerity-era cuts mean we’d verify local delivery before committing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Spring ranges 6–13 °C (43–55 °F); layered clothing and waterproof shoes stay essential for school runs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "For families based in Edinburgh, Institutions are steady but Brexit-era leadership churn shows politics can be noisy every few years.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "For families based in Edinburgh, Politics oscillates between centrist Conservatives and Labour, so policy swings require periodic recalibration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "For families based in Edinburgh, A mature mixed economy balances free markets with public services like the NHS, matching the family’s preference for safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summers hover around 14–20 °C (57–68 °F); rare heat spikes above 25 °C are brief but nights remain cool.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "For families based in Edinburgh, Visa fees, NHS surcharges, and biometrics push costs into the thousands per adult, and processing can stretch to several months.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "For families based in Edinburgh, Surveys show middling trust after scandals, so expect lively political debate at the school gate.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "For families based in Edinburgh, Issues surface around procurement or lobbying rather than day-to-day bribery, so it rarely touches family life.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "For families based in Edinburgh, Senior dev pay trails US hubs, so Trey and Sarah would lean on remote-friendly roles or equity to balance London-area costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "For families based in Edinburgh, Weekends mix kids’ clubs, museums, and park time; Sunday trading rules leave ample family windows even without a car.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "For families based in Edinburgh, Schools run roughly 08:30–15:00 and offices 09:00–17:30, so we’d lean on wraparound care or flex hours to bridge commutes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "For families based in Edinburgh, Statutory 28 days including bank holidays beats US norms and lets the family plan regular school-break trips.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "For families based in Edinburgh, Tech employers often offer 30–33 days plus buy/sell schemes, keeping family adventures aligned with school calendars.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "For families based in Edinburgh, Opinions on the EU and Ireland are mixed post-Brexit, so dinner-table talk can get political.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "For families based in Edinburgh, The UK balances pride in institutions with a pragmatic streak, making locals confident yet approachable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "For families based in Edinburgh, Neighbors respect UK culture but criticise Brexit-era politics, which the family should expect to hear while travelling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "For families based in Edinburgh, Skilled Worker and Global Talent routes are viable but expensive, and Innovator Founder demands robust business plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "For families based in Edinburgh, Shared language and cultural ties make Americans broadly welcome, especially in cosmopolitan cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Living amid Enlightenment architecture with instant access to festivals and Highlands hikes fits our love of culture and nature.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters average 1–6 °C (34–43 °F); damp chill and short daylight need cozy routines and maybe a SAD lamp.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "For families based in Edinburgh, Contracts target 37.5–40 hours and flex arrangements are common, yet finance and game studios still expect overtime around launches.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "For families based in Edinburgh, Hybrid norms, 28+ days of leave, and cultural respect for evenings help Sarah secure calmer schedules, though crunch remains in some London studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "For families based in Edinburgh, Holiday pay, sick leave, and union protections exceed US baselines, though zero-hour contracts linger in retail and hospitality.",
+      "alignmentValue": 7
+    }
+  ]
+}

--- a/reports/united_kingdom_manchester_report.json
+++ b/reports/united_kingdom_manchester_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "GB",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "For families based in Manchester, Enterprise, fintech, and public-sector demand keeps .NET roles plentiful in London, Manchester, and Leeds, giving Trey steady options.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Busy arterial roads push NO2 above targets some days, so we'd track GM Clean Air updates before biking with the kids.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "For families based in Manchester, Secularism is common and religion rarely intrudes on workplaces or schools, matching the family’s secular preference.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "For families based in Manchester, Independent courts, free media, and active civil society keep backsliding low despite occasional executive-overreach debates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "For families based in Manchester, Contactless, Faster Payments, and open banking apps make cashless living seamless for daily errands and business invoices.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Formby and Lytham beaches are doable by train for day trips, yet the Irish Sea stays chilly and travel time limits spontaneity.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Fan Boy 3, Travelling Man, and UK Games Expo satellites ensure constant tabletop events.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "For families based in Manchester, Tax-free childcare accounts and funded hours help once both parents work, but under-three costs remain steep.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "For families based in Manchester, Most cities prioritise pram access, family lanes on transit, and museums geared to kids, though older infrastructure can add stairs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "For families based in Manchester, Citizens tap shared parental leave, child benefit, and expanded free-hours rollouts, though out-of-pocket nursery costs stay high for under-threes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "For families based in Manchester, Temporary visas unlock 30 funded hours once both parents work, but NRPF rules block child benefit so we’d budget extra cash flow.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "For families based in Manchester, Football, hiking, gaming, and pub quizzes keep plenty of overlap with the family’s interests.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "For families based in Manchester, Local councils, clubs, and neighborhood WhatsApp groups help newcomers plug in quickly, which suits their search for community.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "For families based in Manchester, We must track absences for ILR, register for taxes promptly, and update digital status, but rules are transparent.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Housing and childcare are mid-range, leaving room in the budget for Trey's studio runway compared with southern England.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "For families based in Manchester, The UK allows dual nationality, so the family can retain US passports without complications.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "For families based in Manchester, The UK services economy is mature but slow-growing, with inflation aftershocks and regional inequality to watch.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "For families based in Manchester, A regulated market economy with social safety nets supports entrepreneurship while cushioning healthcare and schooling costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "For families based in Manchester, Quality varies by local authority, so we’d target strong Ofsted areas or consider academy chains with robust STEM tracks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "For families based in Manchester, Thousands of licensed sponsors exist, but high fees and salary thresholds mean we must target shortage-list employers early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Manchester's core is urban but canalside revitalization and nearby Peak District escapes keep everyday life from feeling concrete-bound.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "For families based in Manchester, Combined tech salaries fall into 40% higher-rate bands, so we’d lean on pension contributions and child benefit clawback planning.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn keeps to 9–15 °C (48–59 °F) with plenty of grey skies, making indoor cultural plans handy.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "For families based in Manchester, Libraries, museums, and free festivals give the boys endless weekend options, and most towns offer playgrounds within a short walk.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "For families based in Manchester, Dependents can work or study freely once visas are issued, but NHS surcharge and school admissions timelines require upfront planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "For families based in Manchester, Statutory leave plus flexible working rights back up Sarah’s work-life goals, even if benefit levels lag Nordic standards.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "For families based in Manchester, Middle-class families often mix statutory leave with part-time returns and grandparents, a pattern we could mirror with hybrid roles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "For families based in Manchester, Many leave rights apply, but means-tested benefits exclude most work visas, so we’d rely on employer top-ups.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "For families based in Manchester, Women pair athleisure with tailored coats, making it easy for Sarah to stay comfortable and polished.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "For families based in Manchester, Smart-casual layers and weatherproof outerwear dominate, so Trey’s tech wardrobe fits right in.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "For families based in Manchester, Women comfortably mix professional and casual styles, and weather-ready layers keep expectations practical for Sarah.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Firms like Cloud Imperium, TT Games, and Rockstar Dundee's proximity create diverse engineering opportunities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "For families based in Manchester, Legal recognition of non-binary identities is emerging and urban schools teach inclusion, though rural areas can be conservative.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "For families based in Manchester, The Equality Act and active advocacy groups deliver strong protections, even if pay gaps persist in some sectors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "For families based in Manchester, Dual-career households are normal and dads taking leave is increasingly accepted, aligning with the family’s egalitarian approach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "For families based in Manchester, BRP-to-eVisa transitions, proof-of-address hurdles, and credit history building take effort during the first year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "For families based in Manchester, Climate models flag more heavy rain and coastal flood risk, so we'd budget for flood-aware housing and insurance while still seeing the islands as relatively safe from extreme heat.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "For families based in Manchester, The NHS covers care without bills, but specialty waits and GP backlogs mean we’d pair it with occasional private visits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "For families based in Manchester, Paying the Immigration Health Surcharge grants full NHS access, though first-year GP registration and wait times require patience.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "For families based in Manchester, Domestic tuition caps and income-based loans keep university feasible for the boys if we settle long term.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "For families based in Manchester, Until indefinite leave, the kids would face international fees, so permanent residency becomes key before university age.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family homes in Chorlton or Didsbury cost less than London; new builds in Salford Quays add inventory though demand is rising.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "For families based in Manchester, PAYE handles most income tax automatically, and digital self-assessment tools make side projects manageable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "For families based in Manchester, State schools are free with decent secular options; we just need to pick catchments with strong Ofsted reports.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "For families based in Manchester, Children on dependent visas can enroll easily, yet proof of address and NHS numbers add upfront paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "For families based in Manchester, English dominates daily life and services, so integration is frictionless while the kids still meet Welsh or Gaelic at school for enrichment.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "For families based in Manchester, Legal equality and visible Pride events keep queer families supported, with only isolated pushback outside cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "For families based in Manchester, Leftist movements stay mostly academic or activist; mainstream parties frame them as fringe.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "For families based in Manchester, Modern fatherhood and flexible work are increasingly celebrated, though pub and sport culture still prize stoicism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "TechNorth, Gameopolis, and thriving arts collectives give instant community touchpoints for both parents.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "For families based in Manchester, The National Living Wage rises annually and covers core expenses outside London, though big-city rents would still push the family toward dual tech incomes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Full-fibre rollouts, 5G coverage, and ongoing rail upgrades keep infrastructure competitive for remote work.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "The Peak District, Lake District trains, and Pennine trails provide abundant scenery just beyond city limits.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Flooding along the Irwell is the main concern, mitigated by new defences; other natural hazards stay rare.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Northern Rail and guided cycleways make weekend hikes and climbing trips simple without owning a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Iconic venues like Albert Hall and Band on the Wall keep live music accessible without London travel.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Late trams and 24-hour bus routes support nights out, though we can still retreat to quieter suburbs afterward.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gameopolis meetups, PixelMill, and universities feed a collaborative ecosystem.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Cloud Imperium's UK team, Rebellion North, and indie outfits in MediaCity signal a strong studio cluster.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "MediaCityUK, GMCA grants, and HOST Salford accelerators give Trey's startup real support.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "MediaCity and Northern Quarter hum with energy while surrounding suburbs stay relaxed, offering balance for Sarah.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "For families based in Manchester, Parents juggle school runs, sports clubs, and homework but the schedule is manageable with wraparound care and plentiful parks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "For families based in Manchester, Five years on a qualifying visa plus 12 months ILR, Life in the UK, and language tests make the process structured yet paperwork-heavy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "For families based in Manchester, Transparency laws and watchdog journalism keep corruption low, with sleaze stories typically triggering resignations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "For families based in Manchester, A parliamentary democracy with devolved nations offers checks and civic engagement channels the family appreciates.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "For families based in Manchester, Major cities host polyamory meetups and sex-positive therapists, yet the legal framework stays monogamy-only so we would stay discreet with schools.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "For families based in Manchester, Funded 15–30 hour nursery slots help at ages 3–4, yet infant care has waitlists and high fees in London.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "For families based in Manchester, Independent schools offer strong academics but fees rival US colleges, so we’d treat them as backup rather than plan A.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "For families based in Manchester, Cities lean progressive with protections for LGBTQ+ residents, though national politics swing between centrist parties.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "For families based in Manchester, Campaigns lean on patriotic framing and culture-war headlines, but plural media lets the family curate calmer sources.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "For families based in Manchester, Public broadcasters provide balance, yet tabloids and partisan social media keep spin in the daily mix.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Metrolink trams, heavy rail, and improving bus franchising support a solid car-light lifestyle, albeit with occasional delays.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "For families based in Manchester, Religion is mostly private nationally, yet Northern Ireland and some school policies keep faith voices visible.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "For families based in Manchester, Hybrid weeks and coworking hubs are normal in tech, letting Sarah secure a low-stress remote role while Trey taps London meetings as needed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "For families based in Manchester, Most work visas run 2–5 years with clear upgrade paths to Indefinite Leave to Remain if we track absence limits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "For families based in Manchester, The state pension supplements workplace schemes, but comfortable retirement still depends on private savings and housing equity.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "For families based in Manchester, Access hinges on National Insurance years and keeping UK pensions portable, so we’d maintain US savings as backup.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "For families based in Manchester, Ruby is niche but active across London and Edinburgh startups, so Sarah would need networking yet still find remote or hybrid teams.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "City-centre nightlife brings some antisocial behaviour; family areas remain calmer but we’d stay alert for bike theft.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "For families based in Manchester, State, academy, and a smattering of secular private schools give us choice, but grammar and faith admissions require careful catchment planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Irish Sea temps run 7–17 °C (45–63 °F), so any real swimming is a summer-day excursion with wetsuits.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Expect mild temperatures but frequent drizzle; investing in waterproof gear is essential for school runs and weekend outings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "For families based in Manchester, Comprehensive sex education and liberal norms in metros support the family’s sex-positive outlook, even if rural areas stay discreet.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "For families based in Manchester, Universal healthcare and benefits exist, yet austerity-era cuts mean we’d verify local delivery before committing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Spring settles around 7–14 °C (45–57 °F) with intermittent rain requiring layers and waterproof shoes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "For families based in Manchester, Institutions are steady but Brexit-era leadership churn shows politics can be noisy every few years.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "For families based in Manchester, Politics oscillates between centrist Conservatives and Labour, so policy swings require periodic recalibration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "For families based in Manchester, A mature mixed economy balances free markets with public services like the NHS, matching the family’s preference for safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summers sit near 16–22 °C (61–72 °F); humid spells happen but seldom top 28 °C.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "For families based in Manchester, Visa fees, NHS surcharges, and biometrics push costs into the thousands per adult, and processing can stretch to several months.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "For families based in Manchester, Surveys show middling trust after scandals, so expect lively political debate at the school gate.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "For families based in Manchester, Issues surface around procurement or lobbying rather than day-to-day bribery, so it rarely touches family life.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "For families based in Manchester, Senior dev pay trails US hubs, so Trey and Sarah would lean on remote-friendly roles or equity to balance London-area costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "For families based in Manchester, Weekends mix kids’ clubs, museums, and park time; Sunday trading rules leave ample family windows even without a car.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "For families based in Manchester, Schools run roughly 08:30–15:00 and offices 09:00–17:30, so we’d lean on wraparound care or flex hours to bridge commutes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "For families based in Manchester, Statutory 28 days including bank holidays beats US norms and lets the family plan regular school-break trips.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "For families based in Manchester, Tech employers often offer 30–33 days plus buy/sell schemes, keeping family adventures aligned with school calendars.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "For families based in Manchester, Opinions on the EU and Ireland are mixed post-Brexit, so dinner-table talk can get political.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "For families based in Manchester, The UK balances pride in institutions with a pragmatic streak, making locals confident yet approachable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "For families based in Manchester, Neighbors respect UK culture but criticise Brexit-era politics, which the family should expect to hear while travelling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "For families based in Manchester, Skilled Worker and Global Talent routes are viable but expensive, and Innovator Founder demands robust business plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "For families based in Manchester, Shared language and cultural ties make Americans broadly welcome, especially in cosmopolitan cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Manchester blends global music heritage, Premier League energy, and quick escapes to national parks—an appealing mix for the whole family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters hover 2–7 °C (36–45 °F); damp chill persists but snow is rare.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "For families based in Manchester, Contracts target 37.5–40 hours and flex arrangements are common, yet finance and game studios still expect overtime around launches.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "For families based in Manchester, Hybrid norms, 28+ days of leave, and cultural respect for evenings help Sarah secure calmer schedules, though crunch remains in some London studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "For families based in Manchester, Holiday pay, sick leave, and union protections exceed US baselines, though zero-hour contracts linger in retail and hospitality.",
+      "alignmentValue": 7
+    }
+  ]
+}

--- a/reports/united_kingdom_richmond_report.json
+++ b/reports/united_kingdom_richmond_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "GB",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "For families based in Richmond, Enterprise, fintech, and public-sector demand keeps .NET roles plentiful in London, Manchester, and Leeds, giving Trey steady options.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Air along the Thames corridor stays cleaner than central London, though the A316 still causes occasional NO2 spikes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "For families based in Richmond, Secularism is common and religion rarely intrudes on workplaces or schools, matching the family’s secular preference.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "For families based in Richmond, Independent courts, free media, and active civil society keep backsliding low despite occasional executive-overreach debates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "For families based in Richmond, Contactless, Faster Payments, and open banking apps make cashless living seamless for daily errands and business invoices.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Day trips to Brighton or West Wittering are easy by rail, but local 'beach' time is riverside rather than true surf.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Local clubs plus easy Tube rides to central board-game cafes keep tabletop nights in reach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "For families based in Richmond, Tax-free childcare accounts and funded hours help once both parents work, but under-three costs remain steep.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "For families based in Richmond, Most cities prioritise pram access, family lanes on transit, and museums geared to kids, though older infrastructure can add stairs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "For families based in Richmond, Citizens tap shared parental leave, child benefit, and expanded free-hours rollouts, though out-of-pocket nursery costs stay high for under-threes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "For families based in Richmond, Temporary visas unlock 30 funded hours once both parents work, but NRPF rules block child benefit so we’d budget extra cash flow.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "For families based in Richmond, Football, hiking, gaming, and pub quizzes keep plenty of overlap with the family’s interests.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "For families based in Richmond, Local councils, clubs, and neighborhood WhatsApp groups help newcomers plug in quickly, which suits their search for community.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "For families based in Richmond, We must track absences for ILR, register for taxes promptly, and update digital status, but rules are transparent.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "High council tax, childcare costs, and London-priced groceries demand a two-income budget or remote salaries.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "For families based in Richmond, The UK allows dual nationality, so the family can retain US passports without complications.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "For families based in Richmond, The UK services economy is mature but slow-growing, with inflation aftershocks and regional inequality to watch.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "For families based in Richmond, A regulated market economy with social safety nets supports entrepreneurship while cushioning healthcare and schooling costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "For families based in Richmond, Quality varies by local authority, so we’d target strong Ofsted areas or consider academy chains with robust STEM tracks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "For families based in Richmond, Thousands of licensed sponsors exist, but high fees and salary thresholds mean we must target shortage-list employers early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Richmond-upon-Thames couples dense town centres with vast Richmond Park and Kew Gardens, giving the boys deer-filled greenspace minutes from home.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "For families based in Richmond, Combined tech salaries fall into 40% higher-rate bands, so we’d lean on pension contributions and child benefit clawback planning.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn runs 10–17 °C (50–63 °F) with manageable rain, ideal for park runs and Thames walks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "For families based in Richmond, Libraries, museums, and free festivals give the boys endless weekend options, and most towns offer playgrounds within a short walk.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "For families based in Richmond, Dependents can work or study freely once visas are issued, but NHS surcharge and school admissions timelines require upfront planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "For families based in Richmond, Statutory leave plus flexible working rights back up Sarah’s work-life goals, even if benefit levels lag Nordic standards.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "For families based in Richmond, Middle-class families often mix statutory leave with part-time returns and grandparents, a pattern we could mirror with hybrid roles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "For families based in Richmond, Many leave rights apply, but means-tested benefits exclude most work visas, so we’d rely on employer top-ups.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "For families based in Richmond, Women pair athleisure with tailored coats, making it easy for Sarah to stay comfortable and polished.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "For families based in Richmond, Smart-casual layers and weatherproof outerwear dominate, so Trey’s tech wardrobe fits right in.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "For families based in Richmond, Women comfortably mix professional and casual styles, and weather-ready layers keep expectations practical for Sarah.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Local roles are sparse, but Southwest Trains puts Trey within commuting distance of London's major studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "For families based in Richmond, Legal recognition of non-binary identities is emerging and urban schools teach inclusion, though rural areas can be conservative.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "For families based in Richmond, The Equality Act and active advocacy groups deliver strong protections, even if pay gaps persist in some sectors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "For families based in Richmond, Dual-career households are normal and dads taking leave is increasingly accepted, aligning with the family’s egalitarian approach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "For families based in Richmond, BRP-to-eVisa transitions, proof-of-address hurdles, and credit history building take effort during the first year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "For families based in Richmond, Climate models flag more heavy rain and coastal flood risk, so we'd budget for flood-aware housing and insurance while still seeing the islands as relatively safe from extreme heat.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "For families based in Richmond, The NHS covers care without bills, but specialty waits and GP backlogs mean we’d pair it with occasional private visits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "For families based in Richmond, Paying the Immigration Health Surcharge grants full NHS access, though first-year GP registration and wait times require patience.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "For families based in Richmond, Domestic tuition caps and income-based loans keep university feasible for the boys if we settle long term.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "For families based in Richmond, Until indefinite leave, the kids would face international fees, so permanent residency becomes key before university age.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Semi-detached homes with gardens often top £1M; we may need to rent smaller terraces or look to Twickenham for affordability.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "For families based in Richmond, PAYE handles most income tax automatically, and digital self-assessment tools make side projects manageable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "For families based in Richmond, State schools are free with decent secular options; we just need to pick catchments with strong Ofsted reports.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "For families based in Richmond, Children on dependent visas can enroll easily, yet proof of address and NHS numbers add upfront paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "For families based in Richmond, English dominates daily life and services, so integration is frictionless while the kids still meet Welsh or Gaelic at school for enrichment.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "For families based in Richmond, Legal equality and visible Pride events keep queer families supported, with only isolated pushback outside cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "For families based in Richmond, Leftist movements stay mostly academic or activist; mainstream parties frame them as fringe.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "For families based in Richmond, Modern fatherhood and flexible work are increasingly celebrated, though pub and sport culture still prize stoicism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Family-friendly meetups, expat groups, and proximity to London's tech scene give us both local and citywide networks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "For families based in Richmond, The National Living Wage rises annually and covers core expenses outside London, though big-city rents would still push the family toward dual tech incomes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Full-fibre broadband, 5G, and world-class public services deliver the modern conveniences we expect.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Richmond Park, Kew Gardens, and the Thames Path put outstanding green space at our doorstep.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Floodplains along the Thames demand vigilance, yet defences and alerts keep major risk manageable.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Car-free access to deer parks, river walks, and nearby Surrey Hills keeps nature a daily option.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Richmond Theatre and riverside pubs offer culture close to home, while central London venues remain a quick train ride away.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Most local venues wind down by midnight; true late nights require heading into central London.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "We can tap into London Game Dev Lunch, Ukie events, and Richmond's own creative meetups with minimal travel.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Supermassive Games in Guildford, Media Molecule, and London studios remain accessible by train.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "London investors, Creative England, and nearby coworking hubs give Trey's studio credible capital options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Weekdays feel commuter-heavy, but riverside evenings slow down enough to match Sarah's pace when we stay local.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "For families based in Richmond, Parents juggle school runs, sports clubs, and homework but the schedule is manageable with wraparound care and plentiful parks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "For families based in Richmond, Five years on a qualifying visa plus 12 months ILR, Life in the UK, and language tests make the process structured yet paperwork-heavy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "For families based in Richmond, Transparency laws and watchdog journalism keep corruption low, with sleaze stories typically triggering resignations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "For families based in Richmond, A parliamentary democracy with devolved nations offers checks and civic engagement channels the family appreciates.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "For families based in Richmond, Major cities host polyamory meetups and sex-positive therapists, yet the legal framework stays monogamy-only so we would stay discreet with schools.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "For families based in Richmond, Funded 15–30 hour nursery slots help at ages 3–4, yet infant care has waitlists and high fees in London.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "For families based in Richmond, Independent schools offer strong academics but fees rival US colleges, so we’d treat them as backup rather than plan A.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "For families based in Richmond, Cities lean progressive with protections for LGBTQ+ residents, though national politics swing between centrist parties.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "For families based in Richmond, Campaigns lean on patriotic framing and culture-war headlines, but plural media lets the family curate calmer sources.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "For families based in Richmond, Public broadcasters provide balance, yet tabloids and partisan social media keep spin in the daily mix.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "District line, Overground, and South Western Railway put central London within 30 minutes, with buses filling local gaps.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "For families based in Richmond, Religion is mostly private nationally, yet Northern Ireland and some school policies keep faith voices visible.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "For families based in Richmond, Hybrid weeks and coworking hubs are normal in tech, letting Sarah secure a low-stress remote role while Trey taps London meetings as needed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "For families based in Richmond, Most work visas run 2–5 years with clear upgrade paths to Indefinite Leave to Remain if we track absence limits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "For families based in Richmond, The state pension supplements workplace schemes, but comfortable retirement still depends on private savings and housing equity.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "For families based in Richmond, Access hinges on National Insurance years and keeping UK pensions portable, so we’d maintain US savings as backup.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "For families based in Richmond, Ruby is niche but active across London and Edinburgh startups, so Sarah would need networking yet still find remote or hybrid teams.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Richmond ranks among London's safest boroughs, so we feel comfortable with evening strolls and park time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "For families based in Richmond, State, academy, and a smattering of secular private schools give us choice, but grammar and faith admissions require careful catchment planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Trips to the Sussex coast mean Channel temps of 8–18 °C (46–64 °F); wetsuits still extend swim season.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Southwest London's microclimate stays mild, but humid spells and winter drizzle mean we budget for ventilation and drying space.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "For families based in Richmond, Comprehensive sex education and liberal norms in metros support the family’s sex-positive outlook, even if rural areas stay discreet.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "For families based in Richmond, Universal healthcare and benefits exist, yet austerity-era cuts mean we’d verify local delivery before committing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Spring warms to 9–16 °C (48–61 °F); cherry blossoms in Kew make outdoor play inviting early in the year.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "For families based in Richmond, Institutions are steady but Brexit-era leadership churn shows politics can be noisy every few years.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "For families based in Richmond, Politics oscillates between centrist Conservatives and Labour, so policy swings require periodic recalibration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "For families based in Richmond, A mature mixed economy balances free markets with public services like the NHS, matching the family’s preference for safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summer highs of 20–27 °C (68–81 °F) can turn humid in Victorian semis, so portable AC helps upstairs bedrooms.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "For families based in Richmond, Visa fees, NHS surcharges, and biometrics push costs into the thousands per adult, and processing can stretch to several months.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "For families based in Richmond, Surveys show middling trust after scandals, so expect lively political debate at the school gate.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "For families based in Richmond, Issues surface around procurement or lobbying rather than day-to-day bribery, so it rarely touches family life.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "For families based in Richmond, Senior dev pay trails US hubs, so Trey and Sarah would lean on remote-friendly roles or equity to balance London-area costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "For families based in Richmond, Weekends mix kids’ clubs, museums, and park time; Sunday trading rules leave ample family windows even without a car.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "For families based in Richmond, Schools run roughly 08:30–15:00 and offices 09:00–17:30, so we’d lean on wraparound care or flex hours to bridge commutes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "For families based in Richmond, Statutory 28 days including bank holidays beats US norms and lets the family plan regular school-break trips.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "For families based in Richmond, Tech employers often offer 30–33 days plus buy/sell schemes, keeping family adventures aligned with school calendars.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "For families based in Richmond, Opinions on the EU and Ireland are mixed post-Brexit, so dinner-table talk can get political.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "For families based in Richmond, The UK balances pride in institutions with a pragmatic streak, making locals confident yet approachable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "For families based in Richmond, Neighbors respect UK culture but criticise Brexit-era politics, which the family should expect to hear while travelling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "For families based in Richmond, Skilled Worker and Global Talent routes are viable but expensive, and Innovator Founder demands robust business plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "For families based in Richmond, Shared language and cultural ties make Americans broadly welcome, especially in cosmopolitan cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Richmond marries London's global opportunities with a village feel and UNESCO-level gardens for weekend resets.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winter sits around 3–8 °C (37–46 °F); damp chill means investing in drying cupboards and cozy indoor spaces.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "For families based in Richmond, Contracts target 37.5–40 hours and flex arrangements are common, yet finance and game studios still expect overtime around launches.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "For families based in Richmond, Hybrid norms, 28+ days of leave, and cultural respect for evenings help Sarah secure calmer schedules, though crunch remains in some London studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "For families based in Richmond, Holiday pay, sick leave, and union protections exceed US baselines, though zero-hour contracts linger in retail and hospitality.",
+      "alignmentValue": 7
+    }
+  ]
+}

--- a/reports/united_kingdom_walthamstow_report.json
+++ b/reports/united_kingdom_walthamstow_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "GB",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "For families based in Walthamstow, Enterprise, fintech, and public-sector demand keeps .NET roles plentiful in London, Manchester, and Leeds, giving Trey steady options.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Traffic on the A406 and A12 still elevates NO2, so we’d rely on low-traffic neighbourhoods and monitor alerts before bike rides.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "For families based in Walthamstow, Secularism is common and religion rarely intrudes on workplaces or schools, matching the family’s secular preference.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "For families based in Walthamstow, Independent courts, free media, and active civil society keep backsliding low despite occasional executive-overreach debates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "For families based in Walthamstow, Contactless, Faster Payments, and open banking apps make cashless living seamless for daily errands and business invoices.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Hop-on trains reach Southend or Brighton in about 90 minutes, but local recreation is canals and reservoirs rather than true beaches.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Local cafes plus quick Victoria line rides to central gaming bars keep tabletop nights accessible.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "For families based in Walthamstow, Tax-free childcare accounts and funded hours help once both parents work, but under-three costs remain steep.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "For families based in Walthamstow, Most cities prioritise pram access, family lanes on transit, and museums geared to kids, though older infrastructure can add stairs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "For families based in Walthamstow, Citizens tap shared parental leave, child benefit, and expanded free-hours rollouts, though out-of-pocket nursery costs stay high for under-threes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "For families based in Walthamstow, Temporary visas unlock 30 funded hours once both parents work, but NRPF rules block child benefit so we’d budget extra cash flow.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "For families based in Walthamstow, Football, hiking, gaming, and pub quizzes keep plenty of overlap with the family’s interests.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "For families based in Walthamstow, Local councils, clubs, and neighborhood WhatsApp groups help newcomers plug in quickly, which suits their search for community.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "For families based in Walthamstow, We must track absences for ILR, register for taxes promptly, and update digital status, but rules are transparent.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "London-level childcare and utilities keep budgets tight; Trey's studio runway would need supplemental remote income.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "For families based in Walthamstow, The UK allows dual nationality, so the family can retain US passports without complications.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "For families based in Walthamstow, The UK services economy is mature but slow-growing, with inflation aftershocks and regional inequality to watch.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "For families based in Walthamstow, A regulated market economy with social safety nets supports entrepreneurship while cushioning healthcare and schooling costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "For families based in Walthamstow, Quality varies by local authority, so we’d target strong Ofsted areas or consider academy chains with robust STEM tracks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "For families based in Walthamstow, Thousands of licensed sponsors exist, but high fees and salary thresholds mean we must target shortage-list employers early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Walthamstow sits between Lea Valley wetlands and Epping Forest, giving us greenery alongside urban density.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "For families based in Walthamstow, Combined tech salaries fall into 40% higher-rate bands, so we’d lean on pension contributions and child benefit clawback planning.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn sticks to 10–17 °C (50–63 °F) with manageable rain and long park walks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "For families based in Walthamstow, Libraries, museums, and free festivals give the boys endless weekend options, and most towns offer playgrounds within a short walk.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "For families based in Walthamstow, Dependents can work or study freely once visas are issued, but NHS surcharge and school admissions timelines require upfront planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "For families based in Walthamstow, Statutory leave plus flexible working rights back up Sarah’s work-life goals, even if benefit levels lag Nordic standards.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "For families based in Walthamstow, Middle-class families often mix statutory leave with part-time returns and grandparents, a pattern we could mirror with hybrid roles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "For families based in Walthamstow, Many leave rights apply, but means-tested benefits exclude most work visas, so we’d rely on employer top-ups.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "For families based in Walthamstow, Women pair athleisure with tailored coats, making it easy for Sarah to stay comfortable and polished.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "For families based in Walthamstow, Smart-casual layers and weatherproof outerwear dominate, so Trey’s tech wardrobe fits right in.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "For families based in Walthamstow, Women comfortably mix professional and casual styles, and weather-ready layers keep expectations practical for Sarah.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Being within London keeps Trey close to dozens of studios plus remote-friendly employers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "For families based in Walthamstow, Legal recognition of non-binary identities is emerging and urban schools teach inclusion, though rural areas can be conservative.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "For families based in Walthamstow, The Equality Act and active advocacy groups deliver strong protections, even if pay gaps persist in some sectors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "For families based in Walthamstow, Dual-career households are normal and dads taking leave is increasingly accepted, aligning with the family’s egalitarian approach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "For families based in Walthamstow, BRP-to-eVisa transitions, proof-of-address hurdles, and credit history building take effort during the first year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "For families based in Walthamstow, Climate models flag more heavy rain and coastal flood risk, so we'd budget for flood-aware housing and insurance while still seeing the islands as relatively safe from extreme heat.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "For families based in Walthamstow, The NHS covers care without bills, but specialty waits and GP backlogs mean we’d pair it with occasional private visits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "For families based in Walthamstow, Paying the Immigration Health Surcharge grants full NHS access, though first-year GP registration and wait times require patience.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "For families based in Walthamstow, Domestic tuition caps and income-based loans keep university feasible for the boys if we settle long term.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "For families based in Walthamstow, Until indefinite leave, the kids would face international fees, so permanent residency becomes key before university age.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Victorian terraces are more affordable than central London but still command high bids; we may trade garden size for location.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "For families based in Walthamstow, PAYE handles most income tax automatically, and digital self-assessment tools make side projects manageable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "For families based in Walthamstow, State schools are free with decent secular options; we just need to pick catchments with strong Ofsted reports.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "For families based in Walthamstow, Children on dependent visas can enroll easily, yet proof of address and NHS numbers add upfront paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "For families based in Walthamstow, English dominates daily life and services, so integration is frictionless while the kids still meet Welsh or Gaelic at school for enrichment.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "For families based in Walthamstow, Legal equality and visible Pride events keep queer families supported, with only isolated pushback outside cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "For families based in Walthamstow, Leftist movements stay mostly academic or activist; mainstream parties frame them as fringe.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "For families based in Walthamstow, Modern fatherhood and flexible work are increasingly celebrated, though pub and sport culture still prize stoicism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Makerspaces, queer-friendly collectives, and local mutual-aid groups make plugging into community easy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "For families based in Walthamstow, The National Living Wage rises annually and covers core expenses outside London, though big-city rents would still push the family toward dual tech incomes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Full-fibre broadband, extensive cycleways, and 5G coverage match the family's need for modern connectivity.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Walthamstow Wetlands, Epping Forest, and the Lea Valley offer surprising wilderness minutes from the Victoria line.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Flood mitigation on the River Lea works well; extreme weather remains limited to heatwaves and stormy downpours.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Cycleways and the Overground connect us to wetlands, forests, and canal paths without a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Local breweries, God's Own Junkyard events, and swift travel to Hackney or Soho deliver plenty of evening options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Night Tube services and 24-hour buses mean we can enjoy late shows while still getting home easily.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Ukie events, London Game Dev Lunch, and nearby coworking hubs provide deep networking opportunities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Media Molecule, Rocksteady, Splash Damage, and countless indies are a Tube ride away.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Access to London investors, Digital Catapult, and community workspaces like Blackhorse Workshop helps Trey's indie studio thrive.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Markets and creative hubs buzz on weekends, yet family streets calm quickly at night, giving us a manageable tempo.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "For families based in Walthamstow, Parents juggle school runs, sports clubs, and homework but the schedule is manageable with wraparound care and plentiful parks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "For families based in Walthamstow, Five years on a qualifying visa plus 12 months ILR, Life in the UK, and language tests make the process structured yet paperwork-heavy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "For families based in Walthamstow, Transparency laws and watchdog journalism keep corruption low, with sleaze stories typically triggering resignations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "For families based in Walthamstow, A parliamentary democracy with devolved nations offers checks and civic engagement channels the family appreciates.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "For families based in Walthamstow, Major cities host polyamory meetups and sex-positive therapists, yet the legal framework stays monogamy-only so we would stay discreet with schools.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "For families based in Walthamstow, Funded 15–30 hour nursery slots help at ages 3–4, yet infant care has waitlists and high fees in London.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "For families based in Walthamstow, Independent schools offer strong academics but fees rival US colleges, so we’d treat them as backup rather than plan A.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "For families based in Walthamstow, Cities lean progressive with protections for LGBTQ+ residents, though national politics swing between centrist parties.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "For families based in Walthamstow, Campaigns lean on patriotic framing and culture-war headlines, but plural media lets the family curate calmer sources.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "For families based in Walthamstow, Public broadcasters provide balance, yet tabloids and partisan social media keep spin in the daily mix.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The Victoria line, Overground, and extensive bus routes provide rapid connections across London for work and play.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "For families based in Walthamstow, Religion is mostly private nationally, yet Northern Ireland and some school policies keep faith voices visible.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "For families based in Walthamstow, Hybrid weeks and coworking hubs are normal in tech, letting Sarah secure a low-stress remote role while Trey taps London meetings as needed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "For families based in Walthamstow, Most work visas run 2–5 years with clear upgrade paths to Indefinite Leave to Remain if we track absence limits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "For families based in Walthamstow, The state pension supplements workplace schemes, but comfortable retirement still depends on private savings and housing equity.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "For families based in Walthamstow, Access hinges on National Insurance years and keeping UK pensions portable, so we’d maintain US savings as backup.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "For families based in Walthamstow, Ruby is niche but active across London and Edinburgh startups, so Sarah would need networking yet still find remote or hybrid teams.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Petty theft and occasional antisocial behaviour exist, but community policing and neighbours' WhatsApp groups help us stay informed.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "For families based in Walthamstow, State, academy, and a smattering of secular private schools give us choice, but grammar and faith admissions require careful catchment planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Trips to the Essex coast mean waters around 8–18 °C (46–64 °F), limiting swims to peak summer with wetsuits.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "London's mild seasons hold here, though heatwaves reflect quickly in terraced houses, making ventilation a priority.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "For families based in Walthamstow, Comprehensive sex education and liberal norms in metros support the family’s sex-positive outlook, even if rural areas stay discreet.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "For families based in Walthamstow, Universal healthcare and benefits exist, yet austerity-era cuts mean we’d verify local delivery before committing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Spring ranges 9–16 °C (48–61 °F); the wetlands bloom early, ideal for family walks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "For families based in Walthamstow, Institutions are steady but Brexit-era leadership churn shows politics can be noisy every few years.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "For families based in Walthamstow, Politics oscillates between centrist Conservatives and Labour, so policy swings require periodic recalibration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "For families based in Walthamstow, A mature mixed economy balances free markets with public services like the NHS, matching the family’s preference for safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Summers reach 20–28 °C (68–82 °F); occasional 30 °C spikes require fans or portable AC upstairs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "For families based in Walthamstow, Visa fees, NHS surcharges, and biometrics push costs into the thousands per adult, and processing can stretch to several months.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "For families based in Walthamstow, Surveys show middling trust after scandals, so expect lively political debate at the school gate.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "For families based in Walthamstow, Issues surface around procurement or lobbying rather than day-to-day bribery, so it rarely touches family life.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "For families based in Walthamstow, Senior dev pay trails US hubs, so Trey and Sarah would lean on remote-friendly roles or equity to balance London-area costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "For families based in Walthamstow, Weekends mix kids’ clubs, museums, and park time; Sunday trading rules leave ample family windows even without a car.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "For families based in Walthamstow, Schools run roughly 08:30–15:00 and offices 09:00–17:30, so we’d lean on wraparound care or flex hours to bridge commutes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "For families based in Walthamstow, Statutory 28 days including bank holidays beats US norms and lets the family plan regular school-break trips.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "For families based in Walthamstow, Tech employers often offer 30–33 days plus buy/sell schemes, keeping family adventures aligned with school calendars.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "For families based in Walthamstow, Opinions on the EU and Ireland are mixed post-Brexit, so dinner-table talk can get political.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "For families based in Walthamstow, The UK balances pride in institutions with a pragmatic streak, making locals confident yet approachable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "For families based in Walthamstow, Neighbors respect UK culture but criticise Brexit-era politics, which the family should expect to hear while travelling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "For families based in Walthamstow, Skilled Worker and Global Talent routes are viable but expensive, and Innovator Founder demands robust business plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "For families based in Walthamstow, Shared language and cultural ties make Americans broadly welcome, especially in cosmopolitan cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Walthamstow's creative energy, street markets, and quick Victoria line access offer the cosmopolitan lifestyle we want without leaving East London.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters settle near 3–8 °C (37–46 °F); damp chill and condensation mean we budget for dehumidifiers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "For families based in Walthamstow, Contracts target 37.5–40 hours and flex arrangements are common, yet finance and game studios still expect overtime around launches.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "For families based in Walthamstow, Hybrid norms, 28+ days of leave, and cultural respect for evenings help Sarah secure calmer schedules, though crunch remains in some London studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "For families based in Walthamstow, Holiday pay, sick leave, and union protections exceed US baselines, though zero-hour contracts linger in retail and hospitality.",
+      "alignmentValue": 7
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add localized alignment values and narratives for Bristol, Brighton & Hove, Edinburgh, Manchester, Richmond, and Walthamstow
- register the six new UK cities in `main.json` so they appear in the selector

## Testing
- python - <<'PY'
import json, glob
for path in glob.glob('reports/united_kingdom_*_report.json'):
    with open(path) as f:
        json.load(f)
print('validated', len(glob.glob('reports/united_kingdom_*_report.json')), 'city reports')
PY

------
https://chatgpt.com/codex/tasks/task_e_68e33e3320408321830aa23ddaea7c99