### PR TITLE
Add city reports for major global metros

### DIFF
--- a/main.json
+++ b/main.json
@@ -520,7 +520,13 @@
     },
     {
       "name": "China",
-      "file": "reports/china_report.json"
+      "file": "reports/china_report.json",
+      "cities": [
+        {
+          "name": "Shanghai",
+          "file": "reports/china_shanghai_report.json"
+        }
+      ]
     },
     {
       "name": "New Zealand",
@@ -579,6 +585,14 @@
         {
           "name": "San Diego",
           "file": "reports/united_states_san_diego_report.json"
+        },
+        {
+          "name": "Portland",
+          "file": "reports/united_states_portland_report.json"
+        },
+        {
+          "name": "Seattle",
+          "file": "reports/united_states_seattle_report.json"
         }
       ]
     },
@@ -597,6 +611,10 @@
         {
           "name": "Bordeaux",
           "file": "reports/france_bordeaux_report.json"
+        },
+        {
+          "name": "Paris",
+          "file": "reports/france_paris_report.json"
         }
       ]
     },
@@ -701,6 +719,10 @@
         {
           "name": "Walthamstow",
           "file": "reports/united_kingdom_walthamstow_report.json"
+        },
+        {
+          "name": "London",
+          "file": "reports/united_kingdom_london_report.json"
         }
       ]
     },
@@ -802,7 +824,13 @@
     },
     {
       "name": "Japan",
-      "file": "reports/japan_report.json"
+      "file": "reports/japan_report.json",
+      "cities": [
+        {
+          "name": "Tokyo",
+          "file": "reports/japan_tokyo_report.json"
+        }
+      ]
     },
     {
       "name": "Greenland",
@@ -810,7 +838,13 @@
     },
     {
       "name": "South Korea",
-      "file": "reports/south_korea_report.json"
+      "file": "reports/south_korea_report.json",
+      "cities": [
+        {
+          "name": "Seoul",
+          "file": "reports/south_korea_seoul_report.json"
+        }
+      ]
     },
     {
       "name": "North Korea",

--- a/reports/china_shanghai_report.json
+++ b/reports/china_shanghai_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "CN",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Shanghai's riverfront promenades and pocket parks soften the dense skyline, yet industrial runoff and urban heat islands mean we seek weekend getaways for clean air.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "A low-lying delta city, Shanghai faces typhoon storm surges and rising sea levels, though massive seawalls and drainage upgrades mitigate day-to-day risk.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Humid summers and damp winters require dehumidifiers and layered clothing, but spring and autumn offer pleasant windows for exploring neighborhoods.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Annual PM2.5 averages around 30 µg/m³; winter coal use and regional smog demand indoor purifiers and AQI tracking before outdoor play.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Typhoons and Yangtze flooding pose the biggest threats; earthquakes are rare but we still follow emergency prep guidance.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March warms from 10 °C (50 °F) to April-May highs near 22 °C (72 °F) with frequent rain and humidity.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "June–August regularly hit 32–35 °C (90–95 °F) with high humidity and tropical nights, so reliable A/C and siesta scheduling are essential.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September stays warm around 28 °C (82 °F) before easing into crisp, sunny October days near 20 °C (68 °F).",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "December–February hover around 3–9 °C (37–48 °F); damp chill without central heating in older flats means we invest in space heaters.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Nearby beaches like Jinshan are swimmable but often murky; expats prefer day trips to Zhoushan or Hainan flights for clearer water.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Warm in the south but limited swim quality elsewhere.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "City parks are manicured; true nature requires high-speed rail trips to Huangshan or Moganshan mountain retreats.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Shanghai's monthly minimum wage reached ¥2,690 in 2024—strong for China but modest once rent and schooling are included.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers earn ¥350k–¥500k (~$48k–$68k) plus bonuses, comfortable locally but lower than Western packages.",
+      "alignmentValue": 6
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Finance and manufacturing firms maintain .NET stacks, yet Mandarin fluency and long office hours narrow Trey's entry points.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby remains niche; Sarah would rely on multinational teams or remote work to use her stack.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Class A/B work permits require degree, experience, and clean police checks; tech firms sponsor sparingly given quota scrutiny.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Large economy with high growth yet debt concerns.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Shanghai tech largely expects office-first presence, with only multinational hubs allowing sustained hybrid schedules.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Long hours culture such as 996 in tech.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Often exceed statutory 40 hours with overtime.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Five days after first year increasing with tenure.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Many workers take little time off.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Shanghai moves fast—late-night deliveries, crowded metros, and intense school culture mean we'd need to carve out slower routines intentionally.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "International schools run 08:00–15:30; many tech offices expect 09:30–19:00 with overtime, so we'd lean on ayi support or staggered shifts.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends: parks, malls, dining, family visits; extracurriculars common; some sectors work Saturdays; long retail hours in large cities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Strong family obligations and multigenerational households.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Socially unacceptable with potential legal risks.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "High academic pressure and competitiveness.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Infrastructure varies; urban parks limited.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public schools intense; international schools costly but available.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public kindergartens and private centers; supply/cost vary by city tier; expanding 0–3 services; waitlists in core districts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Shanghai residents access longer maternity leave and monthly child stipends, yet slots in quality kindergartens remain competitive.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Expats rarely qualify for subsidies or public kindergarten without Shanghai hukou, pushing families toward costly international preschools.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools broadly available but admissions tied to hukou/residence; quality varies; academic load often heavy.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Foreign dependents often steered to international schools (higher tuition); some cities allow public enrolment with conditions.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International/private schools in major cities (IB/AP/A-Levels); high fees and limited seats; admissions selective.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Maternity/paternity leave expanding; local cash/childcare incentives; housing/tax perks in some cities; coverage uneven.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Benefits generally tied to hukou/social insurance; foreign residents often ineligible for local family subsidies.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Extensive public HE; competitive gaokao; tuition moderate; scholarships and aid exist.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International student options widely available; tuition higher; scholarships exist; residency status may improve options.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Traditional roles prevalent especially outside cities.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Limited acceptance and no legal recognition.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Legal equality on paper but gaps in practice.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Emphasis on appearance and family roles.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Expectation of long work hours and provider role.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Ancient culture and rapid modernization.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Mandarin is essential for schooling, healthcare, and paperwork; English support exists only in expat enclaves of Shanghai and Shenzhen.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Party ideology prioritizes social harmony over individual rights, curbing feminist, queer, and labor activism.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Official ideology influences rhetoric and education.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "High official atheism though traditional religions persist.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Public conservatism and limited sex education.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Pride events are regularly shut down and censorship targets queer media, so openly poly/LGBTQ+ families face persistent state pressure despite decriminalization.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Strong local networks yet wary of outsiders.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Proud of history and national resurgence.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Varies with regional rivalries and disputes.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Often seen as assertive or domineering.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Vibrant in tier‑1 cities (bars, clubs, live music); quieter elsewhere; closing times and enforcement vary by locality.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Urban streetwear and smart‑casual tailoring; sneakers/athleisure common; techwear influences in big cities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Contemporary street style to minimalist chic; dresses/skirts with layering; strong beauty/skin‑care culture.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Mahjong, karaoke, and mobile gaming.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Niche but growing in urban hubs.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Bund rooftops, jazz clubs, and underground electronic scenes keep nightlife lively, though events operate within licensing and censorship limits.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Expanding tech meetups though gatherings are regulated.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Local escapes are mostly curated gardens; genuine wilderness requires train trips to Anhui or Zhejiang provinces.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "One-party socialist state with centralized control.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "State atheism; religion tightly regulated.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Unions are state-run with limited protections.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Socialism with Chinese characteristics guides policy.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "The one-party system deploys surveillance, censorship, and security laws that leave no space for dissent, representing the lowest possible score for democratic resilience.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "State-guided market economy.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Political stability high but dissent suppressed.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "State media strongly shapes narratives.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Promotes unity and party achievements.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Limited rights for dissenting groups.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Official surveys show high trust; dissent is suppressed.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Anti-corruption campaigns ongoing yet local corruption persists.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Both petty and grand corruption, especially locally.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Three-bedroom apartments in central districts exceed ¥25,000/month and require agency fees, so many expats choose Pudong or suburban compounds for space.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Street crime stays low thanks to dense policing, though digital surveillance and internet controls remain pervasive.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Public system improving but uneven quality.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Private insurance often required for expats.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Public nurseries are limited, private centers are costly, and most families rely on grandparents or nannies to cover long work hours.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "State encourages two-child families after relaxing policy.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Flagship schools deliver elite math and science results, yet gaokao pressure, censorship in curricula, and limited progressive pedagogy clash with the family’s priorities.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "A 20-line metro, high-speed rail links, and ubiquitous mobile payments make car-free life effortless once we adapt to health-code style tracking.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "State capitalism with market reforms.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Withholding with annual self-report; complex for expats.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Moderate personal taxes with social contributions.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Advanced mobile payments and cashless society.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Local food and transit are affordable, but international school tuition and imported groceries push overall budgets high for foreign families.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Urban employee basic pension plus enterprise/individual pillars; adequacy varies by region; reforms underway.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Participation depends on city/employer; some contributions refundable on exit; portability limited.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Z visas demand employer sponsorship, background checks, and health exams; entrepreneur or talent visas target high-investment applicants and are rarely approved.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Hospitality at the neighborhood level coexists with rising geopolitical suspicion; regular visa renewals face tighter scrutiny for US citizens.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Z visas convert to 1-year residence permits renewed annually; green cards are rare and require high investment or state sponsorship.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization is rare and restrictive.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Dependent visas allowed but with restrictions.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Processing can be lengthy with heavy paperwork.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Police registrations, exit permits for kids, and Great Firewall compliance are enforced rigorously; policy shifts can void visas with little notice.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "No—dual nationality is not recognized; naturalization typically requires renouncing prior citizenship.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Residence/work permits tied to employer or category; local registration needed for banking/housing; healthcare insurance; internet controls (VPN use).",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Tencent, NetEase, miHoYo, and Lilith maintain large Shanghai studios with heavy demand for engineers, albeit with rigorous hours.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Shanghai hosts miHoYo (Genshin Impact), Lilith Games, and Perfect World teams, keeping Trey's network near global hits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Government-supported incubators and conferences exist.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Government incubators in Zhangjiang Hi-Tech Park and publisher investment exist, but approvals and content regulation slow indie launches.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Maglev trains, cashless payments, and smart city sensors make Shanghai feel ultramodern, even if controls come with that convenience.",
+      "alignmentValue": 10
+    }
+  ]
+}

