### PR TITLE
Add German city reports for priority metros

### DIFF
--- a/main.json
+++ b/main.json
@@ -623,20 +623,96 @@
       "file": "reports/germany_report.json",
       "cities": [
         {
-          "name": "Munich",
-          "file": "reports/germany_munich_report.json"
-        },
-        {
           "name": "Berlin",
           "file": "reports/germany_berlin_report.json"
+        },
+        {
+          "name": "Bremen",
+          "file": "reports/germany_bremen_report.json"
+        },
+        {
+          "name": "Dresden",
+          "file": "reports/germany_dresden_report.json"
+        },
+        {
+          "name": "Düsseldorf",
+          "file": "reports/germany_duesseldorf_report.json"
+        },
+        {
+          "name": "Erfurt",
+          "file": "reports/germany_erfurt_report.json"
+        },
+        {
+          "name": "Frankfurt",
+          "file": "reports/germany_frankfurt_report.json"
+        },
+        {
+          "name": "Halle",
+          "file": "reports/germany_halle_report.json"
         },
         {
           "name": "Hamburg",
           "file": "reports/germany_hamburg_report.json"
         },
         {
-          "name": "Cologne",
-          "file": "reports/germany_cologne_report.json"
+          "name": "Hannover",
+          "file": "reports/germany_hannover_report.json"
+        },
+        {
+          "name": "Jena",
+          "file": "reports/germany_jena_report.json"
+        },
+        {
+          "name": "Karlsruhe",
+          "file": "reports/germany_karlsruhe_report.json"
+        },
+        {
+          "name": "Kiel",
+          "file": "reports/germany_kiel_report.json"
+        },
+        {
+          "name": "Köln",
+          "file": "reports/germany_koeln_report.json"
+        },
+        {
+          "name": "Leipzig",
+          "file": "reports/germany_leipzig_report.json"
+        },
+        {
+          "name": "Lübeck",
+          "file": "reports/germany_lubeck_report.json"
+        },
+        {
+          "name": "Magdeburg",
+          "file": "reports/germany_magdeburg_report.json"
+        },
+        {
+          "name": "Mainz",
+          "file": "reports/germany_mainz_report.json"
+        },
+        {
+          "name": "München",
+          "file": "reports/germany_muenchen_report.json"
+        },
+        {
+          "name": "Nürnberg",
+          "file": "reports/germany_nuernberg_report.json"
+        },
+        {
+          "name": "Stuttgart",
+          "file": "reports/germany_stuttgart_report.json"
+        },
+        {
+          "name": "Trier",
+          "file": "reports/germany_trier_report.json"
+        },
+        {
+          "name": "Wiesbaden",
+          "file": "reports/germany_wiesbaden_report.json"
+        },
+        {
+          "name": "Wolfsburg",
+          "file": "reports/germany_wolfsburg_report.json"
         }
       ]
     },

