### PR TITLE
Fix report overflow and move collapse control to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Migration Report</title>
   <style>
+    *, *::before, *::after { box-sizing: border-box; }
     :root {
       --md-font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
       --md-color-surface: #ffffff;
@@ -60,7 +61,7 @@
     .container { max-width: 100%; margin: 0 auto; padding: 12px 24px 24px; }
     .controls { display: flex; flex-direction: column; gap: 8px; flex: 1 1 auto; min-height: 0; overflow: hidden; }
     .controls .toggle { align-self: flex-start; }
-    .layout { display: grid; grid-template-columns: minmax(260px, 320px) 1fr; gap: 16px; align-items: stretch; width: 100%; flex: 1 1 auto; min-height: 0; }
+    .layout { display: grid; grid-template-columns: minmax(260px, 320px) minmax(0, 1fr); gap: 16px; align-items: stretch; width: 100%; flex: 1 1 auto; min-height: 0; }
     @media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
     .sidebar {
       position: sticky; top: 12px;
@@ -74,7 +75,7 @@
       flex-direction: column;
       overflow: hidden;
     }
-    .content { display: flex; flex-direction: column; min-height: 0; }
+    .content { display: flex; flex-direction: column; min-height: 0; min-width: 0; }
     #report { }
     .toolbar { display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; margin: 8px 0; }
     .toggle {
@@ -137,12 +138,6 @@
     }
     .toggle input { accent-color: var(--md-color-primary); }
     .controls .pill-button { align-self: flex-start; }
-    .report-actions {
-      display: flex;
-      justify-content: flex-end;
-      margin: 8px 0 4px;
-    }
-    .report-actions .pill-button { margin-left: auto; }
     .flag-icon { width: 18px; height: 12px; border-radius: 2px; object-fit: cover; box-shadow: 0 0 0 1px rgba(0,0,0,0.06); }
     th.country-header .flag-icon { margin-right: 6px; vertical-align: -2px; }
     /* selection preview removed */
@@ -497,6 +492,15 @@
     .hero .toolbar .toggle { background: #ffffff; border-color: #e5e7eb; color: #111; }
     .hero .toolbar .toggle:hover { border-color: var(--md-color-primary); box-shadow: 0 0 0 3px color-mix(in srgb, var(--md-color-primary) 16%, transparent); }
     .hero .toolbar .toggle:has(input:checked) { background: color-mix(in srgb, var(--md-color-primary) 14%, #ffffff); border-color: var(--md-color-primary); color: #111; }
+    .hero .toolbar .pill-button {
+      background: #ffffff;
+      border-color: #e5e7eb;
+      color: #111827;
+    }
+    .hero .toolbar .pill-button:hover {
+      border-color: var(--md-color-primary);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--md-color-primary) 16%, transparent);
+    }
   </style>
 </head>
 <body>
@@ -510,6 +514,7 @@
           <label class="toggle"><input type="checkbox" id="themeToggle"/> Dark mode</label>
           <label class="toggle"><input type="checkbox" id="scoresToggle"/> Show scores</label>
           <button id="weightsBtn" type="button" class="toggle">Adjust weights</button>
+          <button id="collapseCategoriesBtn" type="button" class="pill-button">Collapse all categories</button>
         </div>
         <div id="legendMount" class="legend"></div>
       </div>

--- a/script.js
+++ b/script.js
@@ -729,6 +729,12 @@ loadMain();
 async function renderComparison(selectedList, mainData, options = {}) {
   const reportDiv = document.getElementById('report');
   reportDiv.innerHTML = '';
+  const collapseCategoriesBtn = document.getElementById('collapseCategoriesBtn');
+  if (collapseCategoriesBtn) {
+    collapseCategoriesBtn.disabled = true;
+    collapseCategoriesBtn.onclick = null;
+    collapseCategoriesBtn.setAttribute('aria-disabled', 'true');
+  }
 
   // Fetch all selected countries (with caching)
   const datasets = await Promise.all(selectedList.map(async s => ({
@@ -848,34 +854,6 @@ async function renderComparison(selectedList, mainData, options = {}) {
   // Collapsible category support
   const collapsedSet = new Set(getStored('collapsedCategories', []));
   const catSections = [];
-  const actionsBar = document.createElement('div');
-  actionsBar.className = 'report-actions';
-  const collapseCategoriesBtn = document.createElement('button');
-  collapseCategoriesBtn.type = 'button';
-  collapseCategoriesBtn.className = 'pill-button';
-  collapseCategoriesBtn.textContent = 'Collapse all categories';
-  collapseCategoriesBtn.addEventListener('click', () => {
-    if (!catSections.length) return;
-    const collapsedNames = [];
-    catSections.forEach(section => {
-      if (!section) return;
-      if (section.name) collapsedNames.push(section.name);
-      if (section.header) {
-        section.header.classList.add('collapsed');
-      }
-      if (Array.isArray(section.rows)) {
-        section.rows.forEach(row => { row.style.display = 'none'; });
-      }
-      if (section.toggle) {
-        section.toggle.textContent = '▸';
-        section.toggle.setAttribute('aria-expanded', 'false');
-        section.toggle.title = 'Expand category';
-      }
-    });
-    const uniqueNames = Array.from(new Set(collapsedNames.filter(Boolean)));
-    setStored('collapsedCategories', uniqueNames);
-  });
-  actionsBar.appendChild(collapseCategoriesBtn);
 
   // Normalize key strings to avoid Unicode-degree/encoding mismatches in lookups
   const canonKey = (s) => {
@@ -1097,9 +1075,36 @@ async function renderComparison(selectedList, mainData, options = {}) {
 
   table.appendChild(tbody);
 
-  if (!catSections.length) {
-    actionsBar.hidden = true;
-    collapseCategoriesBtn.disabled = true;
+  if (collapseCategoriesBtn) {
+    if (!catSections.length) {
+      collapseCategoriesBtn.disabled = true;
+      collapseCategoriesBtn.onclick = null;
+      collapseCategoriesBtn.setAttribute('aria-disabled', 'true');
+    } else {
+      collapseCategoriesBtn.disabled = false;
+      collapseCategoriesBtn.removeAttribute('aria-disabled');
+      collapseCategoriesBtn.onclick = () => {
+        if (!catSections.length) return;
+        const collapsedNames = [];
+        catSections.forEach(section => {
+          if (!section) return;
+          if (section.name) collapsedNames.push(section.name);
+          if (section.header) {
+            section.header.classList.add('collapsed');
+          }
+          if (Array.isArray(section.rows)) {
+            section.rows.forEach(row => { row.style.display = 'none'; });
+          }
+          if (section.toggle) {
+            section.toggle.textContent = '▸';
+            section.toggle.setAttribute('aria-expanded', 'false');
+            section.toggle.title = 'Expand category';
+          }
+        });
+        const uniqueNames = Array.from(new Set(collapsedNames.filter(Boolean)));
+        setStored('collapsedCategories', uniqueNames);
+      };
+    }
   }
 
   // Ensure sensible minimum width to avoid initial horizontal scrollbar with one country,
@@ -1120,7 +1125,6 @@ async function renderComparison(selectedList, mainData, options = {}) {
   frow.className = 'floating-row';
   floating.appendChild(frow);
   // Insert floating header above the scroll container
-  reportDiv.appendChild(actionsBar);
   reportDiv.appendChild(floating);
   reportDiv.appendChild(wrap);
 


### PR DESCRIPTION
## Summary
- prevent the report column from forcing a page-wide horizontal scroll by tightening the grid layout and content sizing
- surface the "Collapse all categories" control in the header toolbar with matching styling
- rewire the comparison renderer to use the shared collapse button and disable it when no categories are available

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e347136a848321991d8909b7cb5404