### PR TITLE
Limit selections to three locations

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,7 +561,7 @@
   <div class="container layout">
     <aside class="sidebar">
       <div class="controls">
-        <label>Select Locations (up to 4):</label>
+        <label>Select Locations (up to 3):</label>
         <div class="sort-controls">
           <label for="countrySort">Sort by:</label>
           <select id="countrySort">

--- a/script.js
+++ b/script.js
@@ -27,7 +27,7 @@ function renderEmptyReportState() {
   wrap.appendChild(heading);
 
   const message = document.createElement('p');
-  message.textContent = 'Select up to four countries or cities from the list to build a migration comparison report.';
+  message.textContent = 'Select up to three countries or cities from the list to build a migration comparison report.';
   wrap.appendChild(message);
 
   const hint = document.createElement('p');
@@ -51,7 +51,7 @@ function loadSelectedFromStorage(nodesMap) {
   const result = [];
   saved.forEach(f => {
     if (!nodesMap || typeof nodesMap.get !== 'function') return;
-    if (nodesMap.has(f) && result.length < 4) {
+    if (nodesMap.has(f) && result.length < 3) {
       result.push(nodesMap.get(f));
     }
   });
@@ -677,8 +677,8 @@ function toggleSelectNode(item, notice) {
     appState.selected.splice(idx, 1);
     if (notice) notice.textContent = '';
   } else {
-    if (appState.selected.length >= 4) {
-      if (notice) notice.textContent = 'Limited to 4 selections; deselect one to add more.';
+    if (appState.selected.length >= 3) {
+      if (notice) notice.textContent = 'Limited to 3 selections; deselect one to add more.';
       return;
     }
     appState.selected.push(item);


### PR DESCRIPTION
## Summary
- limit the selection logic to allow only three active locations at once
- refresh helper text so the UI communicates the new three-item limit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e34b52b83c8321bd042570a24c6206