--- a/reports/germany_bremen_report.json
+++ b/reports/germany_bremen_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Airbus Defence & Space, OHB, and Mercedes-Benz rely on .NET-heavy production systems in Bremen, but the market skews toward German-language manufacturing contracts, so Trey keeps freelancing leads warm while courting these legacy teams.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like KING Art Games and smaller indies around the Überseestadt coworking scene hire Unity talent, yet openings are project-based, meaning Trey leans on the community to spot gigs early.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family-sized flats in Viertel or Schwachhausen hover near €11/m², letting the family trade a slightly longer tram ride for affordable space and proximity to parks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English is common within universities and larger employers, yet daily errands still expect A2 German, nudging the family toward evening Volkshochschule classes.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Jacobs University groups, Gamecity Bremen meetups, and English-friendly maker spaces help newcomers plug into tech and family circles within weeks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Fiber-backed port logistics, 5G pilots, and reliable district heating keep infrastructure solid, though some Altbau renovations lag on energy retrofits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Bürgerpark, Blockland bike trails, and quick weekend trips to Wadden Sea tidal flats give the kids plenty of green and coastal playtime.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Schlachthof concerts, Viertel jazz clubs, and Breminale’s riverside stages give Trey and Sarah creative nights out without overwhelming crowds.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "WFB’s Creative Hub grants and Gamecity Bremen mentoring lower prototype costs, but limited venture capital means Trey still plans to bootstrap and tap remote collaborators for scale.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Maritime rhythms, compact commutes, and community festivals on the Weser keep daily life slower than major metros, matching Sarah’s need for decompression time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "BSAG trams, Regio-S-Bahn links to Oldenburg and Bremerhaven, and dense bus coverage make school and work commutes easy, though late-night frequencies thin out compared to Berlin.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Port logistics and aerospace suppliers embraced hybrid teams post-2020, so Trey can negotiate 3-day in-office rhythms while Sarah stays fully remote.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Bremen posts one of Germany’s higher property-crime rates around the Hauptbahnhof, so we budget for secure bike storage and teach the kids big-city street smarts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers land roughly €55–65k in Bremen’s aerospace and logistics firms—comfortable when paired with Germany’s benefits, yet below Berlin or Munich’s pay bands.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "UNESCO-listed Markt square charm paired with a hands-on maritime science scene gives the family a playful base that still supports Trey’s studio ambitions.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_dresden_report.json
+++ b/reports/germany_dresden_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Silicon Saxony anchors .NET demand at SAP, GlobalFoundries support teams, and Infineon suppliers, yet Trey still networks across research parks to surface English-friendly roles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Indie outfits tied to Games & XR Mitteldeutschland provide occasional Unity work, but most studios are small and project-based, so Trey balances passion gigs with remote clients.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Renovated Altbau in Striesen or Neustadt still sits near €10/m², letting the family secure space and quick tram access if they apply early.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English works in labs and tourist zones, yet daily errands and Kita paperwork lean on German, so the adults keep practicing.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Silicon Saxony gatherings, maker spaces at Technische Universität, and family-friendly expat groups help the family plug into community without overwhelm.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Rebuilt Altstadt charm coexists with modern semiconductor campuses, though some older panel buildings await energy upgrades.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Riverfront cycling and 40-minute train trips to Saxon Switzerland’s sandstone cliffs give the family stunning weekend adventures.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Semperoper premieres, Neustadt clubs, and jazz at Blue Note mix high culture with casual nights out, even if things quiet down midweek.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "State-backed programs like futureSAX and Dresden’s Smart Systems Hub offer mentorship and grants, though hardware-focused investors expect clear commercialization plans.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Baroque scenery, short commutes, and a strong café culture keep the daily rhythm calm without sacrificing cultural events for the adults.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "DVB’s dense tram grid, S-Bahn links to the airport, and regional trains into Saxon Switzerland keep car-free routines workable for the whole family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Hardware-heavy employers still favor on-site teams, but research institutes allow hybrid weeks, giving Trey room to negotiate remote sprints.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Outside a few nightlife blocks in Neustadt, Dresden’s crime rate remains low, giving the kids freedom to roam parks and bike paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers in Dresden’s semiconductor corridor earn around €55–65k, trading top-tier pay for lower living costs and research collaborations.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Living amid Frauenkirche’s revival while exploring Saxon Switzerland offers the family a rare blend of history and nature-driven weekends.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_duesseldorf_report.json
+++ b/reports/germany_duesseldorf_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Consultancies around Königsallee, E.ON’s digital teams, and Trivago’s platform squads keep Düsseldorf’s .NET market humming, letting Trey weigh permanent roles against contract freedom.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Ubisoft Blue Byte, Electronic Arts’ NRW QA hubs, and Mediennetzwerk.NRW-supported indies sustain steady Unity and Unreal demand, though competition is stiff.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family apartments in Pempelfort or Oberkassel can top €16/m², so we balance commute time with more affordable left-bank neighborhoods like Heerdt.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Trade fairs and global HQs keep English widely used at work and in city services, though navigating Kita enrollment still benefits from B1 German.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "StartupDorf, NRW tech meetups, and an active Japanese expat community offer plenty of avenues to find fellow parents and collaborators.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Rheinbahn’s mobile ticketing, smart-city pilots in Medienhafen, and robust gigabit coverage underscore Düsseldorf’s polished infrastructure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Rhine embankments, Kaiserswerth river beaches, and quick S-Bahn rides into the Bergisches Land satisfy the kids’ need for green space.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Altstadt pubs, jazz at Pardon To Tu, and the Tonhalle’s orchestral calendar give the couple both raucous nights and high-culture dates without long travel.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Mediengründerzentrum NRW stipends, NRW.BANK creative loans, and a dense agency ecosystem make it realistic to launch a boutique studio if Trey lines up prototype milestones.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Weekdays move at a polished corporate clip, but Rhine promenades, Japanese gardens, and regional getaways offer quick resets for Sarah’s slower pace.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Stadtbahn tunnels, Rhein-Ruhr S-Bahn links, and frequent trams cover the metro well, though late-night trips after Altstadt outings occasionally require taxis to the suburbs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Agencies and multinationals now budget hybrid setups, so Trey can split time between home office sprints and on-site design reviews while Sarah stays remote-first.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Police presence keeps the Altstadt’s “longest bar in the world” lively yet manageable, with most crime concentrated around weekend nightlife.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers see €70–80k packages in Düsseldorf’s finance and media firms, enough to fund childcare and prototype runway even with Rhine-side rents.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "A sizable Japanese community, avant-garde architecture, and NRW’s media scene give the family a cosmopolitan base with easy airport hops.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_erfurt_report.json
+++ b/reports/germany_erfurt_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "State agencies, MDR media IT, and a handful of logistics firms provide .NET roles, but openings are sporadic enough that Trey keeps freelance contracts in reserve.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Aside from a few indie teams linked to the local university, Erfurt lacks established studios, so Trey would rely on remote collaboration for game work.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family flats in Andreasvorstadt or Brühlervorstadt stay under €10/m², so we can secure space near Kitas without bidding wars.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Outside university circles, English use is limited, making early German immersion essential for errands and school meetings.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Coworking spaces like KrämerLoft host modest tech meetups and family-friendly events, so building community takes a little initiative.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Upgraded tram lines and fiber pilots keep basics reliable, though some housing blocks still lag on energy retrofits.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "The Gera river trails and 45-minute rail rides into the Thuringian Forest make weekend hikes and bike trips easy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Student pubs and the Theater Erfurt provide casual nights out, though options pale compared to bigger German metros.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Thuringia’s LEG grants and the Erfurt Accelerator offer mentorship, yet limited investor depth means a studio would need lean budgets and remote partners.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "A compact center, short school runs, and nearby Thuringian forest hikes align with Sarah’s desire for a gentle daily rhythm.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "EVAG trams and trains on the Thuringian Railway keep commutes easy, though evening service drops off outside the compact core.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Public employers still expect in-office presence, so Trey and Sarah lean on remote US clients or hybrid setups rather than purely local roles.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Erfurt posts low violent-crime stats, and medieval streets stay lively but safe, giving the kids freedom to explore playgrounds and tram stops.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers in Erfurt earn roughly €50–55k across public sector and media firms, trading higher pay for a low cost of living.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Living steps from the Krämerbrücke and UNESCO-listed cathedral square offers a storybook base that still feels approachable.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_frankfurt_report.json
+++ b/reports/germany_frankfurt_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Frankfurt’s banks, Lufthansa Systems, and Deutsche Börse cloud teams offer steady .NET demand with high salaries, but regulated industries expect tight security clearances.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Crytek, Keen Games, and esports firms around the Messe sustain a robust talent pool, letting Trey stay in AAA networks while exploring indie prototypes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Central family flats often exceed €20/m², so we weigh smaller city apartments against more spacious suburbs like Offenbach or Bad Vilbel.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Finance, aviation, and expat services operate comfortably in English, with German mostly needed for bureaucracy and school meetings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "TechQuartier, RheinMain GameDev meetups, and international parent groups make it easy to find peers from day one.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Frankfurt’s skyline reflects its fiber backbone, airport connectivity, and well-funded public works that keep daily life efficient.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Palmengarten, riverside bike paths, and quick S-Bahn rides into the Taunus hills give the family greenery despite the skyline.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Jazzkeller, techno clubs like Robert Johnson, and Alte Oper concerts give Trey and Sarah deep music options plus reliable late-night transit.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Hessen’s Games funding, Deutsche Börse’s fintech accelerators, and Frankfurt RheinMain’s investor scene give Trey a real shot at funding a cross-border studio.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Global finance schedules keep weekdays intense; weekend escapes to the Taunus become essential for Sarah’s slower pace.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "RMV’s S-Bahn web, U-Bahn tunnels, and airport regional trains make car-free living realistic, even for late flights and suburban school runs.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Banks still favor hybrid compliance routines, but fintechs and consultancies embrace remote weeks, letting Trey juggle corporate gigs with indie work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Financial districts stay orderly, but the Hauptbahnhof area sees open drug use, prompting clear safety rules for the kids.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers earn €75–90k in Frankfurt’s finance and aviation sector, supporting private childcare bridges while Trey incubates a studio.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "A global airport hub, riverside skyline, and cross-border business scene let the family stay plugged into international life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_halle_report.json
+++ b/reports/germany_halle_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Energy utilities, data centers tied to Leipzig-Halle Airport, and university IT teams offer occasional .NET roles, but Trey plans for gaps between contracts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Beyond a handful of indie outfits in the Games & XR Mitteldeutschland network, Halle lacks dedicated studios, pushing Trey toward remote collaborations.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Generous Altbau near Peißnitzinsel rents around €8–9/m², giving the family space and park access without bidding wars.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English support appears in university settings, yet most services and childcare operate firmly in German.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Coworking spots like SaltLabs and regional tech groups offer community, but expect to hop to Leipzig for larger events.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "The ICE hub and recent tram upgrades shine, but some neighborhoods still grapple with aging post-war housing stock.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "The Saale floodplain, Dölauer Heide forest, and nearby Mansfeld lakes give the kids quick outdoor escapes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Student bars, Georg-Friedrich-Händel concerts, and Leipzig’s scene 30 minutes away supply options, even if big tours skip Halle itself.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Creative Hub Halle and Saxony-Anhalt grants help with prototypes, yet limited local investors mean Trey would court Leipzig or Berlin partners for scaling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "University energy mixes with a relaxed riverfront feel, helping Sarah keep days unhurried while Trey taps regional hubs as needed.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "HAVAG trams, Leipzig S-Bahn connections, and easy ICE access keep commutes light, though late evening service thins out in suburban districts.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Many professionals split time between Halle and Leipzig, so hybrid and remote arrangements are increasingly accepted.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Halle is generally safe, but we stay alert around the station corridor and plan safe routes home from evening events.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers see €50–55k in Halle’s public sector and logistics companies, so we pair local roles with remote income to hit savings goals.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Handel heritage, river island playgrounds, and proximity to Leipzig’s culture make Halle a quiet-but-connected base.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_hannover_report.json
+++ b/reports/germany_hannover_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Continental, TUI, and public-sector IT providers keep Hannover’s .NET teams active, with hybrid roles that balance stability and modern stacks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like Limbic Entertainment and the indie-friendly SAE Institute community offer gigs, though major AAA outfits remain in Hamburg or Berlin.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family housing in List or Südstadt averages €12/m², balancing affordability with access to good schools and parks.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Trade fairs and multinational HQs keep English prevalent at work, though city offices still expect German paperwork.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Hackover, Maker Faire Hannover, and family-friendly expat circles make it easy to plug into tech and parenting networks.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "EXPO 2000 legacies—smart transit control, district heating, and reliable broadband—keep infrastructure polished.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Eilenriede—the continent’s largest urban forest—plus Maschsee and Steinhuder Meer day trips deliver abundant outdoor time for the kids.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Maschseefest, jazz at Glocksee, and indie venues along the Limmerstraße give the couple regular nights out without megacity chaos.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Startup Niedersachsen grants, the Games & XR Niedersachsen network, and CeBIT’s innovation legacy give Trey access to mentors and prototype funding.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Weekdays revolve around steady corporate schedules, yet the expansive Eilenriede forest keeps weekends restful for Sarah.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "ÜSTRA’s Stadtbahn tunnels, S-Bahn ring, and integrated bike lanes keep commutes reliable even during big trade fairs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Post-pandemic, many Hannover employers normalized hybrid weeks, letting Trey split between home office and on-site design sessions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Hannover scores middle-of-the-pack on crime stats, with most issues clustered near the station—manageable with basic precautions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers make €65–75k in Hannover’s insurance, mobility, and manufacturing firms, enough to support childcare and indie runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Living beside Eilenriede while tapping a major trade-fair economy offers both green respite and professional reach.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_jena_report.json
+++ b/reports/germany_jena_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Optics giants like Carl Zeiss and Jenoptik use .NET for manufacturing and research tooling, offering stable yet specialized roles that value German proficiency.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Indie collectives linked to the University of Jena and local XR labs provide occasional Unity gigs, so Trey supplements with remote clients.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "High student demand pushes rents to €12–13/m² in popular districts, so the family may consider nearby villages for more space.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English flows in labs and among international students, yet city administration still runs primarily in German.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "OptoNet, AI research circles, and family playgroups anchored by the university help newcomers integrate quickly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Science parks boast gigabit links and modern labs, while ongoing rail upgrades keep intercity travel convenient.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Saale river trails, Jenzig hill hikes, and quick trips to the Thuringian Forest give the family ample outdoor adventures.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Student bars along Wagnergasse, jazz at Kassablanca, and classical concerts at the Volkshaus provide varied but small-scale nightlife.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "The Digital Innovation Hub, Thüringer Gründerpreis, and optics-focused accelerators make it feasible to build a niche studio that blends science and games.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Short commutes, riverfront cafés, and regular hikes into the Saale valley keep the overall rhythm relaxed.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Jena’s tram network and frequent regional trains to Leipzig and Erfurt keep daily life car-light, even if late-night service is thin.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Research labs still expect lab time, but software teams now allow hybrid schedules, letting Trey juggle prototypes with on-site sprints.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Low crime stats and a tight-knit university community make it easy to let the kids walk to playgrounds and libraries.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers earn about €55–60k across research institutes, trading higher pay for access to cutting-edge science partners.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Jena’s fusion of optics research, student energy, and dramatic valley landscapes gives the family a science-meets-nature lifestyle.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_karlsruhe_report.json
+++ b/reports/germany_karlsruhe_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Energy utilities like EnBW, fintech providers, and KIT spin-offs rely on .NET expertise, keeping a steady stream of senior roles with modern tooling.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Gameforge, Limbic’s nearby teams, and CyberForum’s dev collectives provide regular Unity and Unreal openings for Trey.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Demand from students and tech workers pushes rents near €13/m² in Weststadt, so we may look toward Durlach for larger family flats.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "KIT’s international programs and multinational firms keep English common at work, though local bureaucracy still expects German.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "CyberForum, Chaos Computer Club Erfa, and family-friendly STEM clubs make it easy to meet collaborators and friends.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Early gigabit rollouts, smart tram control, and strong district heating showcase Karlsruhe’s engineering-forward infrastructure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Hardtwald forests, Rhine floodplains, and hour-long trips to the Black Forest give the family abundant outdoor options.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Substage concerts, Tollhaus events, and craft beer pubs create a solid nightlife mix without Berlin-level intensity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "CyberLab accelerators, Medien und Filmgesellschaft Baden-Württemberg grants, and KIT talent pipelines make it realistic to seed a boutique studio.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "A strong cycling culture, quick commutes, and nearby vineyards balance the bustle of its research institutions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "The Karlsruhe Model Stadtbahn links regional towns seamlessly, and the new tunnel keeps trams reliable even through the city center.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Tech employers embraced hybrid workflows, so Trey can anchor at home while popping into coworking hubs like Perfekt Futur as needed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Karlsruhe remains one of Germany’s safer metros, with most incidents limited to nightlife strips around Europaplatz.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers earn €65–75k across Karlsruhe’s mobility and cybersecurity firms, pairing well with the city’s moderate cost of living.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Living between KIT’s research scene and the Black Forest’s trails gives the family both innovation energy and easy escapes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_kiel_report.json
+++ b/reports/germany_kiel_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "German Navy IT commands, Sartori & Berger logistics, and digital maritime startups hire .NET talent, though roles concentrate around German-speaking teams.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Indie studios tied to Kieler Kreativkühlschrank and FH Kiel’s media program offer occasional Unity contracts, but long-term roles remain scarce.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Naval staff and students tighten supply near the fjord, yet family flats in Gaarden or Ravensberg remain attainable around €11/m².",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Naval operations and universities keep English present, yet day-to-day errands still prefer German, especially in Kitas.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Maritime Startups, WomenTechmakers Kiel, and English-speaking parent groups help newcomers build networks quickly.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Ongoing waterfront redevelopment, fiber rollouts, and green ferry pilots highlight Kiel’s modern maritime focus.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Baltic Sea beaches, sailing clubs, and Holstein Switzerland parks deliver constant outdoor adventures for the kids.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Student bars around Bergstraße, Pumpe concerts, and Kiel Week festivals provide bursts of nightlife even if options narrow off-season.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Digital Week Kiel, Lighthouse project funding, and Blue Port initiatives support prototypes, yet Trey's studio would rely on remote collaborators for growth.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "A maritime rhythm, short commutes, and waterfront promenades keep stress levels low for the whole family.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Bus lines, Förde ferries, and regional trains cover Kiel, but limited evening service makes a family car or cargo bike handy for late outings.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Port digitization projects and universities normalize hybrid teams, so Trey can combine remote sprints with periodic on-site reviews.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Kiel stays largely safe, with occasional port-related incidents; neighborhoods remain comfortable for kids biking to school.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers typically make €55–60k across maritime tech and health IT, reflecting moderate demand paired with low living costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Living beside the fjord with access to Europe’s largest sailing festival lets the family embrace a seafaring lifestyle.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_koeln_report.json
+++ b/reports/germany_koeln_report.json
@@ -4,22 +4,22 @@
   "values": [
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Cologne’s mix of Deutsche Telekom teams, Ford’s IT hub, and media-tech firms in the Rheinauhafen keeps senior .NET roles available, though German fluency accelerates leadership opportunities.",
+      "alignmentText": "Köln (Cologne)’s mix of Deutsche Telekom teams, Ford’s IT hub, and media-tech firms in the Rheinauhafen keeps senior .NET roles available, though German fluency accelerates leadership opportunities.",
       "alignmentValue": 7
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Traffic on the Cologne Belt and lignite power from nearby Rhineland raises annual PM2.5 to roughly 14 µg/m³, so the family tracks AQI during stagnant winter weeks.",
+      "alignmentText": "Traffic on the Köln (Cologne) Belt and lignite power from nearby Rhineland raises annual PM2.5 to roughly 14 µg/m³, so the family tracks AQI during stagnant winter weeks.",
       "alignmentValue": 6
     },
     {
       "key": "Atheism",
-      "alignmentText": "Cologne remains culturally Catholic, yet urban neighborhoods and universities are secular enough that openly atheist parents meet little friction.",
+      "alignmentText": "Köln (Cologne) remains culturally Catholic, yet urban neighborhoods and universities are secular enough that openly atheist parents meet little friction.",
       "alignmentValue": 7
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Cologne benefits from Germany’s federal checks—coalition politics, constitutional courts, and a vigilant press—that keep far-right surges from eroding civil liberties.",
+      "alignmentText": "Köln (Cologne) benefits from Germany’s federal checks—coalition politics, constitutional courts, and a vigilant press—that keep far-right surges from eroding civil liberties.",
       "alignmentValue": 9
     },
     {
@@ -64,12 +64,12 @@
     },
     {
       "key": "Community Vibes",
-      "alignmentText": "Cologne’s Karneval culture and neighborhood festivals make it easy to meet people; Sarah can build friendships through Elterncafés and community centers at a relaxed pace.",
+      "alignmentText": "Köln (Cologne)’s Karneval culture and neighborhood festivals make it easy to meet people; Sarah can build friendships through Elterncafés and community centers at a relaxed pace.",
       "alignmentValue": 8
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Keeping Anmeldung current, submitting freelance tax declarations, and renewing permits on schedule keeps Cologne’s bureaucracy predictable—late filings mostly trigger fines.",
+      "alignmentText": "Keeping Anmeldung current, submitting freelance tax declarations, and renewing permits on schedule keeps Köln (Cologne)’s bureaucracy predictable—late filings mostly trigger fines.",
       "alignmentValue": 7
     },
     {
@@ -79,7 +79,7 @@
     },
     {
       "key": "Dual Citizenship Allowed",
-      "alignmentText": "Germany’s 2024 reform applies statewide, and Cologne’s Ausländerbehörde processes dual applications with clear documentation lists.",
+      "alignmentText": "Germany’s 2024 reform applies statewide, and Köln (Cologne)’s Ausländerbehörde processes dual applications with clear documentation lists.",
       "alignmentValue": 9
     },
     {
@@ -94,7 +94,7 @@
     },
     {
       "key": "Education",
-      "alignmentText": "Cologne follows NRW’s comprehensive school reforms; Gymnasium access depends on grades and teacher recommendations, so family engagement stays important.",
+      "alignmentText": "Köln (Cologne) follows NRW’s comprehensive school reforms; Gymnasium access depends on grades and teacher recommendations, so family engagement stays important.",
       "alignmentValue": 7
     },
     {
@@ -104,7 +104,7 @@
     },
     {
       "key": "Environment",
-      "alignmentText": "Cologne balances Rhine greenways, Stadtwald parks, and nearby Eifel forests with industrial corridors to the north; weekend nature escapes are straightforward.",
+      "alignmentText": "Köln (Cologne) balances Rhine greenways, Stadtwald parks, and nearby Eifel forests with industrial corridors to the north; weekend nature escapes are straightforward.",
       "alignmentValue": 7
     },
     {
@@ -144,7 +144,7 @@
     },
     {
       "key": "Fashion Trends (Female)",
-      "alignmentText": "Cologne mixes relaxed streetwear with bold Karneval flair, letting Sarah blend tech casual with colorful touches.",
+      "alignmentText": "Köln (Cologne) mixes relaxed streetwear with bold Karneval flair, letting Sarah blend tech casual with colorful touches.",
       "alignmentValue": 7
     },
     {
@@ -159,17 +159,17 @@
     },
     {
       "key": "Game Dev Work Prospects",
-      "alignmentText": "Studios like Ubisoft Blue Byte, Electronic Arts (in nearby Cologne-Ehrenfeld), and indie outfits create opportunities, but the market is smaller than Berlin or Hamburg.",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Electronic Arts (in nearby Köln (Cologne)-Ehrenfeld), and indie outfits create opportunities, but the market is smaller than Berlin or Hamburg.",
       "alignmentValue": 6
     },
     {
       "key": "Gender Fluidity",
-      "alignmentText": "Cologne Pride, queer churches, and inclusive nightlife around Schaafenstraße support gender-diverse residents, even if services are more spread out.",
+      "alignmentText": "Köln (Cologne) Pride, queer churches, and inclusive nightlife around Schaafenstraße support gender-diverse residents, even if services are more spread out.",
       "alignmentValue": 8
     },
     {
       "key": "Gender Rights",
-      "alignmentText": "Cologne enforces Germany’s anti-discrimination laws, funds queer counseling, and offers third-gender registration pathways.",
+      "alignmentText": "Köln (Cologne) enforces Germany’s anti-discrimination laws, funds queer counseling, and offers third-gender registration pathways.",
       "alignmentValue": 9
     },
     {
@@ -179,7 +179,7 @@
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Proof of insurance, income, and housing keeps visa renewals smooth; Cologne’s online booking portal fills fast, so planning ahead is essential.",
+      "alignmentText": "Proof of insurance, income, and housing keeps visa renewals smooth; Köln (Cologne)’s online booking portal fills fast, so planning ahead is essential.",
       "alignmentValue": 7
     },
     {
@@ -199,7 +199,7 @@
     },
     {
       "key": "Higher Education Access (Citizens)",
-      "alignmentText": "University of Cologne, TH Köln, and nearby Bonn campuses provide broad, low-cost study options for citizens.",
+      "alignmentText": "University of Köln (Cologne), TH Köln, and nearby Bonn campuses provide broad, low-cost study options for citizens.",
       "alignmentValue": 8
     },
     {
@@ -234,7 +234,7 @@
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Cologne Pride draws one of Europe’s largest parades, and queer-friendly neighborhoods like Ehrenfeld feel welcoming to poly and LGBTQ+ families.",
+      "alignmentText": "Köln (Cologne) Pride draws one of Europe’s largest parades, and queer-friendly neighborhoods like Ehrenfeld feel welcoming to poly and LGBTQ+ families.",
       "alignmentValue": 9
     },
     {
@@ -244,7 +244,7 @@
     },
     {
       "key": "Masculinity Norms",
-      "alignmentText": "Men are expected to be dependable and involved parents; macho posturing clashes with Cologne’s friendly, open culture.",
+      "alignmentText": "Men are expected to be dependable and involved parents; macho posturing clashes with Köln (Cologne)’s friendly, open culture.",
       "alignmentValue": 8
     },
     {
@@ -254,12 +254,12 @@
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "Cologne follows the €12.41 national minimum, with higher collective agreements in chemicals and automotive sectors.",
+      "alignmentText": "Köln (Cologne) follows the €12.41 national minimum, with higher collective agreements in chemicals and automotive sectors.",
       "alignmentValue": 7
     },
     {
       "key": "Modernity & Infrastructure",
-      "alignmentText": "Fiber and 5G rollouts are progressing, KVB trams link the metro, and Cologne/Bonn Airport adds international connections despite some Deutsche Bahn delays.",
+      "alignmentText": "Fiber and 5G rollouts are progressing, KVB trams link the metro, and Köln (Cologne)/Bonn Airport adds international connections despite some Deutsche Bahn delays.",
       "alignmentValue": 7
     },
     {
@@ -279,7 +279,7 @@
     },
     {
       "key": "Nightlife & Music",
-      "alignmentText": "Cologne’s club scene, live music venues, and classical concerts at Kölner Philharmonie give parents abundant date-night choices.",
+      "alignmentText": "Köln (Cologne)’s club scene, live music venues, and classical concerts at Kölner Philharmonie give parents abundant date-night choices.",
       "alignmentValue": 9
     },
     {
@@ -289,12 +289,12 @@
     },
     {
       "key": "Notable Game Development Communities",
-      "alignmentText": "devcom, Cologne Game Lab, and local IGDA meetups connect game creators thanks to Gamescom’s annual presence.",
+      "alignmentText": "devcom, Köln (Cologne) Game Lab, and local IGDA meetups connect game creators thanks to Gamescom’s annual presence.",
       "alignmentValue": 7
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Ubisoft Blue Byte, EA, and indie studios around Cologne Game Lab anchor the local industry, giving Trey a starting network.",
+      "alignmentText": "Ubisoft Blue Byte, EA, and indie studios around Köln (Cologne) Game Lab anchor the local industry, giving Trey a starting network.",
       "alignmentValue": 7
     },
     {
@@ -304,7 +304,7 @@
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Cologne balances productive workdays with relaxed evenings on the Rhine; Sundays and Karneval season slow the pace dramatically for family time.",
+      "alignmentText": "Köln (Cologne) balances productive workdays with relaxed evenings on the Rhine; Sundays and Karneval season slow the pace dramatically for family time.",
       "alignmentValue": 8
     },
     {
@@ -314,7 +314,7 @@
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "Reforms allow naturalization after five years (three with integration milestones); Cologne’s offices process applications steadily if paperwork is complete.",
+      "alignmentText": "Reforms allow naturalization after five years (three with integration milestones); Köln (Cologne)’s offices process applications steadily if paperwork is complete.",
       "alignmentValue": 8
     },
     {
@@ -344,7 +344,7 @@
     },
     {
       "key": "Progressivism",
-      "alignmentText": "Cologne city hall leans progressive, championing climate, LGBTQ+, and integration programs aligned with the family’s values.",
+      "alignmentText": "Köln (Cologne) city hall leans progressive, championing climate, LGBTQ+, and integration programs aligned with the family’s values.",
       "alignmentValue": 8
     },
     {
@@ -394,12 +394,12 @@
     },
     {
       "key": "Ruby Work Prospects",
-      "alignmentText": "Rails roles exist in media companies, Cologne/Bonn startups, and digital agencies, yet the market is smaller than Berlin so networking matters.",
+      "alignmentText": "Rails roles exist in media companies, Köln (Cologne)/Bonn startups, and digital agencies, yet the market is smaller than Berlin so networking matters.",
       "alignmentValue": 6
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Cologne is generally safe; petty theft clusters around main station nightlife, but family neighborhoods stay calm.",
+      "alignmentText": "Köln (Cologne) is generally safe; petty theft clusters around main station nightlife, but family neighborhoods stay calm.",
       "alignmentValue": 7
     },
     {
@@ -419,12 +419,12 @@
     },
     {
       "key": "Sex (Attitudes)",
-      "alignmentText": "Cologne’s sex-positive culture, comprehensive education, and queer communities create open conversations about relationships and consent.",
+      "alignmentText": "Köln (Cologne)’s sex-positive culture, comprehensive education, and queer communities create open conversations about relationships and consent.",
       "alignmentValue": 9
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Cologne invests in housing, transit, and integration, aligning with Germany’s generous welfare infrastructure.",
+      "alignmentText": "Köln (Cologne) invests in housing, transit, and integration, aligning with Germany’s generous welfare infrastructure.",
       "alignmentValue": 8
     },
     {
@@ -434,7 +434,7 @@
     },
     {
       "key": "Stability",
-      "alignmentText": "Germany’s diversified economy and EU backing keep Cologne stable even as certain industries transition to greener tech.",
+      "alignmentText": "Germany’s diversified economy and EU backing keep Köln (Cologne) stable even as certain industries transition to greener tech.",
       "alignmentValue": 9
     },
     {
@@ -459,7 +459,7 @@
     },
     {
       "key": "Trust in Government",
-      "alignmentText": "Citizen surveys show solid trust in Cologne’s city hall and federal institutions, bolstered by participatory budgeting efforts.",
+      "alignmentText": "Citizen surveys show solid trust in Köln (Cologne)’s city hall and federal institutions, bolstered by participatory budgeting efforts.",
       "alignmentValue": 8
     },
     {
@@ -494,22 +494,22 @@
     },
     {
       "key": "View of Neighboring Countries",
-      "alignmentText": "Cologne’s location fosters friendly ties with Belgium, the Netherlands, and Luxembourg, encouraging weekend travel.",
+      "alignmentText": "Köln (Cologne)’s location fosters friendly ties with Belgium, the Netherlands, and Luxembourg, encouraging weekend travel.",
       "alignmentValue": 8
     },
     {
       "key": "View of self",
-      "alignmentText": "Colognes see themselves as warm, inclusive, and a bit irreverent—proud of their cathedral and Karneval spirit.",
+      "alignmentText": "Köln (Cologne) residents see themselves as warm, inclusive, and a bit irreverent—proud of the cathedral, Karneval spirit, and creative media scene.",
       "alignmentValue": 8
     },
     {
       "key": "View of Them by Neighboring Countries",
-      "alignmentText": "Neighbors see Cologne as open and celebratory, sometimes teasing its carnival chaos but valuing its hospitality.",
+      "alignmentText": "Neighbors view Köln (Cologne) as festive and welcoming, occasionally teasing its carnival chaos but valuing its hospitality and cross-border outlook.",
       "alignmentValue": 7
     },
     {
       "key": "Visa Paths",
-      "alignmentText": "Blue Cards, skilled worker visas, Chancenkarte, and artist/freelancer permits run through Cologne’s immigration office with clear checklists once appointments are secured.",
+      "alignmentText": "Blue Cards, skilled worker visas, Chancenkarte, and artist/freelancer permits run through Köln (Cologne)’s immigration office with clear checklists once appointments are secured.",
       "alignmentValue": 8
     },
     {
@@ -519,7 +519,7 @@
     },
     {
       "key": "What Is Intriguing",
-      "alignmentText": "Cologne blends a creative media economy, inclusive culture, and legendary festivals—offering the family progressive values with big-city warmth.",
+      "alignmentText": "Köln (Cologne) blends a creative media economy, inclusive culture, and legendary festivals—offering the family progressive values with big-city warmth.",
       "alignmentValue": 8
     },
     {

--- a/reports/germany_leipzig_report.json
+++ b/reports/germany_leipzig_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "E-commerce hubs around DHL, public administration digitization, and IT consultancies keep Leipzig’s .NET market steady, though German fluency opens the best roles.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Games & XR Mitteldeutschland, HandyGames’ satellite teams, and a lively indie coworking scene create contract opportunities even if AAA studios are rare.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Gentrification in Plagwitz and Südvorstadt pushes rents toward €12/m², so we scout earlier for kid-friendly flats near green space.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "International students and creative industries use English widely, though bureaucracy still expects German forms.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Tech events at Basislager, indie game jams, and international parenting groups make it easy to build friendships fast.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Massive rail investments and smart-city pilots in Plagwitz highlight Leipzig’s modern infrastructure alongside its industrial heritage.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Leipzig’s New Lakes District, Clara-Zetkin Park, and floodplain forests give the kids room to roam within minutes of home.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Connewitz clubs, Gewandhaus concerts, and Wave-Gotik-Treffen showcase everything from underground to classical scenes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "SpinLab Leipzig, Creative Europe desks, and the Leipzig Games Convention legacy keep investors curious about prototypes coming out of the city.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Creative neighborhoods, short commutes, and lake day-trips keep the pace balanced between city energy and downtime.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "LVB trams, S-Bahn Mitteldeutschland, and late-night buses cover the metro comprehensively, so the family can live car-free.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Logistics giants and creative agencies embraced hybrid work, so Trey can split weeks between home sprints and onsite workshops.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Leipzig feels largely safe, but Connewitz demonstrations and Hauptbahnhof petty crime mean we stay situationally aware.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers typically earn €60k across logistics, energy, and fintech, balanced by moderate housing costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Leipzig’s mix of avant-garde arts, sprawling lakes, and resurgent economy give the family a progressive playground.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_lubeck_report.json
+++ b/reports/germany_lubeck_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Medical tech leader Dräger, logistics firms, and the Lübeck port authority maintain .NET teams, though roles remain tied to German-language operations.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Beyond small indies and university labs, Lübeck lacks dedicated studios, so Trey relies on remote-first collaborations for game work.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Tourism and limited Altstadt stock keep rents around €12/m², so we target family flats in St. Jürgen or St. Lorenz for better value.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Tourism keeps English serviceable in cafes, yet municipal offices and childcare lean heavily on German.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Media Docks coworking, university parent groups, and international choir circles help newcomers find community with a bit of initiative.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Port digitization and medtech labs are modern, but some neighborhoods still await fiber rollouts.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Baltic beaches at Travemünde, canoeing on the Wakenitz, and forested nature reserves deliver frequent outdoor escapes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Students keep bars lively and the Musik- und Kongresshalle hosts concerts, though big tours stick to Hamburg.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Technikzentrum Lübeck and Northern Germany creative grants offer seed support, yet scaling a studio would involve tapping Hamburg or Copenhagen networks.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "A harbor pace, seaside weekends, and small-city commutes align with Sarah’s preference for slower days.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Bus networks and hourly trains to Hamburg or the Baltic resorts cover essentials, but lack of trams means more planning for cross-town trips.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Many professionals commute to Hamburg part-time, so hybrid and remote schedules are becoming more accepted locally.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Lübeck remains notably safe, letting the kids explore the UNESCO old town with minimal worry.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers earn €55–60k in Lübeck’s medtech and logistics sector, balanced by manageable living costs.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "A Hanseatic UNESCO core paired with quick Baltic swims gives the family storybook scenery and coastal downtime.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_magdeburg_report.json
+++ b/reports/germany_magdeburg_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "State ministries, mechanical engineering firms, and new Intel supplier projects create pockets of .NET work, but Trey expects stretches between local contracts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "A few indie developers around the University of Magdeburg collaborate on XR projects, yet the city lacks standing studios, making remote work essential.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Post-war housing surplus keeps family flats under €9/m², so we can rent spacious units near parks without strain.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Outside academia, English is limited, reinforcing the need for the family to advance their German quickly.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "University maker labs and the state’s digital hubs offer networking, though we may travel to Berlin for larger communities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "The upcoming Intel fabs spur infrastructure upgrades, yet several neighborhoods still rely on older utilities.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Elbauenpark, riverfront trails, and nearby Harz excursions give the family ample outdoor space.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Clubs like Projekt 7 and the Factory host regional acts, but big tours still prefer Berlin or Leipzig.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Silicon Saxony-Anhalt grants and the Innovate! Hub provide mentorship, though raising capital likely means pitching in Berlin.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Short commutes and a quieter downtown suit Sarah’s slower pace while leaving space for Trey’s side projects.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Magdeburg’s tram grid, Elbe bike network, and hourly ICE links to Berlin keep commutes smooth despite the city’s sprawl.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Regional employers increasingly accept hybrid work, letting Trey base in Magdeburg while collaborating with Berlin clients.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Crime concentrates near the main station and nightlife strips; residential districts stay calm with basic precautions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers earn €50–55k across public-sector and manufacturing roles, reflecting a modest market.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "The Elbe water bridge, green parks, and proximity to the emerging semiconductor hub provide a unique blend of engineering and nature.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_mainz_report.json
+++ b/reports/germany_mainz_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "ZDF, Schott, and Biontech’s digital teams hire .NET talent, though many roles blend German-language enterprise resource planning with regulated workflows.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Indie collectives linked to Hochschule Mainz and nearby Frankfurt studios offer collaboration, but sustained roles are limited locally.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Limited stock and Frankfurt spillover push rents toward €15/m², so we may consider Wiesbaden or Rheinhessen villages for more space.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "English is common at Biontech and ZDF, yet city offices still operate primarily in German, so language classes stay on the agenda.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Rhein-Main tech meetups, XRhub Mainz, and international parent groups help the family build networks quickly.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Smart-city pilots in the Zollhafen district and robust rail links highlight Mainz’s modern infrastructure.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Rhine river paths, vineyards, and Taunus hikes make it simple to unplug with the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Altstadt wine bars, KUZ concerts, and fast trains to Frankfurt’s clubs give Trey and Sarah plenty of evening variety.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Media funding from Rheinland-Pfalz, proximity to Frankfurt investors, and XR hub SyncReality make it feasible to launch a boutique studio.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Rhine promenades, wine festivals, and quick S-Bahn rides keep life balanced between big-city access and small-town charm.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Mainz’s tram revival, S-Bahn into Frankfurt, and reliable bus lines make cross-river commutes manageable without a car.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Biotech and media employers blend hybrid weeks, allowing Trey to split time between home sprints and Frankfurt client visits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Mainz stays generally safe, with occasional nightlife noise in Altstadt that’s easy to avoid with the kids.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers see €65–75k thanks to biotech and media employers, supporting comfortable living despite higher rents.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Wine-country sunsets, Gutenberg heritage, and proximity to Frankfurt’s economy deliver both charm and opportunity.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_muenchen_report.json
+++ b/reports/germany_muenchen_report.json
@@ -4,22 +4,22 @@
   "values": [
     {
       "key": ".NET Work Prospects",
-      "alignmentText": "Munich’s corporate corridor of Siemens, Allianz, and Microsoft partners keeps .NET teams hiring senior engineers, and English-forward cloud migration projects give Trey a realistic path even before his German catches up.",
+      "alignmentText": "München (Munich)’s corporate corridor of Siemens, Allianz, and Microsoft partners keeps .NET teams hiring senior engineers, and English-forward cloud migration projects give Trey a realistic path even before his German catches up.",
       "alignmentValue": 8
     },
     {
       "key": "Air Quality",
-      "alignmentText": "Low-emission zones, widespread district heating, and Alpine breezes keep Munich’s annual PM2.5 near 12 µg/m³, so the kids only need to watch AQI alerts on a handful of stagnant winter days.",
+      "alignmentText": "Low-emission zones, widespread district heating, and Alpine breezes keep München (Munich)’s annual PM2.5 near 12 µg/m³, so the kids only need to watch AQI alerts on a handful of stagnant winter days.",
       "alignmentValue": 8
     },
     {
       "key": "Atheism",
-      "alignmentText": "Bavaria still collects Kirchensteuer, yet Munich’s tech and university circles skew secular, so openly atheist parents rarely feel pressure beyond the occasional traditional holiday ritual at school.",
+      "alignmentText": "Bavaria still collects Kirchensteuer, yet München (Munich)’s tech and university circles skew secular, so openly atheist parents rarely feel pressure beyond the occasional traditional holiday ritual at school.",
       "alignmentValue": 8
     },
     {
       "key": "Authoritarian Backsliding Risk",
-      "alignmentText": "Munich benefits from Germany’s federal guardrails—independent courts, coalition politics, and a vigilant press—that keep far-right surges from eroding civil liberties the family values.",
+      "alignmentText": "München (Munich) benefits from Germany’s federal guardrails—independent courts, coalition politics, and a vigilant press—that keep far-right surges from eroding civil liberties the family values.",
       "alignmentValue": 9
     },
     {
@@ -34,7 +34,7 @@
     },
     {
       "key": "Boardgaming & Tabletop",
-      "alignmentText": "Spielwiesn, community centers like GameTogether, and English-friendly board-game cafés keep Munich’s tabletop scene lively, making it easy for Trey to test prototypes or join campaigns.",
+      "alignmentText": "Spielwiesn, community centers like GameTogether, and English-friendly board-game cafés keep München (Munich)’s tabletop scene lively, making it easy for Trey to test prototypes or join campaigns.",
       "alignmentValue": 10
     },
     {
@@ -49,7 +49,7 @@
     },
     {
       "key": "Childcare Support (Citizens)",
-      "alignmentText": "Munich citizens tap Kindergeld, capped Kita fees, and Landeserziehungsgeld, but still navigate annual re-registration to hold coveted bilingual spots.",
+      "alignmentText": "München (Munich) citizens tap Kindergeld, capped Kita fees, and Landeserziehungsgeld, but still navigate annual re-registration to hold coveted bilingual spots.",
       "alignmentValue": 8
     },
     {
@@ -69,7 +69,7 @@
     },
     {
       "key": "Compliance & Risks",
-      "alignmentText": "Keeping Melderegister data current, renewing residence permits, and filing local tax declarations on time keeps Munich bureaucracy predictable—missed deadlines mainly trigger fines, not status threats.",
+      "alignmentText": "Keeping Melderegister data current, renewing residence permits, and filing local tax declarations on time keeps München (Munich) bureaucracy predictable—missed deadlines mainly trigger fines, not status threats.",
       "alignmentValue": 7
     },
     {
@@ -79,12 +79,12 @@
     },
     {
       "key": "Dual Citizenship Allowed",
-      "alignmentText": "Germany’s 2024 reform applies in Bavaria, letting naturalized residents keep their U.S. passport with straightforward notifications to Munich’s Kreisverwaltungsreferat.",
+      "alignmentText": "Germany’s 2024 reform applies in Bavaria, letting naturalized residents keep their U.S. passport with straightforward notifications to München (Munich)’s Kreisverwaltungsreferat.",
       "alignmentValue": 9
     },
     {
       "key": "Economic Health",
-      "alignmentText": "Munich anchors southern Germany’s economy with low unemployment near 3% and resilient automotive, biotech, and fintech clusters, cushioning the family against national slowdowns.",
+      "alignmentText": "München (Munich) anchors southern Germany’s economy with low unemployment near 3% and resilient automotive, biotech, and fintech clusters, cushioning the family against national slowdowns.",
       "alignmentValue": 8
     },
     {
@@ -99,12 +99,12 @@
     },
     {
       "key": "Employer Visa Sponsorship",
-      "alignmentText": "Munich multinationals regularly sponsor EU Blue Cards for senior developers, though HR still expects degree verification and German-language contracts before onboarding.",
+      "alignmentText": "München (Munich) multinationals regularly sponsor EU Blue Cards for senior developers, though HR still expects degree verification and German-language contracts before onboarding.",
       "alignmentValue": 7
     },
     {
       "key": "Environment",
-      "alignmentText": "Munich’s extensive parks, strict recycling, and district heating systems keep neighborhoods green, even if nearby industrial corridors add occasional truck noise along the ring road.",
+      "alignmentText": "München (Munich)’s extensive parks, strict recycling, and district heating systems keep neighborhoods green, even if nearby industrial corridors add occasional truck noise along the ring road.",
       "alignmentValue": 8
     },
     {
@@ -134,7 +134,7 @@
     },
     {
       "key": "Family Policy (Common Family)",
-      "alignmentText": "Typical Munich households rely on ElterngeldPlus, subsidized childcare, and flexible work policies, though managing benefits across city and Bavarian agencies takes persistence.",
+      "alignmentText": "Typical München (Munich) households rely on ElterngeldPlus, subsidized childcare, and flexible work policies, though managing benefits across city and Bavarian agencies takes persistence.",
       "alignmentValue": 8
     },
     {
@@ -144,7 +144,7 @@
     },
     {
       "key": "Fashion Trends (Female)",
-      "alignmentText": "Women balance smart-casual layering—wool coats, scarves, and sneakers—with climate-ready gear, so Sarah can blend practicality with Munich’s polished aesthetic.",
+      "alignmentText": "Women balance smart-casual layering—wool coats, scarves, and sneakers—with climate-ready gear, so Sarah can blend practicality with München (Munich)’s polished aesthetic.",
       "alignmentValue": 7
     },
     {
@@ -164,7 +164,7 @@
     },
     {
       "key": "Gender Fluidity",
-      "alignmentText": "Munich’s queer community centers and the 2024 Self-Determination Act support name and gender marker changes, though some regional paperwork still defaults to binary options.",
+      "alignmentText": "München (Munich)’s queer community centers and the 2024 Self-Determination Act support name and gender marker changes, though some regional paperwork still defaults to binary options.",
       "alignmentValue": 8
     },
     {
@@ -174,17 +174,17 @@
     },
     {
       "key": "Gender Roles",
-      "alignmentText": "Dual-career households are normal in Munich, even if parts of Bavaria lean traditional; school communities increasingly expect fathers at Elternabende and pickup rotations.",
+      "alignmentText": "Dual-career households are normal in München (Munich), even if parts of Bavaria lean traditional; school communities increasingly expect fathers at Elternabende and pickup rotations.",
       "alignmentValue": 8
     },
     {
       "key": "General Considerations for Visa Holders",
-      "alignmentText": "Stay organized around Anmeldung, health insurance enrollment, and annual income reviews, and Munich’s Ausländerbehörde processes remain transparent with predictable renewal timelines.",
+      "alignmentText": "Stay organized around Anmeldung, health insurance enrollment, and annual income reviews, and München (Munich)’s Ausländerbehörde processes remain transparent with predictable renewal timelines.",
       "alignmentValue": 7
     },
     {
       "key": "Global Warming Risk",
-      "alignmentText": "Being inland spares Munich from sea-level threats, but heavier Alpine storms and Isar flooding mean the family should choose housing off the immediate river plain.",
+      "alignmentText": "Being inland spares München (Munich) from sea-level threats, but heavier Alpine storms and Isar flooding mean the family should choose housing off the immediate river plain.",
       "alignmentValue": 6
     },
     {
@@ -199,7 +199,7 @@
     },
     {
       "key": "Higher Education Access (Citizens)",
-      "alignmentText": "Citizens pay only semester fees at LMU or TU Munich, and applied sciences universities offer cooperative programs that support Anduin’s future STEM interests.",
+      "alignmentText": "Citizens pay only semester fees at LMU or TU München (Munich), and applied sciences universities offer cooperative programs that support Anduin’s future STEM interests.",
       "alignmentValue": 9
     },
     {
@@ -234,7 +234,7 @@
     },
     {
       "key": "LGBTQ+ Attitudes",
-      "alignmentText": "Munich Pride, queer community centers, and inclusive nightlife signal broad acceptance, though rural Bavaria remains more conservative than the city core.",
+      "alignmentText": "München (Munich) Pride, queer community centers, and inclusive nightlife signal broad acceptance, though rural Bavaria remains more conservative than the city core.",
       "alignmentValue": 8
     },
     {
@@ -254,7 +254,7 @@
     },
     {
       "key": "Minimum Wage",
-      "alignmentText": "Munich follows the national €12.41 per hour minimum, though local collective agreements often pay more to offset the high cost of living.",
+      "alignmentText": "München (Munich) follows the national €12.41 per hour minimum, though local collective agreements often pay more to offset the high cost of living.",
       "alignmentValue": 7
     },
     {
@@ -269,7 +269,7 @@
     },
     {
       "key": "Natural Disasters",
-      "alignmentText": "Munich avoids earthquakes and hurricanes, but heavy rain can swell the Isar and occasional Föhn storms bring strong winds—risks mitigated with good insurance and cellar storage.",
+      "alignmentText": "München (Munich) avoids earthquakes and hurricanes, but heavy rain can swell the Isar and occasional Föhn storms bring strong winds—risks mitigated with good insurance and cellar storage.",
       "alignmentValue": 7
     },
     {
@@ -294,17 +294,17 @@
     },
     {
       "key": "Notable Game Studios",
-      "alignmentText": "Studios like Chimera Entertainment, Remote Control Productions, and HandyGames maintain Munich presences, giving Trey networking footholds.",
+      "alignmentText": "Studios like Chimera Entertainment, Remote Control Productions, and HandyGames maintain München (Munich) presences, giving Trey networking footholds.",
       "alignmentValue": 8
     },
     {
       "key": "Opportunities for Video Game Startup",
-      "alignmentText": "Bavaria funds prototypes through FFF Bayern, and UnternehmerTUM plus Werk1 offer incubators, making Munich a fertile launchpad for a small studio.",
+      "alignmentText": "Bavaria funds prototypes through FFF Bayern, and UnternehmerTUM plus Werk1 offer incubators, making München (Munich) a fertile launchpad for a small studio.",
       "alignmentValue": 9
     },
     {
       "key": "Pace of Life",
-      "alignmentText": "Munich mixes efficient workdays with slower evenings; transit commutes are predictable, and Sundays stay quiet thanks to retail closures that encourage family downtime.",
+      "alignmentText": "München (Munich) mixes efficient workdays with slower evenings; transit commutes are predictable, and Sundays stay quiet thanks to retail closures that encourage family downtime.",
       "alignmentValue": 7
     },
     {
@@ -314,7 +314,7 @@
     },
     {
       "key": "Path to Citizenship",
-      "alignmentText": "The reformed law lets long-term residents naturalize after five years (or three with integration milestones), so a stable stay in Munich can lead to passports this decade.",
+      "alignmentText": "The reformed law lets long-term residents naturalize after five years (or three with integration milestones), so a stable stay in München (Munich) can lead to passports this decade.",
       "alignmentValue": 8
     },
     {
@@ -329,7 +329,7 @@
     },
     {
       "key": "Polyamory",
-      "alignmentText": "Munich hosts discreet poly-friendly meetups and therapists, and while legal recognition stops at monogamous partnerships, social circles in the city center stay largely accepting.",
+      "alignmentText": "München (Munich) hosts discreet poly-friendly meetups and therapists, and while legal recognition stops at monogamous partnerships, social circles in the city center stay largely accepting.",
       "alignmentValue": 7
     },
     {
@@ -364,7 +364,7 @@
     },
     {
       "key": "Religion in Politics",
-      "alignmentText": "The CSU references Christian heritage, yet Munich’s coalition politics keep overt religious policy limited to symbolic debates like shop-closing hours.",
+      "alignmentText": "The CSU references Christian heritage, yet München (Munich)’s coalition politics keep overt religious policy limited to symbolic debates like shop-closing hours.",
       "alignmentValue": 7
     },
     {
@@ -399,7 +399,7 @@
     },
     {
       "key": "Safety & Crime",
-      "alignmentText": "Munich ranks among Europe’s safest big cities; crime centers on bike theft and festival pickpocketing, so teens walking home from clubs remain low risk.",
+      "alignmentText": "München (Munich) ranks among Europe’s safest big cities; crime centers on bike theft and festival pickpocketing, so teens walking home from clubs remain low risk.",
       "alignmentValue": 9
     },
     {
@@ -424,7 +424,7 @@
     },
     {
       "key": "Social Policies",
-      "alignmentText": "Germany’s welfare state underpins healthcare, unemployment insurance, and family benefits, and Munich layers on housing subsidies for lower-income residents.",
+      "alignmentText": "Germany’s welfare state underpins healthcare, unemployment insurance, and family benefits, and München (Munich) layers on housing subsidies for lower-income residents.",
       "alignmentValue": 8
     },
     {
@@ -434,12 +434,12 @@
     },
     {
       "key": "Stability",
-      "alignmentText": "Strong institutions, NATO membership, and a diversified economy make Munich a low-volatility base for long-term plans.",
+      "alignmentText": "Strong institutions, NATO membership, and a diversified economy make München (Munich) a low-volatility base for long-term plans.",
       "alignmentValue": 9
     },
     {
       "key": "State Ideology",
-      "alignmentText": "Bavaria’s conservative CSU sets the tone statewide, yet Munich’s city government blends social-democratic and green policies focused on transit, housing, and climate goals.",
+      "alignmentText": "Bavaria’s conservative CSU sets the tone statewide, yet München (Munich)’s city government blends social-democratic and green policies focused on transit, housing, and climate goals.",
       "alignmentValue": 7
     },
     {
@@ -469,7 +469,7 @@
     },
     {
       "key": "Typical Software Salaries",
-      "alignmentText": "Senior .NET or full-stack roles at Munich HQs pay €85k–€95k, and top offers crack €105k when paired with cloud leadership or German proficiency.",
+      "alignmentText": "Senior .NET or full-stack roles at München (Munich) HQs pay €85k–€95k, and top offers crack €105k when paired with cloud leadership or German proficiency.",
       "alignmentValue": 8
     },
     {
@@ -489,22 +489,22 @@
     },
     {
       "key": "Vacation Days (Typical)",
-      "alignmentText": "Munich tech firms commonly offer 28–30 days off, and collective agreements add bridge days around major holidays.",
+      "alignmentText": "München (Munich) tech firms commonly offer 28–30 days off, and collective agreements add bridge days around major holidays.",
       "alignmentValue": 9
     },
     {
       "key": "View of Neighboring Countries",
-      "alignmentText": "Munich residents travel frequently to Austria, Italy, and Czechia, fostering a pragmatic, cooperative view of neighbors.",
+      "alignmentText": "München (Munich) residents travel frequently to Austria, Italy, and Czechia, fostering a pragmatic, cooperative view of neighbors.",
       "alignmentValue": 8
     },
     {
       "key": "View of self",
-      "alignmentText": "Locals embrace Munich as a “Weltstadt mit Herz” balancing Bavarian tradition with global industry.",
+      "alignmentText": "Locals embrace München (Munich) as a “Weltstadt mit Herz” balancing Bavarian tradition with global industry.",
       "alignmentValue": 8
     },
     {
       "key": "View of Them by Neighboring Countries",
-      "alignmentText": "Neighboring regions see Munich as affluent and orderly, sometimes teasing its high costs but respecting its innovation.",
+      "alignmentText": "Neighboring regions see München (Munich) as affluent and orderly, sometimes teasing its high costs but respecting its innovation.",
       "alignmentValue": 7
     },
     {
@@ -519,7 +519,7 @@
     },
     {
       "key": "What Is Intriguing",
-      "alignmentText": "Munich melds Alpine weekend adventures with a serious tech economy, letting the family enjoy outdoorsy downtime without giving up career momentum.",
+      "alignmentText": "München (Munich) melds Alpine weekend adventures with a serious tech economy, letting the family enjoy outdoorsy downtime without giving up career momentum.",
       "alignmentValue": 9
     },
     {

--- a/reports/germany_nuernberg_report.json
+++ b/reports/germany_nuernberg_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Siemens, DATEV, and Fraunhofer IIS run sizeable .NET teams, giving Trey steady enterprise opportunities with modern tooling.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Indie studios around the Nürnberg Digital Festival and nearby Erlangen universities create a modest scene, though AAA roles still cluster in Munich.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Family housing costs around €12–13/m² in outer districts, so early planning secures space near good schools.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Global corporations use English internally, but daily admin still expects German proficiency.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Nürnberg Digital Festival, Women in Tech meetups, and family networks tied to Siemens create a welcoming community.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Driverless metro lines, smart logistics hubs, and strong broadband underline Nuremberg’s modern infrastructure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Pegnitz river trails, Tiergarten, and quick drives to Franconian Switzerland give the family easy outdoor escapes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Craft beer halls, indie venues like Club Stereo, and classical concerts provide solid nightlife even if mega-clubs are rare.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "ZOLLHOF Tech Incubator, the Bavarian Games Hub, and local investor interest support launching a mid-sized studio.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Efficient transit and compact commutes keep weekdays manageable, while Franconian culture encourages relaxed weekends.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "U-Bahn, S-Bahn, and tram lines cover the region well, and Nuremberg’s driverless metro keeps late-night service dependable.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Manufacturing firms blend on-site hardware work with remote weeks, so Trey can negotiate hybrid arrangements.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Crime rates stay low, and historic neighborhoods feel safe for kids walking to activities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers earn €65–75k across industrial automation and finance, with costs lower than Munich.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "A medieval core paired with high-tech employers and a famous Christmas market delivers both charm and opportunity.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_stuttgart_report.json
+++ b/reports/germany_stuttgart_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Mercedes-Benz, Porsche Digital, and Bosch’s engineering hubs keep .NET specialists busy with high-impact mobility projects.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Studios like NUKKLEAR and Aesir Interactive’s satellite teams provide roles, though many creatives commute from nearby towns.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Demand from auto execs pushes rents beyond €18/m², so families often look to Esslingen or Ludwigsburg for affordable space.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Multinationals operate in English, though Swabian dialect pops up in daily life—German classes help with integration.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Startup Stuttgart, automotive innovation labs, and international parent groups keep networking easy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "High-speed rail, autonomous vehicle pilots, and top-tier research facilities showcase Stuttgart’s infrastructure.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Vineyard walks, the Swabian Jura, and Black Forest day trips offer quick escapes into nature.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Jazz at Bix, electronic nights at Romantica, and nearby concert halls give the couple solid nightlife variety.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Games BW funding, accelerator programmes at HdM, and automotive-linked XR labs create a fertile launchpad for Trey’s studio.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Corporate schedules and hillside commutes keep weekdays busy, so planned downtime is vital for Sarah.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "S-Bahn tunnels, expanding U-Bahn lines, and the new Stadtbahn additions connect hillside neighborhoods, albeit with occasional construction delays.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Manufacturers now mix on-site prototyping with remote sprint planning, letting Trey blend corporate work and indie projects.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Stuttgart stays safe overall, with occasional protests around Schlossplatz requiring simple route planning.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior engineers command €75–85k thanks to the automotive cluster, offsetting Stuttgart’s steep living costs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Pairing world-class engineering museums with vineyard-lined suburbs gives the family both innovation and leisure.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_trier_report.json
+++ b/reports/germany_trier_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Regional hospitals, the university, and cross-border finance links to Luxembourg provide occasional .NET roles, but Trey anticipates gaps between contracts.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Trier lacks established studios, so any game work would rely almost entirely on remote teams or Trey's own startup.",
+      "alignmentValue": 3
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Rents stay moderate around €11/m², though Luxembourg demand raises prices in some districts, so early scouting is wise.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Tourism and cross-border work keep English visible, yet municipal offices still favor German paperwork.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "EU cross-border entrepreneur groups and university families provide community, though tech-specific meetups are sparse.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Rail links and broadband meet expectations, though some heritage buildings lag on insulation and smart-home upgrades.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Moselle river cruises, hiking along the Saar-Hunsrück trail, and vineyard picnics give the family abundant outdoor options.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Student pubs and the Europahalle’s concert lineup provide modest nightlife; major acts are a train ride away in Luxembourg or Cologne.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "IHKT incubators and Greater Region EU funds can support prototypes, yet scaling would require tapping Luxembourg or Cologne investors.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Roman ruins, compact streets, and wine-country excursions make for a slow, family-friendly pace that suits Sarah perfectly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Bus lines, Mosel valley trains, and hourly services to Luxembourg cover basics, but evening frequency drops, making a family car useful.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Many locals work remotely for Luxembourg or Cologne employers, normalizing hybrid setups that Trey can emulate.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Trier enjoys low crime, and the historic center feels safe for kids exploring after school.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers earn €50–55k locally, though cross-border commuters can chase higher Luxembourg salaries if needed.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "Roman amphitheaters, Luxembourg day trips, and vineyard culture promise rich history and travel for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_wiesbaden_report.json
+++ b/reports/germany_wiesbaden_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Consultancies, state ministries, and nearby US military IT contracts generate steady .NET demand with hybrid schedules.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "A few boutique studios and Frankfurt collaborators provide opportunities, but sustained roles still mean tapping the Rhein-Main network.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Spa-town appeal and commuter demand push rents near €15/m², so we may target Biebrich or Dotzheim for better value.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "US military presence and international companies keep English common, easing daily life while we build German fluency.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Creative Hub, RheinMain Tech, and international parent circles help newcomers connect across the region.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Reliable utilities, smart spa renovations, and cross-river mobility projects keep infrastructure modern even amid historic architecture.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "The Taunus foothills, Rhine promenades, and spa gardens give the family quick outdoor escapes.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Kurhaus concerts, Schlachthof cultural center, and easy S-Bahn hops to Frankfurt keep nightlife options open even if the city itself is quieter.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "Creative Hub Wiesbaden, Hessen’s game funding, and proximity to Frankfurt investors make it practical to incubate a small studio.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Thermal baths, vineyards, and short commutes deliver a calm daily rhythm despite proximity to Frankfurt.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "S-Bahn links to Frankfurt, regional buses, and ongoing citybahn plans cover daily routes, though rail bottlenecks toward Mainz persist.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Consultancies and state agencies now mix remote weeks with on-site briefings, supporting Trey’s hybrid ambitions.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Wiesbaden stays safe overall, with most issues limited to nightlife near the Kurhaus.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Senior developers earn €70k± thanks to consulting and health tech employers, enough to absorb higher housing costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "A spa heritage, nearby vineyards, and access to Frankfurt’s opportunities deliver both wellness and career reach.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}

--- a/reports/germany_wolfsburg_report.json
+++ b/reports/germany_wolfsburg_report.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "iso": "DE",
+  "values": [
+    {
+      "key": ".NET Work Prospects",
+      "alignmentText": "Volkswagen’s digital labs and suppliers like Siemens Mobility anchor most .NET roles, so Trey’s opportunities concentrate within the automotive ecosystem.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Air Quality",
+      "alignmentText": "EU emissions standards and widespread transit keep annual PM2.5 around 12 µg/m³ in major metros, though diesel traffic and winter wood smoke create a few watch-the-AQI days for the kids.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Atheism",
+      "alignmentText": "Church membership is optional via the Kirchensteuer and eastern states are majority secular, so openly atheist parents or kids rarely encounter pressure outside a few tradition-minded towns.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Authoritarian Backsliding Risk",
+      "alignmentText": "A strong Federal Constitutional Court, proportional elections, and independent media keep far-right surges in check, aligning with the family’s demand for resilient democratic guardrails.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Banking & Payments",
+      "alignmentText": "Accounts are stable and SEPA transfers are fast once we clear the in-person onboarding, yet everyday life still leans on cash or Girocard rather than tap-to-pay ubiquity.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Beach Life",
+      "alignmentText": "North and Baltic Sea beaches are clean but require long rail trips and the water tops out near 19 °C, so seaside outings are more bracing weekend adventures than routine family swims.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Boardgaming & Tabletop",
+      "alignmentText": "Germany is the heart of modern board gaming—Spiel Essen, Spiel des Jahres designers, and year-round board game cafés make it effortless for Trey and Sarah to plug into vibrant tabletop circles.",
+      "alignmentValue": 10
+    },
+    {
+      "key": "Child Care Support",
+      "alignmentText": "Kita subsidies and parental leave culture mean families share resources, but spotty staffing still forces us to join waitlists and cultivate backup caregivers when both parents need time to work.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Child-Friendliness of Cities",
+      "alignmentText": "Most neighborhoods feature traffic-calmed streets, pocket playgrounds, and stroller-friendly transit, though dense inner-city blocks in Berlin or Hamburg require extra street smarts at rush hour.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Citizens)",
+      "alignmentText": "Citizens receive Kindergeld plus generous Elterngeld and capped Kita fees, yet navigating paperwork and the occasional shortage still demands planning from even well-connected local families.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Childcare Support (Visa Holders)",
+      "alignmentText": "Once we register residence and contribute to social insurance, Blue Card families can tap Kindergeld and Kita subsidies, but eligibility proofs and state-by-state rules add lag time.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Common Hobbies",
+      "alignmentText": "From Vereins for hiking, climbing, and maker crafts to thriving gaming, music, and coding scenes, there’s a club or community for nearly every family pastime within an hour’s train ride.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Community Vibes",
+      "alignmentText": "Neighbors start reserved, yet school parents, sports Vereine, and local festivals build dependable circles over time—ideal for Sarah’s slower-paced community goals once we invest the effort.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Compliance & Risks",
+      "alignmentText": "So long as we renew registrations, keep statutory health insurance active, and update addresses promptly, Germany’s rules stay predictable—missing a form mainly risks fines rather than status.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Cost of Living (Optional)",
+      "alignmentText": "Groceries and transit stay manageable, but family-sized rentals in Munich, Hamburg, or Berlin can exceed €2,200 a month, so we balance location with Trey’s studio ambitions.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Dual Citizenship Allowed",
+      "alignmentText": "The 2024 reform lets naturalized residents keep U.S. passports with only routine notifications, making long-term planning easier for a binational household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Economic Health",
+      "alignmentText": "Manufacturing slowdowns and energy-price shocks have growth near zero, yet unemployment and social insurance remain steady enough to support Trey's entrepreneurial runway.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Economic System",
+      "alignmentText": "Germany’s social market economy backs SMEs, co-determination, and safety nets, though licensing rules and bureaucracy can slow Sarah if she chases freelance gigs.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Education",
+      "alignmentText": "Academic outcomes are solid but early tracking at age 10 and uneven funding by Land mean we’ll monitor school quality closely for Anduin and Alasdair.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Employer Visa Sponsorship",
+      "alignmentText": "Blue Card hiring is common for senior developers, but employers still expect recognized degrees, German contracts, and salary floors, so Trey must target larger firms or EU-funded studios.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Environment",
+      "alignmentText": "Protected forests, strict recycling, and widespread renewable power keep family neighborhoods green, even if industrial corridors along the Rhine demand the occasional air-quality check.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Expected Tax Rate (Our Family)",
+      "alignmentText": "Dual-income tech salaries face roughly 38–42% effective taxes once social contributions are added, so we budget around the higher take-home hit in exchange for healthcare and schooling.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Fall Temperature Range (C/F)",
+      "alignmentText": "Expect 6–16 °C (43–61 °F) with breezy rain fronts—layered jackets work for school runs, but we plan leaf-peeping around occasional North Sea gales.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Family Life",
+      "alignmentText": "Long parental leave, afternoon playground culture, and child benefits keep families front-and-center, though coordinating Kita pickups with half-day primary schools still takes a shared calendar.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Members",
+      "alignmentText": "Spouses and minor children gain work and schooling rights immediately under skilled-worker permits, yet bringing other dependents or coordinating U.S. visits still requires careful paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Citizens)",
+      "alignmentText": "Citizen families enjoy up to 14 months of income-linked Elterngeld, split parental leave, and monthly Kindergeld, matching the household’s desire for robust, gender-balanced support.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Family Policy (Common Family)",
+      "alignmentText": "Mainstream families can rely on Elterngeld, Kinderzuschlag, and flexible working laws, but navigating benefits across Bundesländer keeps planners busy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Family Policy (Visa Holders)",
+      "alignmentText": "Resident visa holders qualify for most benefits once registered and contributing, yet means tests and language-heavy applications introduce friction we must schedule around.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Female)",
+      "alignmentText": "Women blend functional outerwear with minimalist style—think layered coats, sneakers, and sustainable labels—so Sarah fits in while dressing for drizzle.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Fashion Trends (Male)",
+      "alignmentText": "Men lean toward smart-casual staples like tailored jeans, weatherproof shells, and leather sneakers, balancing practicality with understated design.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Femininity Norms",
+      "alignmentText": "Professional women lead teams and split caregiving, and opting for pragmatic style or leadership roles rarely draws pushback beyond a few conservative rural expectations.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Game Dev Work Prospects",
+      "alignmentText": "Wolfsburg hosts esports and simulation labs at Autostadt, but traditional studios are scarce, pushing Trey toward remote collaborations.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Gender Fluidity",
+      "alignmentText": "The 2024 Self-Determination Act eases ID changes and urban culture is supportive, though some schools and clinics still operate on binary paperwork the family must advocate through.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Rights",
+      "alignmentText": "Equal-pay gaps persist, but parental leave parity, anti-discrimination laws, and women’s leadership in politics align with the family’s progressive priorities.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Gender Roles",
+      "alignmentText": "Two-career households and fathers on Elternzeit are common in cities, yet parts of Bavaria and Baden-Württemberg still assume mom leads childcare, so we choose locale carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "General Considerations for Visa Holders",
+      "alignmentText": "Blue Card families juggle Anmeldung, statutory insurance, and periodic renewals, but the rules are transparent and rarely jeopardize status if we stay organized.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Global Warming Risk",
+      "alignmentText": "Heavier Rhine floods, hotter summers, and forest-dieback demand resilience planning, yet inland housing faces far less risk than coastal Europe overall.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Healthcare (Citizens)",
+      "alignmentText": "Statutory insurance guarantees comprehensive care, capped drug costs, and pediatric checkups—a strong match for the family’s desire for universal access.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Healthcare (Visa Holders)",
+      "alignmentText": "Non-EU residents must enroll in statutory or approved private plans, providing solid coverage once premiums are paid, though English-language providers can book out in expat districts.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Higher Education Access (Citizens)",
+      "alignmentText": "Tuition-free universities, dual-study programs, and vocational tracks make future degrees affordable, even if high-demand courses still require strong Abitur results.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Higher Education Access (Visa Holders)",
+      "alignmentText": "International students pay only semester fees but must show blocked-account savings and German proficiency, so college planning stays accessible with early paperwork.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Housing Situation",
+      "alignmentText": "Company-backed housing keeps rents moderate around €11–12/m², though selection tightens during new VW model launches.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "How Taxes Are Handled",
+      "alignmentText": "Payroll withholding covers most liabilities, but class-based filings, solidarity surcharges, and Elster submissions push us toward hiring a Steuerberater each spring.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "K-12 Education Access (Citizens)",
+      "alignmentText": "Public schools are free and safe, yet early Gymnasium tracking and uneven facilities between Länder mean we map neighborhoods to secure the pedagogy we want.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "K-12 Education Access (Visa Holders)",
+      "alignmentText": "Resident kids enroll alongside citizens with integration classes and special-needs support, though documentation and language placement meetings take extra parent time.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Language & English Ubiquity",
+      "alignmentText": "Automotive teams use English for global coordination, yet city services still expect German proficiency.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "LGBTQ+ Attitudes",
+      "alignmentText": "Marriage equality, anti-discrimination laws, and visible Pride scenes welcome queer families, while smaller towns still expect discretion that polyamorous parents must gauge.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Marxism (Societal Attitudes)",
+      "alignmentText": "Leftist ideas thrive in academia and parties like Die Linke, yet broader society stays pragmatic about the social market model rather than embracing Marxism outright.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Masculinity Norms",
+      "alignmentText": "Co-parenting dads pushing strollers are the norm in major cities, and taking parental leave or expressing emotions rarely triggers stigma outside conservative enclaves.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Meetups & Communities",
+      "alignmentText": "Mobility meetups, VW family networks, and international schools provide community, though indie scenes stay small.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Minimum Wage",
+      "alignmentText": "The €12.41 hourly minimum covers core expenses outside Munich or Frankfurt, and enforcement is solid, though single-income renters in hot markets still feel the squeeze.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Modernity & Infrastructure",
+      "alignmentText": "Autostadt’s smart mobility pilots, strong broadband, and new energy-efficient housing highlight Wolfsburg’s modern infrastructure.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Natural Beauty",
+      "alignmentText": "Black Forest hikes, alpine lakes, and the Mosel valley offer rewarding day trips, even if scenery feels more pastoral than dramatic compared with Mediterranean cliffs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Natural Disasters",
+      "alignmentText": "Major quakes are absent and building codes are strong, but we remain mindful of river flooding and the sort of 2021 Ahr valley deluges that warrant insurance.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Nature Access",
+      "alignmentText": "Allerpark lakes, the Autostadt parkland, and nearby Elm-Lappwald forests offer plenty of outdoor time for the kids.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Nightlife & Music",
+      "alignmentText": "Arenas host occasional major acts, yet nightlife leans quiet; big concerts require trips to Hanover or Berlin.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Nightlife Culture",
+      "alignmentText": "Nightlife districts stay lively yet safe, with 24-hour U-Bahn lines and Sunday quiet laws that gently nudge us back into family mode after big nights out.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Notable Game Development Communities",
+      "alignmentText": "Gamescom, devcom, and numerous Unreal and Unity meetups anchor a collaborative dev scene that supports Trey’s goal of founding an indie studio.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Notable Game Studios",
+      "alignmentText": "Studios like Ubisoft Blue Byte, Crytek, YAGER, and InnoGames offer recognizable peers, even if Germany lacks the density of AAA publishers found in Montreal or Tokyo.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Opportunities for Video Game Startup",
+      "alignmentText": "STARTUP AUTOBAHN partnerships and VW’s mobility incubators offer mentorship for simulation-heavy ideas, yet entertainment-focused funding remains limited.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Pace of Life",
+      "alignmentText": "Corporate schedules anchor weekdays, but compact districts and abundant playgrounds keep family life relaxed.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Parenting Expectations",
+      "alignmentText": "Schools and pediatrics back gentle, child-led approaches, and fathers taking Elternzeit is celebrated, though homework routines and punctuality are still emphasized.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Path to Citizenship",
+      "alignmentText": "The 2024 Skilled Immigration Act trims naturalization to five years—three with strong integration—and now permits dual nationality, aligning with long-term relocation goals.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Perceived Corruption",
+      "alignmentText": "Transparency International ranks Germany among the world’s least corrupt states; scandals surface but watchdogs and media respond quickly.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Political System",
+      "alignmentText": "A federal parliamentary system with coalition bargaining and strong constitutional courts offers the pluralistic, progressive governance the family prioritizes.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Polyamory",
+      "alignmentText": "Urban queer and poly communities host meetups and family-friendly spaces, yet legal frameworks still assume monogamy, so we stay discreet on paperwork but open socially.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Pre-K / Early Childcare Landscape",
+      "alignmentText": "Public Kitas expand rapidly with capped fees and bilingual programs, but popular centers in Berlin or Munich fill fast, requiring early applications and backup nannies.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Private Education",
+      "alignmentText": "International and Montessori schools exist but charge €12–20k annually and have waiting lists, so we rely on the strong public track unless a bilingual niche is essential.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Progressivism",
+      "alignmentText": "Coalition politics, climate action, and LGBTQ protections signal progressive momentum, even if far-right AfD gains mean activism and voting remain important.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Messaging",
+      "alignmentText": "Public broadcasters emphasize civic solidarity and fact-based policy, with occasional patriotic framing that still acknowledges dissent.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Propaganda Prevalence",
+      "alignmentText": "A diverse press landscape and active fact-checkers keep overt propaganda rare, aligning with the family’s desire for pluralistic, independent media.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Public Transportation",
+      "alignmentText": "Bus routes and regional trains cover basics, but dispersed districts and limited evening service make a car or e-bike necessary for flexibility.",
+      "alignmentValue": 5
+    },
+    {
+      "key": "Religion in Politics",
+      "alignmentText": "Church-run parties exist but policy debates stay largely secular, and court rulings protect pluralism—good news for a progressive, non-religious household.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Remote-Friendly Culture",
+      "alignmentText": "Volkswagen now blends remote sprints with plant visits, so Trey can negotiate hybrid weeks while keeping onsite obligations manageable.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Residency Types & Durations",
+      "alignmentText": "Blue Cards run four years and can convert to permanent residence in 33 months—or 21 with B1 German—providing a clear, family-stable runway.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Retirement (Citizens)",
+      "alignmentText": "Statutory pensions, employer schemes, and universal healthcare support dignified retirements, though benefits hinge on steady contributions and rising retirement ages.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Immigrants)",
+      "alignmentText": "Immigrants who contribute for five years can tap German pensions and bilateral U.S.-Germany agreements protect credits, but long-term security still benefits from private savings.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Retirement (Visa Holders)",
+      "alignmentText": "Once we join the statutory system, contributions count toward eventual pensions and portable agreements, yet short stays yield modest benefits without private investing.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Ruby Work Prospects",
+      "alignmentText": "Ruby roles cluster in Berlin fintech and SaaS firms with English-friendly teams, but competition is tight enough that Sarah keeps polishing full-stack skills.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Safety & Crime",
+      "alignmentText": "Wolfsburg remains notably safe, with low crime rates across its planned neighborhoods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Schooling Options",
+      "alignmentText": "Quality public schools anchor most choices while bilingual, Waldorf, and international campuses exist in large metros—expect applications and commutes for specialized paths.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Seasonal Beach Water Temp",
+      "alignmentText": "Baltic waters hover 17–19 °C at summer peak, so family swims mean short dips or wetsuits rather than warm, languid beach days.",
+      "alignmentValue": 4
+    },
+    {
+      "key": "Seasonal Weather",
+      "alignmentText": "Summers stay mostly in the 20s °C with brief heat spikes, winters are damp near freezing, and overcast skies are common—manageable with good gear and indoor play options.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Sex (Attitudes)",
+      "alignmentText": "Comprehensive sex education, accessible clinics, and open conversations about consent align with the family’s sex-positive values, even if rural areas move slower.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Social Policies",
+      "alignmentText": "Progressive labor protections, unemployment insurance, and healthcare safety nets help families weather transitions, though paperwork can be slow.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Spring Temperature Range (C/F)",
+      "alignmentText": "Expect 5–15 °C (41–59 °F) with frequent showers and pollen bursts—great for jackets and layering while parks green up.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Stability",
+      "alignmentText": "Germany anchors the EU with predictable policy, strong rule of law, and robust civil society, matching the household’s need for long-term stability.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State Ideology",
+      "alignmentText": "A pluralistic, pro-democracy ethos underpins federal policy, celebrating human rights and evidence-based debates even amid lively coalition disagreements.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "State of Capitalism",
+      "alignmentText": "A regulated market with strong Mittelstand firms, codetermination, and consumer protections balances entrepreneurship with social safeguards the family appreciates.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Summer Temperature Range (C/F)",
+      "alignmentText": "Daytime highs average 20–27 °C (68–81 °F) with occasional humid heatwaves, so summers feel pleasant for parks once we plan for the rare 35 °C burst.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Timelines & Costs",
+      "alignmentText": "Blue Card processing typically wraps in 3–6 months with a few thousand euros in fees, legalizations, and translations—predictable enough to budget for.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Trust in Government",
+      "alignmentText": "Surveys show moderate trust—higher in the west than the east—with transparent agencies reinforcing confidence when we navigate residency or benefits.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Type of Corruption",
+      "alignmentText": "Corruption usually appears as isolated procurement scandals, and robust auditing plus media oversight keep it from touching daily family life.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "Typical Software Salaries",
+      "alignmentText": "Automotive IT roles pay €70k±, reflecting Volkswagen’s wage structure and helping absorb regional costs.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Weekend Schedule (Family of Four)",
+      "alignmentText": "Saturdays brim with markets, museums, and bike rides, while Sunday retail closures push us toward parks, cafés, and Spielplatz meetups.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Typical Workday Schedule (Family of Four)",
+      "alignmentText": "Grade schools often end by 13:00 unless we secure Ganztag spots, so we coordinate Hort care or flexible hours to keep both parents’ workdays smooth.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Vacation Days (Minimum)",
+      "alignmentText": "Labor law guarantees at least 20 paid days plus 10–13 public holidays, giving plenty of time for family trips when scheduled early.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Vacation Days (Typical)",
+      "alignmentText": "Tech employers commonly offer 28–30 days off and respect unplugged time, letting the family plan long summer breaks or U.S. visits.",
+      "alignmentValue": 9
+    },
+    {
+      "key": "View of Neighboring Countries",
+      "alignmentText": "Public sentiment toward EU neighbors is largely cooperative, with only occasional friction over defense or fiscal policy.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of self",
+      "alignmentText": "Germany balances pride in engineering and culture with postwar humility, creating a grounded national identity newcomers can plug into.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "View of Them by Neighboring Countries",
+      "alignmentText": "Neighbors see Germany as a reliable EU anchor despite periodic grumbling over economic dominance—supportive overall for cross-border travel.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Visa Paths",
+      "alignmentText": "Blue Cards, the Chancenkarte, and startup-friendly visas provide multiple avenues for skilled families, provided we document credentials and finances carefully.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Welcoming of US Migrants",
+      "alignmentText": "Skilled U.S. migrants are generally welcomed in tech hubs, though bureaucracy and occasional geopolitical skepticism mean we still prove commitment to integrate.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "What Is Intriguing",
+      "alignmentText": "High-tech automotive labs, family-friendly planning, and proximity to Hanover make Wolfsburg a focused yet comfortable base.",
+      "alignmentValue": 7
+    },
+    {
+      "key": "Winter Temperature Range (C/F)",
+      "alignmentText": "Expect -2 to 6 °C (28–43 °F) with damp cold, occasional snow, and early sunsets—cold enough for winter gear but rarely extreme.",
+      "alignmentValue": 6
+    },
+    {
+      "key": "Work Week Hours",
+      "alignmentText": "Most contracts stick to 37–40 hours with overtime caps, aligning with the family’s expectation for predictable schedules.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Work-Life Balance",
+      "alignmentText": "Works councils and right-to-disconnect norms keep evenings and weekends protected, even during crunch periods.",
+      "alignmentValue": 8
+    },
+    {
+      "key": "Workers' Rights",
+      "alignmentText": "Co-determination, sectoral bargaining, and enforced overtime limits give workers strong leverage—great for ensuring Trey and Sarah can safeguard family time.",
+      "alignmentValue": 9
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add localized Germany city reports covering Bremen, Düsseldorf, Dresden, Erfurt, Frankfurt, Halle, Hannover, Jena, Karlsruhe, Kiel, Köln, Leipzig, Lübeck, Magdeburg, Mainz, München, Nürnberg, Stuttgart, Trier, Wiesbaden, and Wolfsburg
- update the Germany listing in main.json to surface the expanded city catalog and use German names for Köln and München

## Testing
- python - <<'PY'
import json, glob
for path in glob.glob('reports/germany_*_report.json'):
    with open(path, encoding='utf-8') as f:
        json.load(f)
print('All JSON files valid')
PY

------
https://chatgpt.com/codex/tasks/task_e_68e475edd8348321a874bb194d8a793f