--- a/reports/france_paris_report.json
+++ b/reports/france_paris_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "FR",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Paris' compact arrondissements hide pockets of green like Parc des Buttes-Chaumont and the Coulée verte, yet we still escape to Fontainebleau forests for breathing room.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "France already faces deadly canicules, drought-stressed rivers, and Atlantic storm surge planning, so the family should expect periodic climate disruptions but benefits from strong adaptation funding.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Atlantic France brings mild, wet winters and comfortable springs, but July–August heatwaves now spike above 35 °C, so the family gets variety with a need for good cooling plans in Paris or Lyon.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Average PM2.5 around 15 µg/m³ and NO2 spikes on périphérique ring roads mean we track smog alerts before long park days.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "River flooding, Atlantic windstorms, and the odd Mediterranean wildfire appear regularly, so insurance and alerts are important but manageable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Atlantic regions hover around 8–15 °C (46–59 °F) and Paris reaches 16 °C (61 °F) by May, with showers but plenty of terrace days the family would enjoy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Paris summer highs average 25 °C (77 °F) but increasingly jump past 35 °C during canicules, while Mediterranean cities exceed 30 °C with warm nights—manageable if the family secures air conditioning.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September stays around 18 °C (64 °F) in Paris before sliding to 10 °C (50 °F) with more rain by November, giving the family a long shoulder season for museum trips and markets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Northern cities hover around 3–8 °C (37–46 °F) with damp chill, while the south stays milder; snow is rare away from the Alps, matching the family’s dislike of harsh winters.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Atlantic beaches like Biarritz and Mediterranean spots near Nice offer lifeguarded sands, though peak tourist season brings crowds and higher prices.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Mediterranean waters warm to 24–26 °C (75–79 °F) by July, while Atlantic coasts stay closer to 19–21 °C, giving the family options depending on comfort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "From Loire Valley châteaux to the Alps and lavender fields in Provence, weekend getaways deliver diverse scenery for the family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The 2024 SMIC near €1,766 gross a month outpaces many EU peers but remains tight once Paris rent and childcare enter the budget.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers in Paris pull €65k–€90k with profit-sharing, enough for metro living but leaner than US remote offers after social charges.",
+      "alignmentValue": 7
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "La Défense banks, aerospace primes, and consultancies hire .NET teams steadily, especially with bilingual talent who can bridge legacy systems.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Rails powers scale-ups like Doctolib, Alan, and BlaBlaCar, giving Sarah healthy pipelines if she navigates French-language standups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Talent Passport and EU Blue Card programs are common for Paris tech hires, yet employers expect French resumes and patience with OFII appointments, so sponsorship is viable but paperwork-heavy.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "France’s €3 trillion economy posts unemployment near 7% and moderate 1–2% growth, offering diversified job markets even during EU downturns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid schedules are normal three days a week, though purely remote contracts often expect periodic office weeks in Paris or Lyon.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "The 35-hour week, legally mandated rest days, and August shutdowns mean managers expect people to disconnect—great for Sarah’s need for predictable downtime.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Statutory 35-hour weeks and overtime caps are enforced, and many tech firms add RTT days, keeping schedules family-friendly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Five weeks statutory leave plus public holidays.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Many offices close in August offering extended breaks.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Central arrondissements buzz late into the evening, so we'd likely settle in calmer suburbs like Montreuil or Issy to protect Sarah's slower cadence.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Primary ~08:30–16:30 (long lunch); Wed often half-day; offices ~09:00–18:00; after‑school care (garderie/études) common.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Family meals, markets, parks, sports; many shops open Sat, limited Sun opening outside big cities; cultural outings.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Weekend markets, public parks, and subsidized sports clubs keep families active, and employers expect parents to take school holidays seriously—great for balancing Trey’s work with kid time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Polyamory lacks legal recognition and is primarily embraced within urban queer networks, so openness requires discretion outside big cities.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools emphasize academics and respect for teachers, with manageable extracurricular commitments compared to US over-scheduling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Urban areas offer parks, museums, and family services.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public collèges/lycées are solid, and Paris/Lyon host bilingual and international schools, though the latter charge €10–15k and require early applications.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "École maternelle is free and near-universal from age 3, while crèche spots and licensed nannies receive CAF subsidies—Trey and Sarah just need to join waitlists early in dense arrondissements.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Parisian families rely on municipal crèches and free école maternelle from age three, but lotteries require early applications and backups with assistantes maternelles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once registered with CAF, visa holders can claim CMG reimbursements, yet French paperwork and processing lags mean we need cash flow for the first months.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens enjoy free, secular schools with strong math/language curricula, and larger cities offer international sections that could give Anduin bilingual exposure.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident children enroll easily once they show address, vaccination, and birth certificates; specialized French-as-a-second-language support helps new arrivals acclimate.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Sous contrat schools cost a few hundred euros per year, while international campuses run €12–€20k and require early applications—important if the family wants English-heavy curricula.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizens tap 16+ weeks paid parental leave, monthly CAF allowances, and tax splitting via the family quotient, all of which underpin generous time with young kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Once the family contributes to Sécurité sociale they can apply for CAF benefits, though proving income and residency history can delay payouts for new arrivals.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Public universities charge a few hundred euros per year, with prestigious CPGE tracks feeding grandes écoles and CROUS housing keeping living costs manageable for future college-aged kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Non-EU students pay a few thousand euros annually unless they secure waivers; scholarships and residency status can bring fees closer to citizen rates over time.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-income households are common and men take more parental leave, though household labor still skews female compared with Nordic norms.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition for gender marker changes exists, yet everyday acceptance varies outside major cities, so queer and trans communities concentrate in urban areas.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Anti-discrimination laws, reproductive rights, and generous parental leave policies align with the family’s equity expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Fashion-conscious culture with broad expressions allowed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Work-life balance and emotional expression encouraged.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Centuries of art, Michelin-level food, and easy train trips to UNESCO sites keep weekends stimulating for the family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "French remains essential for bureaucracy and daily life; English is workable in Paris tech circles but drops fast in prefectures, so the family should plan for classes and translation help.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "France legalised marriage equality and maintains robust secular policies, yet debates over laïcité and policing show tensions—urban areas feel progressive overall for the family.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist traditions influence politics but market economy prevails.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "High secularism with religion largely private.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Sex education is comprehensive and public conversation around relationships is open, though polyamory remains niche outside major cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Legal protections and growing social acceptance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors may seem reserved at first, yet school parent groups, sports clubs, and local associations open doors once the family shows steady participation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "French identity emphasizes republican ideals, culinary heritage, and the role of the state, which locals discuss with pride.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Relations with Germany and Spain are pragmatic and cooperative, while historic rivalries show up mostly in sports banter.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Seen as influential but sometimes aloof.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Paris/Lyon/Marseille vibrant; smaller cities quieter; café/bar culture late dining; safety varies by arrondissement.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Smart‑casual tailoring, minimalist chic, quality sneakers/boots; weather‑appropriate outerwear.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Minimalist to chic; dresses/knits/trousers with layers; strong fashion/beauty culture.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Locals cherish café culture, hiking in the Alps or Pyrenees, and neighborhood sports clubs, offering easy ways for Trey and Sarah to plug into community life.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Publishers like Asmodee are headquartered near Paris, and cities host board-game cafés and festivals such as Paris Est Ludique, aligning with Trey’s tabletop interests.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "From rooftop bars at Cité de la Mode to jazz cellars in Saint-Germain, Paris keeps world-class nightlife within a short metro ride for date nights.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Meetup groups cover startup pitches, queer communities, and parenting circles, especially in Paris and Lyon, giving Trey and Sarah ready-made networks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Regional trains reach hiking trails, vineyards, and coasts within a few hours, making spontaneous nature trips realistic without a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A semi-presidential system with proportional parliamentary elections keeps multiple parties in play and encourages civic engagement.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Strict secularism keeps religion separate from state.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Powerful unions, collective bargaining, and strict dismissal rules give employees leverage if workloads creep up.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "France blends dirigiste economic planning with social welfare, funding public services while courting strategic industries.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Courts, media, and frequent protests keep checks on executive power; even with emergency powers during crises, institutions remain resilient.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Heavy regulation and worker protections coexist with vibrant private enterprise, offering stability at the cost of some bureaucracy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Frequent strikes and protests create noise, yet NATO/EU membership and predictable institutions keep the long-term outlook steady.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters operate independently and investigative journalism is robust, though government messaging spikes during security incidents.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Government campaigns emphasize republican values, anti-extremism, and climate action—messages the family may appreciate even if they can feel frequent after major protests.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare, extensive family benefits, and strong LGBTQ protections align with the family’s progressive values, even if bureaucracy can feel heavy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Eurobarometer surveys show trust hovering near 35%, with protests expressing frustration but not eroding core institutions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "France scores well on Transparency International indices, though periodic political finance scandals remind us to watch procurement processes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption tends to surface in campaign financing or public procurement rather than day-to-day bribery, so diligence on contracts is enough.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family flats inside the périphérique often exceed €2,800 monthly and demand guarantors; many expats choose RER-connected suburbs for space.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime stays low, yet pickpockets around Châtelet and protest marches require situational awareness with the kids.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "France’s universal Sécurité sociale system covers GP visits, maternity care, and prescriptions with low co-pays, delivering reliable care for families.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "After three months of residence the family can enroll in PUMA for public coverage, with supplemental mutuelle plans filling gaps for faster specialist access.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidized childcare and parental benefits available.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Typical families rely on state-run childcare, employer meal vouchers, and long school vacations; coordinating all the paperwork takes effort but pays off.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "High literacy and strong universities though competitive exams.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Sixteen metro lines, RER express trains, and growing tram corridors make car-free living easy, especially once the Grand Paris Express opens new links.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Mixed economy with significant state role.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "France uses pay-as-you-earn withholding plus a streamlined online declaration; expect forms only in French, so hiring an accountant the first year helps.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "High earners face marginal income taxes up to 45% plus ~25% social contributions; with France’s family quotient the effective rate still lands in the low 40s, higher than the family pays today.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "SEPA transfers clear quickly, contactless cards and Apple Pay are ubiquitous, and online banks like Boursorama ease setup once residency documents are ready.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Expect €4,000–€4,500 per month for housing, childcare, and transport in Paris; relocating to commuter towns trims costs but adds travel time.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "France’s pay-as-you-go system now targets retirement around age 64; benefits cover basics but assume homeowners supplement with savings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "US–France totalization lets long-term residents combine contributions, but the family would still rely on private savings given modest state payouts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Talent Passport, EU Blue Card, and Profession Libérale visas cover most scenarios, but each demands diplomas, work contracts, or business plans translated into French.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Large American communities in Paris and Bordeaux smooth integration, yet officials expect French fluency and meticulous paperwork, so patience is required.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Multi-year Talent Passports renew in four-year blocks, and after five years of residence the family can seek 10-year cartes de résident if they maintain income and integration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "After five years of residence (or three if married to a citizen), applicants need B1 French and a civics interview; dual citizenship is allowed so the family can retain US passports.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Long-stay visas allow spouses to work once OFII paperwork is cleared, and children access public schools and healthcare on par with locals.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Consular appointments and OFII validation often stretch 2–4 months, with fees of €200–€450 per adult plus translation costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Visa holders must maintain French tax residence, update prefecture records, and keep health insurance active; missed renewals can trigger exit orders.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Yes—dual nationality is allowed.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Expect ANEF online submissions, in-person OFII visits, French-language leases, and notarized translations; hiring a relocation attorney eases the learning curve.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Ubisoft, Dontnod, Quantic Dream, and Ankama recruit in Paris, while EU studios contract remote specialists, giving Trey steady opportunities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Paris anchors Ubisoft HQ, Quantic Dream, and indie teams like Motion Twin, surrounding Trey with AAA and experimental peers.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Paris Games Week, Game Only meetups, and Women in Games France events keep the dev community active all year.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "CNC grants, the Jeux Vidéo tax credit, and Station F incubators give Trey's studio realistic funding and mentorship paths.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Nationwide fiber, cashless transit gates, and the Grand Paris Express expansion keep infrastructure modern for a tech-focused family.",
+      "alignmentValue": 8
+    }
+  ]
+}

