### PR TITLE
Add empty state placeholder for report view

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,43 @@
     }
     .content { display: flex; flex-direction: column; min-height: 0; }
     #report { }
+    .empty-state {
+      border: 2px dashed var(--md-color-outline);
+      background: color-mix(in srgb, var(--md-color-surface) 92%, var(--md-color-background));
+      border-radius: 16px;
+      padding: 48px 24px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      min-height: 320px;
+      text-align: center;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.4), 0 12px 32px rgba(15,23,42,0.08);
+    }
+    .empty-state__icon {
+      width: 80px;
+      height: 80px;
+      border-radius: 50%;
+      background: color-mix(in srgb, var(--md-color-primary) 12%, transparent);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--md-color-primary);
+    }
+    .empty-state__icon svg { width: 42px; height: 42px; }
+    .empty-state h2 { margin: 0; font-size: 20px; }
+    .empty-state p { margin: 0; max-width: 420px; color: color-mix(in srgb, var(--md-color-on-surface) 88%, transparent); }
+    .empty-state__hint { font-size: 13px; color: color-mix(in srgb, var(--md-color-on-surface) 70%, transparent); }
+    body[data-theme="dark"] .empty-state {
+      background: color-mix(in srgb, var(--md-color-surface) 86%, transparent);
+      border-color: color-mix(in srgb, var(--md-color-outline) 60%, transparent);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.05), 0 12px 32px rgba(0,0,0,0.35);
+    }
+    body[data-theme="dark"] .empty-state__icon {
+      background: color-mix(in srgb, var(--md-color-primary) 26%, transparent);
+      color: color-mix(in srgb, var(--md-color-primary) 90%, #ffffff 10%);
+    }
     .toolbar { display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; margin: 8px 0; }
     .toggle {
       display: inline-flex; align-items: center; gap: 6px; padding: 6px 10px;

--- a/script.js
+++ b/script.js
@@ -1,5 +1,43 @@
 const appState = { countries: [], selected: [], nodesByFile: new Map(), showCitiesOnly: false, expandedState: {} };
 
+function renderEmptyReportState() {
+  const reportDiv = document.getElementById('report');
+  if (!reportDiv) return;
+  reportDiv.innerHTML = '';
+  const wrap = document.createElement('div');
+  wrap.className = 'empty-state';
+
+  const iconWrap = document.createElement('div');
+  iconWrap.className = 'empty-state__icon';
+  iconWrap.innerHTML = `
+    <svg viewBox="0 0 64 64" role="img" aria-hidden="true">
+      <g fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="12" y="10" width="40" height="50" rx="6" ry="6"></rect>
+        <path d="M24 8h16l2 6H22l2-6z"></path>
+        <line x1="20" y1="26" x2="44" y2="26"></line>
+        <line x1="20" y1="36" x2="44" y2="36"></line>
+        <line x1="20" y1="46" x2="36" y2="46"></line>
+      </g>
+    </svg>
+  `;
+  wrap.appendChild(iconWrap);
+
+  const heading = document.createElement('h2');
+  heading.textContent = 'Nothing selected yet';
+  wrap.appendChild(heading);
+
+  const message = document.createElement('p');
+  message.textContent = 'Select up to four countries or cities from the list to build a migration comparison report.';
+  wrap.appendChild(message);
+
+  const hint = document.createElement('p');
+  hint.className = 'empty-state__hint';
+  hint.textContent = 'Tip: tap a location again to remove it and make space for another.';
+  wrap.appendChild(hint);
+
+  reportDiv.appendChild(wrap);
+}
+
 function saveSelectedToStorage() {
   try {
     const files = appState.selected.map(s => s.file);
@@ -347,7 +385,12 @@ async function fetchCountry(file) {
 
 function onSelectionChanged(mainData, notice) {
   const selected = appState.selected;
-  if (!selected || selected.length === 0) return;
+  if (!selected || selected.length === 0) {
+    const legendMount = document.getElementById('legendMount');
+    if (legendMount) legendMount.innerHTML = '';
+    renderEmptyReportState();
+    return;
+  }
   // Preserve current table scroll if present
   const reportDiv = document.getElementById('report');
   const oldWrap = reportDiv ? reportDiv.querySelector('.table-wrap') : null;


### PR DESCRIPTION
## Summary
- add a styled empty-state panel so the report area explains what to do when nothing is selected
- clear the report legend and render guidance with an illustrative icon whenever all selections are removed

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3496671148321a558185f193bdd86