--- a/reports/japan_tokyo_report.json
+++ b/reports/japan_tokyo_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "JP",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Even in dense Tokyo, clean streets and quick escapes to wooded mountains give the kids fresh air, though cedar pollen season means we plan outdoor time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Sea-level rise, harsher typhoons, and deadly heatwaves already test coastal metros, so our risk-averse family would need evacuation plans and extra insurance.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Spring and autumn stay mild enough for park days, but sticky monsoon summers and occasional chilly snaps mean Sarah has to schedule around weather swings.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "National emissions standards keep PM2.5 low most days so the kids can play outside, with only occasional yellow-dust spikes near the capital.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Frequent earthquakes, tsunami alerts, and late-summer typhoons demand constant preparedness and could upend school and work routines.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March–May run roughly 5–20°C (41–68°F) with blooms and light rain, great for outings once we manage cedar allergies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "July–August sit around 30–33°C (86–91°F) with sauna-level humidity and warm nights, so outdoor play needs early mornings and strong A/C.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September starts humid near 25°C (77°F) before cooling to the teens, but typhoons and lingering rain mean we need backup plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Tokyo winters hover near 0–10°C (32–50°F); light coats and occasional frost feel gentler than Missouri cold snaps.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Clean beaches and island getaways exist, yet they require train or flight planning and crowd management during school holidays.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Coastal water only warms above 22°C (72°F) for a short mid-summer window, staying brisk the rest of the year.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Rail trips unlock alpine hikes, onsens, and coastlines, giving the family easy weekend nature escapes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The national average near ¥1,000/hour (~$7) lags far behind big-city living costs, so side income or skilled roles remain essential.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Mid-level engineers typically earn ¥6–8M ($40–55k), which covers local expenses but limits US-style savings for our goals.",
+      "alignmentValue": 5
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Enterprise firms still run .NET stacks, yet most roles expect Japanese fluency and office presence, narrowing Trey's options.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Tokyo's Shibuya and Roppongi startup corridors host vibrant Ruby/Rails teams, with meetups like Tokyo.rb giving Sarah English-friendly peers even if some shops stay Japanese-first.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Large tech employers sponsor engineer visas routinely, though meticulous paperwork and Japanese documents demand patience.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Low unemployment and manageable inflation support stability, but aging demographics keep growth sluggish for entrepreneurs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid policies exist after 2020, yet many teams still default to office-first norms that limit Sarah's preferred remote cadence.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "After-hours expectations and nomikai culture remain strong, clashing with the family's need for predictable evenings.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Legal 40-hour weeks are undercut by common unpaid overtime and weekend crunches in tech.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Employees accrue 10 paid days after six months and slowly build from there, leaving little buffer for extended US visits.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Many staff take fewer than 10 days because of workload and team pressure, so unplugged family trips require negotiation.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Urban life oscillates between intense rush hours and quiet neighborhoods, so we would constantly plan downtime to keep Sarah's stress down.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run roughly 8:30–15:00 while tech jobs stretch past 18:00, forcing us to juggle after-school care or staggered shifts.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends offer museums, festivals, and arcades, yet popular spots book up fast and transit crowds require advance planning.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Safe streets and abundant kid amenities support family routines, though long work hours can cut into shared time.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Polyamorous relationships lack legal standing and are kept discreet, limiting the family's social openness.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools expect parents to volunteer, manage homework clubs, and coordinate uniforms, adding cultural homework for newcomers.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Cities provide spotless parks, nursing rooms, and stroller-friendly transit, offset by small housing that limits indoor play.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public schools are high performing and safe, and major metros add international campuses for continuity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public hoikuen and ninka daycares are plentiful but Tokyo's ward waitlists push families toward licensed private centers or corporate nurseries if they need care before age three.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Tokyo citizens can tap subsidized hoikuen once admitted, but ward lotteries are fierce so dual-working parents often bridge gaps with pricier private nurseries or sitter services.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Registered foreign residents qualify for subsidies after enrolling, but language-heavy forms and guarantor requirements slow access.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Compulsory schooling delivers consistent quality with safe campuses and strong STEM tracks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident visa holders can join local schools, though instruction is Japanese-first and supplemental language support is limited.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International schools provide English continuity but command tuition comparable to US private schools.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Parental leave policies and child allowances exist, yet corporate culture discourages fathers from taking the full benefit.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Long-term residents can tap leave and allowances, but approvals hinge on employer sponsorship and Japanese filings.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Prestigious national universities charge modest tuition and offer strong engineering and design pipelines.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International programs are growing, though language exams and limited English tracks require early planning.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Workplaces still assume women manage home life, making it harder for Sarah to find egalitarian teams.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Non-binary visibility is increasing in cities, yet legal recognition and workplace comfort lag behind family expectations.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Legal protections exist on paper, but political representation and pay equity trail progressive benchmarks.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Kawaii aesthetics and modest dress codes dominate, which may feel restrictive for Sarah's style.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Salaryman expectations prize long hours and stoicism, pressuring Trey to conform in traditional firms.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Cutting-edge tech, safety, and vibrant pop culture align with the family's creative hobbies and game interests.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English signage helps in tourist zones, but daily bureaucracy and most workplaces operate in Japanese, requiring study.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Urban governments champion inclusivity more than national politics, so progressive change moves in incremental steps.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist parties exist but remain minority voices, yielding modest support for socialist policies.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Most residents engage in secular rituals without dogma, matching the family's preference for low religious pressure.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Public conversation stays conservative and sex education is limited, despite a robust private adult industry.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Major cities host Pride events, yet national law still lacks marriage equality and rural acceptance lags.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighborhoods are polite and safe, but making deep friendships takes time and Japanese fluency.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Collectivist norms encourage humility and fitting in, which may challenge the family's desire for direct feedback.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Historical tensions with China and Korea flare periodically, though day-to-day interactions stay cordial.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Japan's defense posture and history still draw criticism from neighbors, affecting regional sentiment.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Late-night trains, izakaya, karaoke, and arcades keep city nightlife lively for adults once childcare is arranged.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men's fashion swings between tailored suits and streetwear, so Trey can blend in whether commuting or networking.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women's styles range from minimalist to kawaii, offering Sarah creative options if she navigates modest dress codes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Gaming, anime, seasonal travel, and craft clubs align with the family's interests and offer ready-made communities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Board game cafes operate in major cities, but many events run in Japanese, so participation may need translation.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Tokyo's Shimokitazawa clubs, Akihabara game bars, and anime festivals give Trey nonstop creative networking without leaving the metro.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech and language meetups abound, yet conversations lean Japanese-first, requiring extra effort to fully engage.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Rail passes unlock mountains, ski towns, and coasts within a few hours, keeping weekend adventures easy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A constitutional monarchy with regular elections maintains democratic norms important to the family.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Religion rarely shapes policy debates, keeping governance largely secular as the family prefers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Labor laws promise overtime pay and leave, but weak enforcement and social pressure undercut protections.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Centrist coalitions favor market stability with social insurance, offering predictability without radical swings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Independent courts and media plus international alliances keep institutions steady despite ruling-party dominance.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A mature market economy offers consumer choice yet still favors keiretsu over scrappy startups.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Crime and political unrest stay low, supporting long-term planning and the kids' schooling continuity.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Media is largely independent, though government disaster messaging is coordinated and omnipresent.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Official communications emphasize resilience, safety drills, and national unity more than overt ideology.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal health care and pensions provide a safety net, but child benefits lag Scandinavian standards.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Public trust is moderate: scandals surface, yet agencies generally deliver services competently.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Corruption cases are infrequent and often investigated, supporting the family's desire for rule of law.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "When corruption appears, it centers on factional favoritism or bid-rigging rather than street-level bribery.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Urban housing is compact and pricey; larger family units near good schools require high rents or suburban commutes.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Extremely low violent crime lets the kids navigate transit independently once older.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Universal insurance keeps doctor visits affordable with short waits, even for specialists.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Foreign residents join national insurance after registering, though English-speaking providers can be scarce.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Monthly child allowances and daycare subsidies exist, yet long hours and waitlists limit how much support feels usable.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Benefits exist on paper, but workplace expectations and small apartments make it hard for a typical family to recharge.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are strong with safe campuses, but pressure-heavy culture may require balancing activities for the kids.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "High-frequency trains, shinkansen links, and IC-card access make car-free living realistic even with children.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A stable market economy ensures reliable services, yet bureaucracy and keiretsu dominance can slow indie ventures.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Employers withhold income tax and file year-end adjustments, but freelancers must navigate Japanese-only e-tax portals.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Combined national and local taxes plus social insurance usually land near 22–28% for a dual tech household.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Cash remains common for rent and clinics, yet IC cards and online banking cover most daily spending once accounts are set up.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Tokyo's rents, childcare fees, and imported groceries stretch budgets unless the family embraces smaller spaces.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "National pensions provide modest stipends that need private savings as the population ages.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Visa holders earn pension credits but must stay long-term to benefit; otherwise only partial lump-sum refunds apply.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Skilled worker, highly-skilled points, and startup visas are available with clear criteria but high documentation burdens.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Immigration officers stay polite yet formal; American talent is accepted professionally but social integration takes work.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Work visas span 1–5 years and permanent residency is possible in 5–10 years with stable income.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization is doable after five years with language interviews but requires renouncing US citizenship.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and dependent kids receive linked visas with school access, while extended relatives face steeper barriers.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Applications take several months and require translations, guarantors, and moderate fees that we must budget.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Strict reporting rules on address changes and employment mean administrative slip-ups can jeopardize status.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Japan expects naturalized citizens to drop other passports, limiting flexibility for the kids.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Securing housing and phones often needs a guarantor and Japanese contracts, so we'd lean on local partners.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Nintendo, Sony, and a strong mobile sector offer plentiful roles for experienced developers with some Japanese.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Heavyweights like Sony, Square Enix, Sega, and Bandai Namco cluster around Tokyo, and Odaiba incubators keep Trey's studio close to AAA partners and middleware vendors.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Meetups such as Tokyo Indies exist but run mostly in Japanese, limiting casual networking until we build fluency.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Startup visas in places like Fukuoka help, yet high costs, local investors favoring proven teams, and language-heavy paperwork raise the bar.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Bullet trains, resilient power grids, and fast fiber connections meet the family's need for reliable modern infrastructure.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/south_korea_seoul_report.json
+++ b/reports/south_korea_seoul_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "KR",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Seoul's Han River parks and nearby Bukhansan hikes offer greenery, but dense towers and traffic mean we chase cleaner air on weekend mountain escapes.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Hotter summers, stronger typhoons, and sea-level rise around Busan raise adaptation stakes.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Humid monsoon summers and below-freezing winters clash with the family’s mild-weather wish list.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Spring yellow dust and winter coal imports push PM2.5 into the 25–35 µg/m³ range several times a year, so we'd rely on air purifiers at home.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Typhoons, flash floods, and the remote risk of DPRK escalation require contingency plans despite strong preparedness.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "10–20°C (50–68°F) with yellow dust and cherry blossoms.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "July–August highs reach 30–33°C (86–91°F) with heavy humidity and tropical nights.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "10–22°C (50–72°F) dry and clear.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winter lows dip to -7°C (19°F) in Seoul, with dry winds that limit playground time.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Busan and Jeju offer beaches but not year-round swimming.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Summer waters near 24°C (75°F) cool by fall.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "National parks, islands, and seasonal blossoms are scenic.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The 2024 minimum wage of ₩9,860/hour (~$7.40) helps service workers, yet Seoul housing makes survival tough without dual professional incomes.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers in Pangyo Techno Valley earn ₩80–110M plus bonuses, covering city life but not matching US remote packages after taxes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Finance, telcos, and Chaebol IT subsidiaries keep .NET teams, though Korean fluency and on-site expectations narrow Trey's options.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Rails shops are niche beyond Coupang or Woowa Brothers, so Sarah would mainly find roles at English-friendly startups or remote employers.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Large companies sponsor E-7 visas, but documentation and points-based reviews can slow onboarding.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "A resilient export economy with strong R&D keeps unemployment low despite global slowdowns.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hybrid arrangements exist post-pandemic, yet many Seoul teams still expect late-night syncs and regular office presence.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "The 52-hour cap exists, but presenteeism and late client calls remain common in tech.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Official weeks are 40 hours, yet unpaid overtime or weekend sprints surface near launches.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Annual leave starts around 15 days after the first year, backed by national holidays.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Many employees leave days unused due to workload and cultural pressure.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Seoul's 24/7 convenience stores and packed subways make daily life fast-paced, so we'd target quieter districts like Seongbuk or Bundang.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run 8:30–15:00, but cram schools extend evenings, and parents often sync late office hours.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Families split weekends between kid activities, markets, and short rail trips to national parks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Strong family emphasis but work hours limit together time.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Non-monogamy has little social or legal acceptance.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "High academic expectations and structured extracurriculars.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Safe with many kid cafes and parks yet space is limited.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public schools high-performing but intense; international schools costly.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Government expanding daycare though spots in Seoul fill quickly.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "National subsidies, free preschool from age 3, and city-run care centers help citizens, but competition for Seoul daycare spots remains fierce.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Long-term foreign residents can access subsidies after registering with the local ward office, yet Korean-only paperwork and waitlists demand persistence.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Universal and high quality with strong outcomes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Public schools open to foreigners though Korean fluency is expected.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Heavy reliance on hagwons adds cost and pressure.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Parental leave and child allowances exist but uptake low for fathers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Some benefits extend to residents yet bureaucracy can limit use.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Top universities like Seoul National offer world-class programs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Many universities have English tracks and scholarships for internationals.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Traditional expectations persist though younger generations push change.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Nonbinary identities receive limited recognition outside activist circles.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Legal equality but wage gap and glass ceiling remain issues.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Strong beauty culture and modesty expectations.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Professional success and military service shape male roles.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Blend of cutting-edge tech, pop culture, and ancient heritage.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English signage helps in Seoul, yet bureaucracy and social circles still rely on Korean.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Younger voters push progressive reforms, but national politics remain centrist-conservative on many issues.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Cold War legacy fosters skepticism toward Marxism.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "About half the population identifies with no religion.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Public discourse is modest; sex education improving slowly.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Pride events occur, yet there’s no legal recognition for same-sex or polyamorous families and stigma persists.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Tight-knit circles form around schools and workplaces; integration takes effort.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Strong national pride tied to rapid development and cultural exports.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Historical tensions with Japan and North Korea; pragmatic with China.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Respected for economic success yet viewed through security lens.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Seoul’s nightlife is vibrant with late-night dining and entertainment.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Streetwear and grooming-focused styles set regional trends.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "K-fashion blends modesty with cutting-edge looks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Hiking, gaming, and cafe socializing are popular.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Board-game cafes and PC bangs support a growing tabletop scene.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Hongdae clubs, Gangnam lounges, and nonstop K-pop concerts give endless nightlife options for date nights.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Expat and tech meetups occur regularly in Seoul.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Mountains and rivers are reachable even from major cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A robust democracy with competitive elections and independent courts, despite polarization.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Religious groups exert limited direct influence on policy.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Labor laws exist but enforcement against overwork is weak.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Liberal democracy paired with strong anti-communist stance.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Institutions are strong, though national security laws and surveillance powers merit monitoring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Market economy dominated by chaebols yet entrepreneurial scene growing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Domestic stability high but North Korea remains a security concern.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Media is largely free though national security messages are common.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Emphasis on anti-North sentiment and national unity.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare and expanding childcare subsidies help, but social safety nets still lag Nordic peers.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Trust swings with political scandals; citizens often rely on civic activism to push reforms.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency scores are mid-to-high, though chaebol influence prompts periodic investigations.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Elite favoritism and corporate collusion surface more than street-level bribery.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "High jeonse deposits and rising monthly rents in Gangnam and Yongsan push many families toward newer suburbs like Songdo for space.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime stays rare and late-night subways feel safe, though we remain mindful of digital scams and protest gatherings downtown.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "National Health Insurance offers fast access to quality hospitals and specialists.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Most long-term visas can join NHI, though initial enrollment requires paperwork in Korean.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Government stipends and public daycare slots are expanding, yet hours can be shorter than US standards.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Support improving yet not as generous as Nordic models.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Public schools deliver excellent academics, albeit with intense exam culture that may stress the kids.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Seoul's 23-line metro, integrated buses, and KTX bullet trains keep commutes smooth with T-money tap payments.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A market economy led by chaebol conglomerates balances innovation with regulatory oversight.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "E-filing is streamlined, and year-end settlements auto-populate many deductions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Combined income around ₩150M incurs marginal rates near 24% plus pension and health contributions.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Contactless payments and fast bank transfers are ubiquitous, though some apps require Korean ID verification.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Transit and dining out are affordable, but private education, jeonse deposits, and imported goods raise the family budget above Kansas City norms.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "National Pension Service provides modest old-age benefits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Foreign workers contribute and may reclaim pension when leaving.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Points-based F-2 residence and D-8 startup visas exist, yet they demand language, income, or investment proof.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Koreans are generally friendly, though social integration hinges on learning Korean and respecting norms.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Most visas renew yearly initially, with longer F-series options after meeting residence and language criteria.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Naturalization requires five years, TOPIK level 4, and renouncing prior citizenship unless special cases apply.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and children can join on dependent visas once the main applicant meets income and housing standards.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Immigration offices process applications in 2–4 months with moderate legal and translation fees.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Maintaining address registration, visa-specific employment, and health insurance is essential to avoid fines.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "Generally not allowed except in rare talent or marriage cases.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Expect mandatory national pension contributions and periodic document checks, but services are reliable.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Seoul hosts Nexon, NCSoft, Netmarble, and Krafton, all hiring engineers for MMOs and mobile titles, keeping Trey's prospects strong.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "From Nexon's Pangyo campus to Smilegate and Pearl Abyss HQ, Seoul concentrates Asia's major studios.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Seoul Indies meetups, G-Star tie-ins, and campus e-sports clubs keep the dev community active year-round.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Government programs like Gyeonggi Content Agency grants and Seoul Startup Hub incubators support new studios, though visa rules require local partners.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit broadband, widespread 5G, and smart-city services like cashless kiosks make Seoul feel hyper-modern for a tech household.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/united_kingdom_london_report.json
+++ b/reports/united_kingdom_london_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "GB",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "London's Royal Parks and Thames Path keep greenery close, yet dense traffic and noise in Zones 1–3 mean we rely on weekend escapes to Surrey Hills for fresher air.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Climate models flag more heavy rain and coastal flood risk, so we'd budget for flood-aware housing and insurance while still seeing the islands as relatively safe from extreme heat.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Marine moderation delivers the mild seasons Sarah craves, though we would plan for grey, drizzly stretches and occasional muggy heat spells.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "ULEZ and electrified buses cut particulate levels to around 10 µg/m³, but NO2 hotspots along the North Circular mean we watch alerts before biking with the boys.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Serious quakes and hurricanes are rare; the main watch-outs are river flooding and winter windstorms, which we can manage with resilient housing choices.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Typical highs around 8–15°C (46–59°F) feel brisk yet manageable, and layering keeps school runs comfortable despite frequent showers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Highs near 17–24°C (63–75°F) suit the family's mild-summer goal, but heatwaves now touch 30°C+ and require fans or portable AC in London flats.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Autumn days around 10–18°C (50–64°F) support weekend hikes, yet Atlantic storms can bring blustery rain that keeps us indoors.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Daytime 2–8°C (36–46°F) is mild by Midwestern standards, but damp chill and limited daylight would push us toward cozy indoor play.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Central London lacks beaches, so seaside days mean rail trips to Brighton or Whitstable with chilly water and crowd planning.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Channel waters near London warm to only 17–19 °C (63–66 °F) in August, so swims are brisk unless we detour to heated lidos.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Hyde Park, Hampstead Heath, and quick trains to the Chilterns keep hikes and woodlands within an hour despite the urban core.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "London's higher real living wage tops £11/hour, yet housing and childcare costs erode take-home pay unless both parents land skilled roles.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers command £80k–£110k plus bonuses in London, which covers metro living but leaves less runway than West Coast contracts.",
+      "alignmentValue": 7
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "London's City fintechs, government contractors in Westminster, and Canary Wharf consultancies hire .NET teams year-round, giving Trey a near-constant pipeline of senior roles.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Shoreditch startups and gov.uk's platform teams keep Ruby roles active, giving Sarah good options if she's open to hybrid days.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Thousands of licensed sponsors exist, but high fees and salary thresholds mean we must target shortage-list employers early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "The UK services economy is mature but slow-growing, with inflation aftershocks and regional inequality to watch.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Post-pandemic London tech embraces hybrid 2–3 day office weeks, and coworking hubs like Second Home give Sarah calm spaces when she needs change of scene.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Hybrid norms, 28+ days of leave, and cultural respect for evenings help Sarah secure calmer schedules, though crunch remains in some London studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Contracts target 37.5–40 hours and flex arrangements are common, yet finance and game studios still expect overtime around launches.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Statutory 28 days including bank holidays beats US norms and lets the family plan regular school-break trips.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers often offer 30–33 days plus buy/sell schemes, keeping family adventures aligned with school calendars.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Central London runs intense with packed Tube commutes, so we'd pick calmer outer boroughs to give Sarah the slower cadence she prefers.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Primary schools run 08:45–15:15 while many offices expect 09:30–18:00 in the City, so we'd lean on breakfast clubs, wraparound care, or staggered shifts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends juggle museum slots, park picnics, and kids' clubs; timed tickets and rail strikes mean we book ahead for popular outings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Libraries, museums, and free festivals give the boys endless weekend options, and most towns offer playgrounds within a short walk.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Major cities host polyamory meetups and sex-positive therapists, yet the legal framework stays monogamy-only so we would stay discreet with schools.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Parents juggle school runs, sports clubs, and homework but the schedule is manageable with wraparound care and plentiful parks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "London's playground density, free museums, and step-free Elizabeth Line stops help with strollers, though narrow Victorian terraces can cramp indoor play.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "London offers strong state primaries, selective grammars nearby, and multiple international schools, but catchments are tight so we must rent with admissions in mind.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Ofsted-rated nurseries fill fast in Zones 2–4; we need to register during pregnancy or use workplace crèches to secure a spot before age three.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "London citizens tap 30 funded hours from age three and tax-free childcare, yet high hourly top-ups mean budgets stay tight unless employers subsidise care.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Dependent visas access funded hours once both parents work, but NRPF rules block child benefit and require savings to cover deposits and retainer fees.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "State schools are free with decent secular options; we just need to pick catchments with strong Ofsted reports.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Children on dependent visas can enroll easily, yet proof of address and NHS numbers add upfront paperwork.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Independent schools offer strong academics but fees rival US colleges, so we’d treat them as backup rather than plan A.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Statutory leave plus flexible working rights back up Sarah’s work-life goals, even if benefit levels lag Nordic standards.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Many leave rights apply, but means-tested benefits exclude most work visas, so we’d rely on employer top-ups.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Domestic tuition caps and income-based loans keep university feasible for the boys if we settle long term.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "Until indefinite leave, the kids would face international fees, so permanent residency becomes key before university age.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Dual-career households are normal and dads taking leave is increasingly accepted, aligning with the family’s egalitarian approach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal recognition of non-binary identities is emerging and urban schools teach inclusion, though rural areas can be conservative.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "The Equality Act and active advocacy groups deliver strong protections, even if pay gaps persist in some sectors.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Women comfortably mix professional and casual styles, and weather-ready layers keep expectations practical for Sarah.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Modern fatherhood and flexible work are increasingly celebrated, though pub and sport culture still prize stoicism.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Living in English, exploring castles, and riding trains to coastal hikes tick both the family’s culture and outdoors boxes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominates daily life and services, so integration is frictionless while the kids still meet Welsh or Gaelic at school for enrichment.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Cities lean progressive with protections for LGBTQ+ residents, though national politics swing between centrist parties.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist movements stay mostly academic or activist; mainstream parties frame them as fringe.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secularism is common and religion rarely intrudes on workplaces or schools, matching the family’s secular preference.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education and liberal norms in metros support the family’s sex-positive outlook, even if rural areas stay discreet.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Legal equality and visible Pride events keep queer families supported, with only isolated pushback outside cities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Local councils, clubs, and neighborhood WhatsApp groups help newcomers plug in quickly, which suits their search for community.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "The UK balances pride in institutions with a pragmatic streak, making locals confident yet approachable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Opinions on the EU and Ireland are mixed post-Brexit, so dinner-table talk can get political.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors respect UK culture but criticise Brexit-era politics, which the family should expect to hear while travelling.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "London balances world-class theatre, queer clubs, and quiet wine bars, giving the couple flexible date night vibes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "London men mix streetwear with tailored coats, so Trey can rotate smart trainers and techwear without standing out.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "From Liberty prints to sustainable brands in Hackney, London style embraces eclectic layers that suit Sarah's comfort-first approach.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "City families balance park runs, climbing walls, gaming cafés, and West End matinees—plenty of overlap with Trey and Sarah's interests.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Dedicated board-game cafes and UK Games Expo-level events give Trey and Sarah regular tabletop scenes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "West End theatres, Brixton Academy, and Shoreditch venues keep live music and geek nights thriving for Trey.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Meetup.com overflows with tech, poly, and parenting groups in London, helping us rebuild community fast.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Regular trains reach Epping Forest, Box Hill, and Kent Downs within an hour, so weekend hikes stay practical without a car.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A parliamentary democracy with devolved nations offers checks and civic engagement channels the family appreciates.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Religion is mostly private nationally, yet Northern Ireland and some school policies keep faith voices visible.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Holiday pay, sick leave, and union protections exceed US baselines, though zero-hour contracts linger in retail and hospitality.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Politics oscillates between centrist Conservatives and Labour, so policy swings require periodic recalibration.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Independent courts, free media, and active civil society keep backsliding low despite occasional executive-overreach debates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A mature mixed economy balances free markets with public services like the NHS, matching the family’s preference for safety nets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Institutions are steady but Brexit-era leadership churn shows politics can be noisy every few years.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Public broadcasters provide balance, yet tabloids and partisan social media keep spin in the daily mix.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Campaigns lean on patriotic framing and culture-war headlines, but plural media lets the family curate calmer sources.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Universal healthcare and benefits exist, yet austerity-era cuts mean we’d verify local delivery before committing.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show middling trust after scandals, so expect lively political debate at the school gate.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency laws and watchdog journalism keep corruption low, with sleaze stories typically triggering resignations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Issues surface around procurement or lobbying rather than day-to-day bribery, so it rarely touches family life.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family-sized rentals inside Zones 1–3 exceed £2,500/month, so we'd target outer boroughs like Richmond or move to commuter towns for space.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "London's violent crime rate is moderate for a global city, yet we avoid late-night transport on certain lines and secure bikes against theft.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "The NHS covers care without bills, but specialty waits and GP backlogs mean we’d pair it with occasional private visits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Paying the Immigration Health Surcharge grants full NHS access, though first-year GP registration and wait times require patience.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Tax-free childcare accounts and funded hours help once both parents work, but under-three costs remain steep.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Middle-class families often mix statutory leave with part-time returns and grandparents, a pattern we could mirror with hybrid roles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Quality varies by local authority, so we’d target strong Ofsted areas or consider academy chains with robust STEM tracks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The Tube, Elizabeth Line, and 24-hour buses let us live car-free, though strikes and weekend engineering works demand backup plans.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A regulated market economy with social safety nets supports entrepreneurship while cushioning healthcare and schooling costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "PAYE handles most income tax automatically, and digital self-assessment tools make side projects manageable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Combined tech salaries fall into 40% higher-rate bands, so we’d lean on pension contributions and child benefit clawback planning.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Contactless, Faster Payments, and open banking apps make cashless living seamless for daily errands and business invoices.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Council tax, energy bills, and groceries are manageable, but mortgage rates and childcare make London budgets stretch beyond Kansas City norms.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "The state pension supplements workplace schemes, but comfortable retirement still depends on private savings and housing equity.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Access hinges on National Insurance years and keeping UK pensions portable, so we’d maintain US savings as backup.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Skilled Worker and Global Talent routes are viable but expensive, and Innovator Founder demands robust business plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Shared language and cultural ties make Americans broadly welcome, especially in cosmopolitan cities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Most work visas run 2–5 years with clear upgrade paths to Indefinite Leave to Remain if we track absence limits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Five years on a qualifying visa plus 12 months ILR, Life in the UK, and language tests make the process structured yet paperwork-heavy.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Dependents can work or study freely once visas are issued, but NHS surcharge and school admissions timelines require upfront planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Visa fees, NHS surcharges, and biometrics push costs into the thousands per adult, and processing can stretch to several months.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "We must track absences for ILR, register for taxes promptly, and update digital status, but rules are transparent.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The UK allows dual nationality, so the family can retain US passports without complications.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "BRP-to-eVisa transitions, proof-of-address hurdles, and credit history building take effort during the first year.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Rocksteady, Creative Assembly's Horsham HQ, and dozens of VR studios in London keep AAA and indie demand strong for Trey's skills.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "London hosts Rocksteady, Sports Interactive, Splash Damage, and PlayStation London Studio, clustering talent near Trey's network.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "London Game Dev Lunch, Games London, and BAFTA events provide regular mixers for devs and founders.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "The Games London accelerator, UK Games Fund showcases, and access to venture capital make London a strong launchpad for Trey's studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Crossrail, contactless payments everywhere, and dense EV charging keep London infrastructure modern enough for a tech-focused family.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/united_states_portland_report.json
+++ b/reports/united_states_portland_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "US",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Portland's tree canopy, urban growth boundary, and Willamette River parks keep daily life green, though spring pollen and industrial corridors require occasional air checks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Climate projections show hotter, drier summers and more wildfire smoke, yet Portland stays safer from sea-level rise than coastal metros.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Mild summers and cool, rainy winters align with Sarah's preferences, aside from a few heat dome weeks that now reach the high 30s °C.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Normal days hover near 8–10 µg/m³, but late-summer wildfire smoke can spike AQI into the unhealthy range for weeks, so we'd own purifiers and masks.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Portland escapes hurricanes and tornadoes but faces Cascadia subduction earthquake risk and occasional ice storms that can disrupt power for days.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March–May daytime highs climb from 12 °C (54 °F) to 18 °C (65 °F) with steady rain, so light layers and waterproof gear stay in rotation.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Typical highs sit around 26 °C (79 °F) with low humidity, but recent heat domes push 38 °C (100 °F) for a few days, making A/C a new necessity.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September starts near 24 °C (75 °F) before rain returns and highs drop to 13 °C (55 °F) by November, great for forest hikes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters average 3–8 °C (38–46 °F) with drizzle and rare snow; freezing rain events can ice roads but deep freezes are uncommon.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "The Oregon Coast sits 90 minutes away with rugged, chilly beaches ideal for tidepooling rather than warm swims.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Atlantic and Pacific beaches range from chilly (12–18 °C) much of the year to bath-warm Gulf waters, so only southern coasts feel swimmable for long.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Columbia River Gorge, Mount Hood, and Forest Park trailheads sit within an hour, giving the family constant outdoor escapes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Portland's metro minimum wage hits $15/hour in 2024, better than the federal floor but still tight relative to housing costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers at Nike, Intel, and local SaaS firms earn $130k–$160k, solid locally though lower than Bay Area packages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Regional employers like Nike, Cambia Health, and government agencies keep .NET roles steady, with remote options expanding the pool.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Portland's indie web scene and companies like GitHub and New Relic historically lean on Rails, so Sarah can find roles though the market is smaller than Seattle or SF.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "H-1B and similar visas exist but quotas, lotteries, and strict compliance make sponsorship unreliable for newcomers.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Despite inflation cycles, GDP growth, deep capital markets, and low unemployment keep the economy resilient for entrepreneurs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Portland embraced remote-first work; coworking spaces like Industrious and coffee shop culture support Sarah's need for flexible schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Long hours, limited leave, and hustle culture clash with Sarah’s need for predictable downtime.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Nominal 40-hour weeks hide frequent unpaid overtime, especially in tech and startups.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "There is no statutory paid vacation, leaving time off entirely to employer policy.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Two to three weeks is common after tenure, which remains modest compared with the family’s expectations.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Bike commuting, compact neighborhoods, and slower West Coast rhythms give Sarah the calmer lifestyle she wants while still offering urban amenities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Elementary schools run roughly 08:45–15:00; tech employers often run 09:00–17:30 with flexible Fridays, so we'd lean on after-school enrichment a few days a week.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends revolve around kids’ sports, errands, and driving to activities, though vibrant city programming offers options.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Family culture varies widely—supportive services exist in some states but childcare and healthcare costs strain budgets.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Polyamory is legal but stigmatized; only progressive urban communities openly support non-monogamous families.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Expectations skew toward intensive, school-centric parenting with limited state support, though progressive enclaves offer flexibility.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Parks and museums are strong in big cities, yet car dependency and safety disparities complicate daily outings.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public, charter, and private schools offer variety, but quality depends heavily on neighborhood wealth and district funding.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Quality programs exist but slots are scarce and costs rival college tuition, demanding long waitlists.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Oregon's Employment Related Day Care subsidies and Preschool Promise expand access, yet waitlists leave many middle-income families paying high tuition.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Non-citizens can access some state subsidies after residency proof, but paperwork and income caps mean we should budget full tuition initially.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens access free public schooling, yet district quality and funding inequality create big differences.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Most visas allow public school attendance, though undocumented families fear enforcement and some districts have residency hurdles.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Private and parochial schools are abundant but expensive, with elite institutions heavily waitlisted in major metros.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "No national paid leave and limited child allowances; benefits depend on employer or state-level programs.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Temporary residents seldom qualify for state benefits and risk losing status if work is paused for caregiving.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Citizens enjoy broad access to community colleges and top universities, albeit with high tuition costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students can enroll but face higher tuition and visa work limits, making persistence costly.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Gender norms are gradually balancing, yet cultural expectations around motherhood and career still surface, especially outside progressive metros.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal protections exist in many states, but anti-trans legislation and social pushback in others create an uneven landscape.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Federal civil rights and Title IX offer protections, though state abortion bans and trans healthcare restrictions erode consistency.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Women face pressures to juggle careers and caregiving, with norms varying sharply between progressive and conservative regions.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Expectations for men still lean toward stoicism and breadwinning, though urban areas embrace more flexible roles.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Startup energy, deep maker communities, and access to cutting-edge tech ecosystems continue to excite Trey.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominates in daily life and services, eliminating language barriers for the family.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Progressive policies thrive in coastal states, yet national politics remain polarized with conservative pushback.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist politics exist in academic and activist circles but mainstream discourse remains skeptical of socialism.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular life is easy in cities, yet Bible Belt regions still expect church affiliation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Attitudes toward sexuality are liberal in metros but conservative laws persist in other states.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Legal protections exist federally, yet state-level anti-LGBTQ legislation and social backlash make support uneven.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Friendliness varies; many neighborhoods are welcoming but mobility and individualism can hinder deep ties.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Strong national identity and belief in exceptionalism remain common.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public opinion sees Canada as close and Mexico as a complex partner with migration tensions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors respect US influence yet critique cultural dominance and policy swings.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Major cities run vibrant nightlife scenes with music, bars, and late dining, though smaller metros close early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Casual dress norms dominate outside coastal fashion hubs, offering moderate style variety.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Urban centers follow global trends, while much of the country leans toward practical casualwear.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Gaming, outdoor sports, and maker hobbies are widespread, offering Trey and Sarah ample communities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Robust convention circuit, specialty shops, and active clubs make tabletop communities easy to find.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Portland's indie venues, food cart pods, and craft breweries create relaxed nightlife for creative date nights.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Platforms like Meetup and vibrant coworking hubs create steady social pipelines for remote workers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Weekend adventures range from surfing in Cannon Beach to skiing on Mount Hood—all within two hours.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Federal democracy with checks and balances remains, yet gerrymandering and minority rule structures frustrate progressives.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Religious rhetoric heavily influences policy debates, especially on reproductive and LGBTQ+ rights.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "At-will employment, limited unions, and minimal paid leave fall short of the family’s expectations.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Market-oriented capitalism and individual responsibility dominate policy making.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Election denialism, voter suppression attempts, and institutional strain signal meaningful democratic risk.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Free-market norms prioritize business flexibility over social safety nets.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Institutions endure but polarization and sporadic unrest introduce uncertainty.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Partisan media ecosystems and algorithmic echo chambers skew information quality compared with the family’s desire for pluralism.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Narratives emphasize national exceptionalism and culture wars, making it hard to find calm, balanced reporting.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive policies advance in blue states while conservative states curtail rights, leaving a mixed national picture.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Public trust remains low, matching Gallup surveys that show skepticism toward federal institutions.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Citizens rate corruption as moderate—campaign finance and lobbying raise concerns without daily bribery.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Legalized influence via lobbying and dark money overshadows petty corruption.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Median Portland rents hover near $2,200 for a three-bedroom; buying remains competitive but less intense than Seattle or SF.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Property crime and visible homelessness are higher downtown, so we'd select eastside neighborhoods with strong neighborhood watches.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Quality care is available but insurance complexity and high costs burden families even with employer plans.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-citizens face steep premiums, limited public coverage, and visa-linked insurance requirements.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidies are limited and dependent on state programs, leaving most costs on families.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Default benefits include child tax credits and unpaid FMLA, which fall short of the supportive policies the family wants.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Education",
+      "alignmentText": "World-class universities contrast with uneven K-12 outcomes, so the family must select districts carefully.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "TriMet light rail, buses, and streetcar support car-light living, but coverage thins in outer suburbs and late nights.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A lightly regulated capitalist system prioritizes markets over social protections.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Federal, state, and local layers add complexity, but withholding automation means payroll taxes are manageable.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "A dual tech-income household faces combined federal and state rates around 25–30% depending on location.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Digital banking, credit access, and payment apps are robust, supporting entrepreneurial needs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries, utilities, and Oregon's lack of sales tax keep expenses manageable, though childcare and property taxes still pressure budgets.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Social Security and 401(k)s offer support but require sustained savings; healthcare costs in retirement remain high.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Non-citizens have limited access to public benefits and must rely on private savings and employer plans.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Diverse visa categories exist, but quotas, interviews, and sponsorship hurdles make immigration arduous for non-citizens.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "As citizens, the family faces no entry barriers and can relocate freely within the country.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Citizenship grants permanent residency rights nationwide, though state benefits depend on domicile.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Citizenship is automatic for the family and their children, eliminating naturalization concerns.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Immediate relatives of citizens have streamlined sponsorship options, though backlogs affect extended family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "For citizens moves are immediate; sponsoring relatives involves fees and multi-year waits but predictable processes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Legal compliance is straightforward for citizens, though regulated industries require diligent paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The U.S. tolerates dual citizenship, though obligations like taxes remain.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Visa holders must maintain employment, face travel restrictions, and manage complex paperwork to avoid status loss.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Panic, Wyld Stallyns, and indie outfits hire selectively; most devs mix remote contracts with local meetups.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Portland hosts indies such as Panic, Laika's interactive wing, and smaller VR studios rather than AAA giants.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Meetups like IGDA chapters, GDC, and PAX West keep developer communities highly active.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "PIE (Portland Incubator Experiment), Oregon Film grants, and a supportive indie community provide mentorship though funding is modest.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber reaches many neighborhoods and EV adoption is high, yet aging bridges and limited airport routes require planning.",
+      "alignmentValue": 7
+    }
+  ]
+}

--- a/reports/united_states_seattle_report.json
+++ b/reports/united_states_seattle_report.json
@@ -1,0 +1,541 @@
+{
+  "version": 2,
+  "iso": "US",
+  "values": [
+    {
+      "key": "Environment",
+      "alignmentText": "Seattle's evergreens, Puget Sound views, and strict stormwater rules keep neighborhoods lush, though industrial SoDo corridors still need air monitoring.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Climate models warn of more wildfire smoke and king tide flooding, yet Seattle remains safer than many U.S. metros if we plan for air-quality disruptions.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Cool summers and drizzly winters give long stretches of mild temps, though the grey season can feel endless without sunlight lamps.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "Most of the year PM2.5 stays near 8 µg/m³, but August wildfire smoke from Eastern Washington can send AQI above 150, so we'd keep filters ready.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Seattle avoids hurricanes but lives with Cascadia earthquake risk, lahar evacuation routes, and occasional ice storms that can knock out power.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "March–May highs climb from 12 °C (54 °F) to 18 °C (65 °F) with light rain and cherry blossoms, ideal for park outings in layers.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Typical highs stay near 24 °C (75 °F) with low humidity; occasional heat waves hit 32 °C (90 °F) but cool off overnight by the water.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "September offers crisp 20 °C (68 °F) days before rain returns and highs dip toward 12 °C (54 °F) by November.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Winters hover around 2–8 °C (36–46 °F); snow is rare but wet cold and short daylight require cozy indoor plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "Alki and Golden Gardens offer pebbly beaches with cold Puget Sound water—great for bonfires and tidepools rather than warm swims.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Atlantic and Pacific beaches range from chilly (12–18 °C) much of the year to bath-warm Gulf waters, so only southern coasts feel swimmable for long.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Ferries to the San Juans, day trips to Olympic National Park, and Mount Rainier hikes keep world-class scenery within two hours.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "Seattle's 2024 minimum wage sits around $19/hour, supporting service workers better than most U.S. cities though housing still strains budgets.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Amazon, Microsoft, and Google routinely offer $170k–$220k total comp for senior engineers, keeping Trey and Sarah well above local medians.",
+      "alignmentValue": 9
+    },
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Microsoft's Redmond campus anchors .NET demand, with AWS, Expedia, and healthcare systems hiring C# teams nonstop.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Seattle's startup scene and consultancies like Substantial still use Ruby, though opportunities are fewer than for JavaScript or cloud roles.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "H-1B and similar visas exist but quotas, lotteries, and strict compliance make sponsorship unreliable for newcomers.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Despite inflation cycles, GDP growth, deep capital markets, and low unemployment keep the economy resilient for entrepreneurs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "West Coast tech embraces hybrid-first policies; it's easy to secure remote roles with occasional Seattle office visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Long hours, limited leave, and hustle culture clash with Sarah’s need for predictable downtime.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Nominal 40-hour weeks hide frequent unpaid overtime, especially in tech and startups.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "There is no statutory paid vacation, leaving time off entirely to employer policy.",
+      "alignmentValue": 1
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Two to three weeks is common after tenure, which remains modest compared with the family’s expectations.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Seattle balances a tech hustle with outdoorsy weekends; traffic can spike but neighborhoods like Ballard or West Seattle keep a calmer rhythm.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Schools run 08:55–15:25; big tech often expects 10:00–18:00 overlap with other time zones, so we'd rely on after-school STEM clubs or flexible hours.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Weekends revolve around kids’ sports, errands, and driving to activities, though vibrant city programming offers options.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Family culture varies widely—supportive services exist in some states but childcare and healthcare costs strain budgets.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Polyamory is legal but stigmatized; only progressive urban communities openly support non-monogamous families.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Expectations skew toward intensive, school-centric parenting with limited state support, though progressive enclaves offer flexibility.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Parks and museums are strong in big cities, yet car dependency and safety disparities complicate daily outings.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Public, charter, and private schools offer variety, but quality depends heavily on neighborhood wealth and district funding.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Quality programs exist but slots are scarce and costs rival college tuition, demanding long waitlists.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Washington's Working Connections Child Care subsidy helps lower-income families, but middle-income parents still face $1,500+ monthly daycare bills.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Visa holders qualify for subsidies only after residency proofs and income tests; expect to pay market rates while paperwork processes.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Citizens access free public schooling, yet district quality and funding inequality create big differences.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Most visas allow public school attendance, though undocumented families fear enforcement and some districts have residency hurdles.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "Private and parochial schools are abundant but expensive, with elite institutions heavily waitlisted in major metros.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "No national paid leave and limited child allowances; benefits depend on employer or state-level programs.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Temporary residents seldom qualify for state benefits and risk losing status if work is paused for caregiving.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Citizens enjoy broad access to community colleges and top universities, albeit with high tuition costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students can enroll but face higher tuition and visa work limits, making persistence costly.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Gender norms are gradually balancing, yet cultural expectations around motherhood and career still surface, especially outside progressive metros.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "Legal protections exist in many states, but anti-trans legislation and social pushback in others create an uneven landscape.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Federal civil rights and Title IX offer protections, though state abortion bans and trans healthcare restrictions erode consistency.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Women face pressures to juggle careers and caregiving, with norms varying sharply between progressive and conservative regions.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Expectations for men still lean toward stoicism and breadwinning, though urban areas embrace more flexible roles.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Startup energy, deep maker communities, and access to cutting-edge tech ecosystems continue to excite Trey.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English dominates in daily life and services, eliminating language barriers for the family.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Progressive policies thrive in coastal states, yet national politics remain polarized with conservative pushback.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist politics exist in academic and activist circles but mainstream discourse remains skeptical of socialism.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Secular life is easy in cities, yet Bible Belt regions still expect church affiliation.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Attitudes toward sexuality are liberal in metros but conservative laws persist in other states.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Legal protections exist federally, yet state-level anti-LGBTQ legislation and social backlash make support uneven.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Friendliness varies; many neighborhoods are welcoming but mobility and individualism can hinder deep ties.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Strong national identity and belief in exceptionalism remain common.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public opinion sees Canada as close and Mexico as a complex partner with migration tensions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors respect US influence yet critique cultural dominance and policy swings.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Major cities run vibrant nightlife scenes with music, bars, and late dining, though smaller metros close early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Casual dress norms dominate outside coastal fashion hubs, offering moderate style variety.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Urban centers follow global trends, while much of the country leans toward practical casualwear.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "Gaming, outdoor sports, and maker hobbies are widespread, offering Trey and Sarah ample communities.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Robust convention circuit, specialty shops, and active clubs make tabletop communities easy to find.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Capitol Hill clubs, Belltown jazz bars, and the Seattle Symphony offer varied nightlife with a creative lean.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Platforms like Meetup and vibrant coworking hubs create steady social pipelines for remote workers.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Kayaking on Lake Union, skiing at Snoqualmie, and backpacking in the Cascades keep world-class nature minutes away.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "Federal democracy with checks and balances remains, yet gerrymandering and minority rule structures frustrate progressives.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Religious rhetoric heavily influences policy debates, especially on reproductive and LGBTQ+ rights.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "At-will employment, limited unions, and minimal paid leave fall short of the family’s expectations.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "Market-oriented capitalism and individual responsibility dominate policy making.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "Election denialism, voter suppression attempts, and institutional strain signal meaningful democratic risk.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "Free-market norms prioritize business flexibility over social safety nets.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Institutions endure but polarization and sporadic unrest introduce uncertainty.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "Partisan media ecosystems and algorithmic echo chambers skew information quality compared with the family’s desire for pluralism.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Narratives emphasize national exceptionalism and culture wars, making it hard to find calm, balanced reporting.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive policies advance in blue states while conservative states curtail rights, leaving a mixed national picture.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Public trust remains low, matching Gallup surveys that show skepticism toward federal institutions.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Citizens rate corruption as moderate—campaign finance and lobbying raise concerns without daily bribery.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Legalized influence via lobbying and dark money overshadows petty corruption.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Median three-bedroom rents top $3,200 and bidding wars remain common in walkable neighborhoods like Capitol Hill or Queen Anne.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Violent crime is moderate but property crime and car break-ins are frequent; we'd invest in secure parking and home security.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Quality care is available but insurance complexity and high costs burden families even with employer plans.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-citizens face steep premiums, limited public coverage, and visa-linked insurance requirements.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Subsidies are limited and dependent on state programs, leaving most costs on families.",
+      "alignmentValue": 2
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Default benefits include child tax credits and unpaid FMLA, which fall short of the supportive policies the family wants.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Education",
+      "alignmentText": "World-class universities contrast with uneven K-12 outcomes, so the family must select districts carefully.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Link light rail expansion, RapidRide buses, and water taxis support car-light living, though late-night coverage and Eastside links remain limited.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "A lightly regulated capitalist system prioritizes markets over social protections.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Federal, state, and local layers add complexity, but withholding automation means payroll taxes are manageable.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "A dual tech-income household faces combined federal and state rates around 25–30% depending on location.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Digital banking, credit access, and payment apps are robust, supporting entrepreneurial needs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "No state income tax helps, but high housing, childcare, and B&O taxes push Seattle budgets well above Midwestern levels.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Social Security and 401(k)s offer support but require sustained savings; healthcare costs in retirement remain high.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Non-citizens have limited access to public benefits and must rely on private savings and employer plans.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Diverse visa categories exist, but quotas, interviews, and sponsorship hurdles make immigration arduous for non-citizens.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "As citizens, the family faces no entry barriers and can relocate freely within the country.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Citizenship grants permanent residency rights nationwide, though state benefits depend on domicile.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "Citizenship is automatic for the family and their children, eliminating naturalization concerns.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Immediate relatives of citizens have streamlined sponsorship options, though backlogs affect extended family.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "For citizens moves are immediate; sponsoring relatives involves fees and multi-year waits but predictable processes.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "Legal compliance is straightforward for citizens, though regulated industries require diligent paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The U.S. tolerates dual citizenship, though obligations like taxes remain.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Visa holders must maintain employment, face travel restrictions, and manage complex paperwork to avoid status loss.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Microsoft, Bungie, Valve, and numerous VR startups hire year-round, making Seattle one of the strongest U.S. hubs for Trey's skills.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Home to 343 Industries, Bungie, Valve, and indie darlings like Campo Santo's partners, Seattle concentrates AAA and indie talent.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Meetups like IGDA chapters, GDC, and PAX West keep developer communities highly active.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Seattle Indies Expo, Global Game Jam, and access to Xbox and Amazon grant programs support founders despite high burn rates.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Gigabit fiber, electrified buses, and SEA's international flights keep infrastructure modern, though road maintenance lags in some neighborhoods.",
+      "alignmentValue": 8
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add detailed city reports for Tokyo, London, Paris, Seoul, Portland, Seattle, and Shanghai covering environment, work prospects, childcare, and community fit
- register the new city reports in `main.json` so the navigation lists each metro under its country

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e4193d3a50832191924aa8c35ec181